### PR TITLE
fix: resolve zhi workspace deployment issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ deployments/compose/config.yaml
 deploy/helm/*/charts/
 deploy/helm/*/Chart.lock
 
+# Worktrees
+.worktrees/
+
 # Zhi plugin build artifacts
 deploy/zhi/plugin/zhi-config-glyphoxa
 deploy/zhi/plugin/dist/

--- a/deploy/zhi/plugin/values.go
+++ b/deploy/zhi/plugin/values.go
@@ -53,6 +53,24 @@ var valueDefs = func() []ValueDef {
 			Description: "Comma-separated list of K8s secret names for pulling images",
 			Type:        "string",
 		},
+		{
+			Path: "core/run-as-user", Default: 999,
+			Section: "Core", DisplayName: "Run As User",
+			Description: "UID for the container security context (runAsUser)",
+			Type:        "int",
+		},
+		{
+			Path: "core/run-as-group", Default: 999,
+			Section: "Core", DisplayName: "Run As Group",
+			Description: "GID for the container security context (runAsGroup)",
+			Type:        "int",
+		},
+		{
+			Path: "core/fs-group", Default: 999,
+			Section: "Core", DisplayName: "FS Group",
+			Description: "GID for volume ownership (fsGroup)",
+			Type:        "int",
+		},
 
 		// ── gateway ──────────────────────────────────────────────────────────
 		{

--- a/deploy/zhi/workspace/templates/apply.sh.tmpl
+++ b/deploy/zhi/workspace/templates/apply.sh.tmpl
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Clean generated/ to prevent stale files from disabled components.
-rm -rf ./generated/*
-
 NAMESPACE="{{ .Get "core/namespace" }}"
 RELEASE="{{ .Get "core/release-name" }}"
 
@@ -33,6 +30,10 @@ kubectl create secret generic "${RELEASE}-admin-key" \
   --namespace "$NAMESPACE" \
   --dry-run=client -o yaml | kubectl apply --server-side --field-manager=zhi-glyphoxa -f -
 {{ end -}}
+
+# Remove empty manifests from disabled components before applying.
+find ./generated/ -name '*.yaml' -empty -delete
+find ./generated/ -name '*.yaml' -size 1c -delete
 
 # Apply all generated manifests.
 kubectl apply --server-side --field-manager=zhi-glyphoxa -f ./generated/ -n "$NAMESPACE"

--- a/deploy/zhi/workspace/templates/gateway-deployment.yaml.tmpl
+++ b/deploy/zhi/workspace/templates/gateway-deployment.yaml.tmpl
@@ -71,9 +71,9 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: 999
-        runAsGroup: 999
-        fsGroup: 999
+        runAsUser: {{ .GetOr "core/run-as-user" "999" }}
+        runAsGroup: {{ .GetOr "core/run-as-group" "999" }}
+        fsGroup: {{ .GetOr "core/fs-group" "999" }}
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/deploy/zhi/workspace/templates/gateway-deployment.yaml.tmpl
+++ b/deploy/zhi/workspace/templates/gateway-deployment.yaml.tmpl
@@ -39,7 +39,7 @@ spec:
         app.kubernetes.io/part-of: glyphoxa
         app.kubernetes.io/managed-by: zhi
       annotations:
-        checksum/config: {{ .ConfigChecksum | sha256sum }}
+        checksum/config: {{ .All | mustToPrettyJson | sha256sum }}
     spec:
       serviceAccountName: {{ $saName }}
 {{- if $pullSecrets }}
@@ -71,13 +71,16 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
         seccompProfile:
           type: RuntimeDefault
       containers:
         - name: gateway
           image: {{ $repo }}:{{ $tag }}
           imagePullPolicy: {{ $pullPolicy }}
-          args: ["--mode=gateway"]
+          args: ["--mode=gateway", "--config=/etc/glyphoxa/config.yaml"]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/deploy/zhi/workspace/templates/mcp-gateway-deployment.yaml.tmpl
+++ b/deploy/zhi/workspace/templates/mcp-gateway-deployment.yaml.tmpl
@@ -54,9 +54,9 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: 999
-        runAsGroup: 999
-        fsGroup: 999
+        runAsUser: {{ .GetOr "core/run-as-user" "999" }}
+        runAsGroup: {{ .GetOr "core/run-as-group" "999" }}
+        fsGroup: {{ .GetOr "core/fs-group" "999" }}
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/deploy/zhi/workspace/templates/mcp-gateway-deployment.yaml.tmpl
+++ b/deploy/zhi/workspace/templates/mcp-gateway-deployment.yaml.tmpl
@@ -35,7 +35,7 @@ spec:
         app.kubernetes.io/part-of: glyphoxa
         app.kubernetes.io/managed-by: zhi
       annotations:
-        checksum/config: {{ .ConfigChecksum | sha256sum }}
+        checksum/config: {{ .All | mustToPrettyJson | sha256sum }}
     spec:
       automountServiceAccountToken: false
 {{- if $pullSecrets }}
@@ -54,13 +54,16 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
         seccompProfile:
           type: RuntimeDefault
       containers:
         - name: mcp-gateway
           image: {{ $repo }}:{{ $tag }}
           imagePullPolicy: {{ $pullPolicy }}
-          args: ["--mode=mcp-gateway"]
+          args: ["--mode=mcp-gateway", "--config=/etc/glyphoxa/config.yaml"]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/internal/observe/provider.go
+++ b/internal/observe/provider.go
@@ -43,13 +43,15 @@ func InitProvider(ctx context.Context, cfg ProviderConfig) (shutdown func(contex
 	}
 
 	// Build the resource describing this service.
-	res, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
+	// Use resource.New instead of merging with resource.Default() to avoid
+	// schema URL conflicts between semconv v1.26.0 and newer OTel defaults.
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
 			semconv.ServiceName(cfg.ServiceName),
 			semconv.ServiceVersion(cfg.ServiceVersion),
 		),
+		resource.WithProcessRuntimeDescription(),
+		resource.WithHost(),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- **Deployment templates**: Replace `.ConfigChecksum` (not available on `TreeData`) with `.All | mustToPrettyJson | sha256sum` in gateway and MCP gateway deployment templates
- **Pod security**: Add explicit `runAsUser/runAsGroup/fsGroup: 999` so k3s PodSecurity admission can verify non-root user
- **Container args**: Pass `--config=/etc/glyphoxa/config.yaml` to gateway and MCP gateway containers
- **apply.sh**: Remove self-destructive `generated/` cleanup that conflicted with zhi's `pre-export: true` setting; add cleanup of empty YAML files from disabled components before `kubectl apply`
- **OTel provider**: Fix schema URL conflict in `observe.InitProvider` by using `resource.New` instead of `resource.Merge` with `resource.Default()`, avoiding semconv v1.26.0 vs newer OTel defaults clash

## Test plan

- [ ] Deploy via zhi workspace to a k3s cluster and verify pods start successfully
- [ ] Confirm config checksum annotation is populated correctly on deployments
- [ ] Verify pod security context passes k3s PodSecurity admission
- [ ] Confirm gateway reads config from the expected path
- [ ] Verify disabled components do not cause `kubectl apply` errors from empty YAML files
- [ ] Check OTel traces/metrics export without schema URL conflict errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)