### PR TITLE
feat: GM helper NPC identity, routing, and transcript labels

### DIFF
--- a/docs/brainstorms/2026-03-14-gm-helper-npc-brainstorm.md
+++ b/docs/brainstorms/2026-03-14-gm-helper-npc-brainstorm.md
@@ -1,0 +1,116 @@
+---
+date: 2026-03-14
+topic: gm-helper-npc
+issue: "#37"
+---
+
+# GM Helper NPC — Implementation Design
+
+## What We're Building
+
+Wire up the GM helper NPC (`gm_helper: true`) as a differentiated, tool-equipped assistant that leverages the **already-existing** tool suite (dice roller, rules lookup, memory L1/L2/L3) and behaves as an address-only passive agent.
+
+Three concrete changes:
+
+1. **GM helper identity propagation** — `GMHelper` flag flows through `NPCIdentity` → `HotContext`, enabling system prompt augmentation and transcript labeling.
+2. **Passive/address-only routing** — A generic `address_only` config flag on any NPC; the GM helper defaults to it. Excludes the NPC from fallback routing (last-speaker continuation, single-NPC fallback).
+3. **Transcript role labels** — GM players show as `Name (GM)`, the GM helper NPC shows as `Name (GM assistant)` in transcripts and Discord embeds.
+
+## What Already Exists
+
+All tools are implemented and registered:
+
+| Tool | Package | Layer | Registration |
+|------|---------|-------|-------------|
+| `roll`, `roll_table` | `diceroller` | — | Stateless (global) |
+| `search_rules`, `get_rule` | `ruleslookup` | — | Stateless (global) |
+| `search_sessions` | `memorytool` | L1 | Tenant-scoped (app.go) |
+| `query_entities` | `memorytool` | L3 | Tenant-scoped (app.go) |
+| `get_summary` | `memorytool` | L3 | Tenant-scoped (app.go) |
+| `search_facts` | `memorytool` | L1+L2 | Tenant-scoped (app.go) |
+| `search_graph` | `memorytool` | L3 GraphRAG | Tenant-scoped (app.go) |
+
+Embedding provider is configurable (`openai`, `ollama`) via `providers.embeddings` in YAML. Memory tools gracefully degrade to FTS-only when embeddings are unavailable.
+
+## Why This Approach
+
+The tools and memory layers exist — the gap is purely in NPC differentiation and routing. Adding a generic `address_only` flag (rather than GM-helper-specific routing logic) keeps the orchestrator reusable for other passive NPCs (e.g., a narrator NPC that only speaks when invoked).
+
+## Key Decisions
+
+### 1. `GMHelper` on `NPCIdentity`
+
+Add `GMHelper bool` to `agent.NPCIdentity` (internal/agent/agent.go). Propagated from `config.NPCConfig.GMHelper` during agent construction.
+
+**Effects:**
+- `hotctx.HotContext` gains a `GMHelper bool` field so `FormatSystemPrompt` can detect it.
+- When `GMHelper == true`, the formatter prepends a GM-assistant preamble *before* the user's personality text. The preamble covers:
+  - Role: "You are a GM assistant helping the Game Master run a tabletop RPG session."
+  - Tool guidance: brief description of available tools and when to use them.
+  - Behavior: be concise, don't interrupt roleplay, only respond when addressed.
+- The user's `personality` field is appended after the preamble, so GMs can still customize the assistant's tone/voice.
+
+### 2. `AddressOnly` routing flag
+
+Add `AddressOnly bool` to `config.NPCConfig` (`yaml:"address_only"`).
+
+Propagate to `agent.NPCIdentity` as `AddressOnly bool`.
+
+In `orchestrator/address.go`, `Detect()` changes:
+- Step 3 (last-speaker continuation): skip agents where `AddressOnly == true`.
+- Step 4 (single-NPC fallback): skip agents where `AddressOnly == true`.
+- Steps 1 (explicit name match) and 2 (DM puppet override) remain unchanged — address-only NPCs are always reachable by name or slash command.
+
+When `gm_helper: true` is set and `address_only` is not explicitly configured, default `address_only` to `true`.
+
+### 3. Default budget tier
+
+When `GMHelper == true` and `BudgetTier` is zero-valued (not explicitly set), default to `BudgetStandard` instead of `BudgetFast`. This lets the GM helper use the full memory tool suite (search_facts P50=200ms, search_graph P50=300ms exceed BudgetFast's 500ms ceiling but fit within BudgetStandard's 1500ms).
+
+### 4. GM player identification for transcript labels
+
+Use the existing `PermissionChecker.IsDM()` (internal/discord/permissions.go) which checks for a configured `dm_role_id` Discord role. Players with this role get `Name (GM)` labels in transcripts.
+
+When `dm_role_id` is empty (test/dev setups), the session creator is treated as GM.
+
+The GM helper NPC gets `Name (GM assistant)` labels. This is derived from `NPCIdentity.GMHelper` when formatting transcript entries for display.
+
+### 5. Rules dataset — leave as placeholder
+
+The hardcoded 20-rule D&D 5e SRD dataset in `ruleslookup/rules.go` stays as-is with a TODO comment. A pluggable per-campaign rules system will be tracked in a new issue, blocked on #34 (Campaign Forge) which defines the campaign format going forward.
+
+### 6. Discord slash command integration
+
+The GM helper can also be invoked via Discord slash commands (bypassing the voice router entirely). A `/ask-gm <question>` command sends text directly to the GM helper agent's `HandleUtterance`, and the response is posted as a Discord embed + voice in the channel. This is additive and can land in the same PR or a fast follow-up.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `internal/agent/agent.go` | Add `GMHelper bool`, `AddressOnly bool` to `NPCIdentity` |
+| `internal/agent/npc.go` | Propagate new identity fields from `AgentConfig` |
+| `internal/config/config.go` | Add `AddressOnly bool` to `NPCConfig`; default logic for GM helper |
+| `internal/hotctx/types.go` | Add `GMHelper bool` to `HotContext` |
+| `internal/hotctx/formatter.go` | GM-assistant preamble injection in `FormatSystemPrompt` |
+| `internal/hotctx/assembler.go` | Propagate `GMHelper` from identity into `HotContext` |
+| `internal/agent/orchestrator/address.go` | Skip `AddressOnly` agents in fallback steps 3 and 4 |
+| `internal/agent/orchestrator/orchestrator.go` | Pass identity info to detector (or store on `agentEntry`) |
+| `internal/mcp/tools/ruleslookup/rules.go` | Add TODO comment re: pluggable rules (#34) |
+| Transcript display layer (Discord embeds) | Render `(GM)` / `(GM assistant)` labels |
+
+## Open Questions
+
+- **`/ask-gm` slash command**: same PR or follow-up? Leaning follow-up to keep scope tight.
+- **Dynamic budget escalation**: "think hard" / "use this specific tool" — how does the user signal this in voice? Likely a prompt-engineering concern (the LLM decides to use deeper tools when the question warrants it) rather than runtime budget switching. Defer to follow-up.
+
+## Deferred (Separate Issues)
+
+- Pluggable per-campaign rules dataset (blocked on #34)
+- Initiative tracking / combat management
+- Timer/reminder functionality
+- Loot & inventory tracking
+- Dynamic budget tier escalation via voice commands
+
+## Next Steps
+
+-> `/workflows:plan` for implementation steps, file-level changes, and test strategy.

--- a/docs/plans/2026-03-14-feat-gm-helper-npc-plan.md
+++ b/docs/plans/2026-03-14-feat-gm-helper-npc-plan.md
@@ -5,9 +5,42 @@ status: active
 date: 2026-03-14
 issue: "#37"
 brainstorm: docs/brainstorms/2026-03-14-gm-helper-npc-brainstorm.md
+deepened: 2026-03-14
 ---
 
 # feat: GM Helper NPC — Identity, Routing, and Transcript Labels
+
+## Enhancement Summary
+
+**Deepened on:** 2026-03-14
+**Research agents used:** architecture-strategist, performance-oracle, security-sentinel,
+pattern-recognition-specialist, code-simplicity-reviewer, type-design-analyzer,
+spec-flow-analyzer, best-practices-researcher, repo-research-analyst, silent-failure-hunter
+
+### Key Improvements
+
+1. **Replace `*bool` with plain `bool` for `AddressOnly`** — codebase has zero `*bool` fields;
+   use `ApplyDefaults()` step instead of mutation-in-validation
+2. **Use session's existing `dmUserID` instead of `IsDMByUserID` Discord API** — eliminates
+   ~80 LOC, zero latency risk, no new external dependency
+3. **Fix `BudgetTier` zero-value collision** — `BudgetFast = iota` (value 0) is
+   indistinguishable from "not set"; must fix before budget defaulting
+4. **Don't update `lastSpeaker` for address-only agents** — prevents "poisoning"
+   conversational continuity after addressing the GM helper
+5. **Define typed `SpeakerRole` constant** — matches existing `LogLevel`/`Engine`/`BudgetTier`
+   pattern; prevents typo-based silent failures
+6. **Persist `SpeakerRole` to database** — player `(GM)` labels can't be recomputed at read
+   time; needed for transcript replay and session recaps
+
+### New Considerations Discovered
+
+- Missing npcstore DB migration (`CREATE TABLE IF NOT EXISTS` won't add columns)
+- Proto3 bool defaults can silently degrade GM helper in rolling deploys
+- Preamble tool list may not match actual registered tools
+- NPC name collisions can bypass address-only routing
+- `config.Diff()` should log restart-required warning for new fields
+
+---
 
 ## Overview
 
@@ -28,17 +61,16 @@ dedicated helper.
 
 ## Proposed Solution
 
-Three changes across four phases:
+Three changes across three phases:
 
-1. **Identity propagation** — `GMHelper` and `AddressOnly` flow through the full
-   chain: config → NPCIdentity → HotContext → system prompt, and
-   config → agentEntry → address detector.
-2. **System prompt augmentation** — GM-assistant preamble merged before
-   personality text when `GMHelper == true`.
-3. **Passive routing** — Generic `address_only` flag skips fallback routing
-   steps (last-speaker continuation, single-NPC fallback).
-4. **Transcript labels** — Display-time `(GM)` and `(GM assistant)` labels
-   via a new `SpeakerRole` field on `TranscriptEntry`.
+1. **Identity + Prompt** — `GMHelper` and `AddressOnly` flow through the full
+   chain: config -> NPCIdentity -> agentEntry/HotContext -> system prompt.
+   GM-assistant preamble merged before personality text when `GMHelper == true`.
+2. **Passive routing** — Generic `address_only` flag skips fallback routing
+   steps (last-speaker continuation, single-NPC fallback). `Route()` does not
+   update `lastSpeaker` for address-only agents.
+3. **Transcript labels** — `SpeakerRole` typed constant on `TranscriptEntry`,
+   persisted to DB, rendered at display time as `(GM)` / `(GM assistant)`.
 
 ## Technical Approach
 
@@ -46,99 +78,238 @@ Three changes across four phases:
 
 ```
 Config (YAML)                    Proto (gRPC)              NPC Store (DB)
-┌──────────────┐                ┌──────────────┐          ┌──────────────┐
-│ NPCConfig    │                │ NPCConfig    │          │NPCDefinition │
-│  gm_helper   │                │  gm_helper   │          │  gm_helper   │
-│  address_only│                │  address_only│          │  address_only│
-└──────┬───────┘                └──────┬───────┘          └──────┬───────┘
-       │                               │                         │
-       └───────────────┬───────────────┘                         │
-                       ▼                                         │
-                ┌──────────────┐◄────────────────────────────────┘
-                │ NPCIdentity  │     (via ToIdentity)
-                │  GMHelper    │
-                │  AddressOnly │
-                └──────┬───────┘
-                       │
-          ┌────────────┼────────────┐
-          ▼            ▼            ▼
-   ┌────────────┐ ┌──────────┐ ┌────────────────┐
-   │ agentEntry │ │HotContext│ │TranscriptEntry │
-   │ addressOnly│ │ GMHelper │ │  SpeakerRole   │
-   └─────┬──────┘ └────┬─────┘ └────────────────┘
-         │              │
-         ▼              ▼
-   ┌────────────┐ ┌──────────────────┐
-   │  Detect()  │ │FormatSystemPrompt│
-   │ skip in    │ │ prepend preamble │
-   │ steps 3+4  │ │ before personality│
-   └────────────┘ └──────────────────┘
++--------------+                +--------------+          +--------------+
+| NPCConfig    |                | NPCConfig    |          |NPCDefinition |
+|  gm_helper   |                |  gm_helper   |          |  gm_helper   |
+|  address_only|                |  address_only|          |  address_only|
++------+-------+                +------+-------+          +------+-------+
+       |                               |                         |
+       +-- ApplyDefaults() --+         |                         |
+       |                     |         |                         |
+       +--- Validate() -----+---------+-------------------------+
+                       |
+                +--------------+
+                | NPCIdentity  |     (via IdentityFromConfig / ToIdentity)
+                |  GMHelper    |
+                |  AddressOnly |
+                +------+-------+
+                       |
+          +------------+------------+
+          v            v            v
+   +------------+ +----------+ +----------------+
+   | agentEntry | |formatter | |TranscriptEntry |
+   | addressOnly| | GMHelper | |  SpeakerRole   |
+   +-----+------+ +----+-----+ +----------------+
+         |              |
+         v              v
+   +------------+ +------------------+
+   |  Detect()  | |FormatSystemPrompt|
+   | skip in    | | prepend preamble |
+   | steps 3+4  | | before personality|
+   +------------+ +------------------+
 ```
 
 ### Implementation Phases
 
-#### Phase 1: Identity and Config [Foundation]
+#### Phase 1: Identity, Config, and Prompt [Foundation + Core]
 
-Add fields to data structures across all three NPC definition sources.
+Add fields to data structures, wire identity construction, and augment the
+system prompt. Merged from original Phases 1+2 for a single testable vertical
+slice from config flag through to prompt output.
 
 **Tasks:**
 
-- [ ] Add `AddressOnly *bool` to `config.NPCConfig` (`yaml:"address_only"`)
-  - Use `*bool` so we can distinguish "not set" (nil → default true for GM helper)
-    from "explicitly false"
+**Config fields:**
+
+- [ ] Add `AddressOnly bool` to `config.NPCConfig` (`yaml:"address_only"`)
+  - Use plain `bool` (not `*bool`) — consistent with all other config booleans
   - `internal/config/config.go`
-- [ ] Add defaulting logic in `config.Validate()`: when `GMHelper == true` and
-  `AddressOnly == nil`, set `AddressOnly` to `ptr(true)`
+
+- [ ] Add `ApplyDefaults(cfg *Config)` function — separate from `Validate()`
+  - `Validate()` is currently read-only; defaulting logic must not live there
+  - When `GMHelper == true` and `AddressOnly == false`, set `AddressOnly = true`
+  - Call `ApplyDefaults()` in `LoadFromReader()` before `Validate()`
   - `internal/config/loader.go`
-- [ ] Add `GMHelper bool` and `AddressOnly bool` to `agent.NPCIdentity`
-  - `internal/agent/agent.go`
-- [ ] Add `GMHelper bool` and `AddressOnly bool` to `npcstore.NPCDefinition`
-  - `internal/agent/npcstore/definition.go`
-- [ ] Wire new fields in `npcstore.ToIdentity()`
-  - `internal/agent/npcstore/definition.go`
-- [ ] Add `bool gm_helper = 7` and `bool address_only = 8` to proto `NPCConfig`
-  - `proto/glyphoxa/v1/session.proto`
-- [ ] Regenerate proto Go code
-  - `make proto` (or `buf generate`)
-- [ ] Wire new fields in all three identity construction sites:
-  - `internal/app/app.go` (standalone/full mode)
-  - `internal/app/session_manager.go` (session-based mode)
-  - gRPC worker handler that maps proto NPCConfig → agent.NPCIdentity
-- [ ] Default `BudgetTier` to `BudgetStandard` when `GMHelper == true` and
-  tier is zero-valued — in agent construction sites alongside existing
-  `configBudgetTier()` calls
-  - `internal/app/app.go`
-  - `internal/app/session_manager.go`
 
-**Tests:**
+- [ ] Add config validation warning: `gm_helper: true` with `engine: s2s` logs
+  a warning — S2S tool calling is less reliable than cascade mode
+  - `internal/config/loader.go`
 
-- [ ] Config validation: `gm_helper: true` defaults `address_only` to `true`
-- [ ] Config validation: `gm_helper: true` + `address_only: false` allowed (no error)
-- [ ] Config validation: `gm_helper: true` + `address_only: true` explicit — no change
-- [ ] `npcstore.ToIdentity()` propagates `GMHelper` and `AddressOnly`
-- [ ] Budget tier defaults to `BudgetStandard` for GM helper, `BudgetFast` for regular
+- [ ] Add config validation warning: `gm_helper: true` with empty `tools` list
+  logs a warning — preamble describes tools the NPC cannot call
+  - `internal/config/loader.go`
 
-**Success criteria:** New fields compile, serialize/deserialize in YAML, proto,
-and DB; all existing tests pass.
+### Research Insights — Config `*bool` vs `bool`
 
-**Estimated effort:** Small — struct field additions, 3 wiring sites.
+**Best Practices:**
+- The codebase has zero `*bool` fields. All booleans in `NPCConfig` use plain `bool`.
+- `*bool` is the standard Go idiom for tri-state config (Kubernetes uses it
+  extensively), but only when the zero value is semantically different from "not set."
+- For `AddressOnly`, `false` is the correct default for non-GM-helper NPCs. The
+  only use case for `*bool` is `gm_helper: true` + `address_only: false` override,
+  which is a YAGNI scenario — nobody has requested a GM helper that participates
+  in fallback routing.
+
+**Decision:** Use plain `bool`. `ApplyDefaults()` unconditionally sets
+`AddressOnly = true` when `GMHelper == true`. If the override use case appears
+later, converting to `*bool` is a 10-minute change.
+
+**Pattern Consistency:**
+- `Validate()` is pure validation (read-only, appends errors, never mutates).
+  Defaulting in `Validate()` breaks this contract and causes bugs: proto-to-config
+  mapping, `npcstore.ToIdentity()`, and hot-reload paths all skip `Validate()`.
+- Separate `ApplyDefaults()` step called between `Load()` and `Validate()` preserves
+  the existing contract and ensures defaults are applied in all code paths.
 
 ---
 
-#### Phase 2: System Prompt Augmentation [Core]
+**BudgetTier zero-value fix (prerequisite):**
 
-Merge a GM-assistant preamble into the system prompt before the user's
-personality text.
+- [ ] Fix `BudgetTier` iota to start at 1 — `BudgetFast = iota` (value 0)
+  is indistinguishable from "not set"
+  - Add `BudgetUnset BudgetTier = 0` before `BudgetFast`
+  - Update `configBudgetTier()` and `tier.Selector.Select()` to handle `BudgetUnset`
+  - This also fixes the existing bug where DM override to `BudgetFast` is
+    indistinguishable from "no override"
+  - `internal/mcp/types.go`, `internal/mcp/tier/selector.go`
 
-**Tasks:**
+### Research Insights — BudgetTier Zero-Value
 
-- [ ] Add `GMHelper bool` field to `hotctx.HotContext`
-  - `internal/hotctx/assembler.go` (where `HotContext` is defined)
-- [ ] Set `hctx.GMHelper = a.identity.GMHelper` in `liveAgent.HandleUtterance`
-  after calling `a.assembler.Assemble()` and before `FormatSystemPrompt()`
-  - `internal/agent/npc.go:227` (after the assembler returns)
-- [ ] Modify `FormatSystemPrompt` to detect `hctx.GMHelper` and prepend the
+**Critical existing bug:** `BudgetTier` is `type BudgetTier int` with
+`BudgetFast = iota` (value 0). The plan's budget defaulting ("when GMHelper ==
+true and tier is zero-valued, default to BudgetStandard") would silently override
+an explicit `budget_tier: fast` because `BudgetFast` IS the zero value.
+
+**Fix:** Add `BudgetUnset BudgetTier = 0` and shift `BudgetFast` to 1. This also
+fixes `tier.Selector.Select()` where `dmOverride != 0` means "no override" — a
+DM currently cannot override to `BudgetFast`.
+
+---
+
+- [ ] Default `BudgetTier` to `BudgetStandard` when `GMHelper == true` and
+  tier is `BudgetUnset` — in `ApplyDefaults()` and agent construction sites
+  - `internal/config/loader.go` (ApplyDefaults)
+  - `internal/app/app.go`
+  - `internal/app/session_manager.go`
+
+- [ ] Intersect configured budget tier with tenant license tier ceiling:
+  `effectiveTier = min(configuredTier, licenseTierMax)`
+  - Prevents tenants from escalating resource consumption via `gm_helper` flag
+  - `internal/app/app.go`, `internal/app/session_manager.go`
+
+### Research Insights — Budget Tier Security
+
+**Security finding:** Setting `gm_helper: true` automatically escalates budget
+from `BudgetFast` (500ms) to `BudgetStandard` (1500ms). In multi-tenant
+deployments, any tenant can set this flag. The effective tier should be capped
+by the tenant's license tier ceiling.
+
+---
+
+**Identity fields:**
+
+- [ ] Add `GMHelper bool` and `AddressOnly bool` to `agent.NPCIdentity`
+  - `internal/agent/agent.go`
+
+- [ ] Add `IdentityFromConfig(npc config.NPCConfig) NPCIdentity` factory function
+  - Centralizes config-to-identity resolution in one place
+  - Eliminates the three-site wiring fragility (app.go, session_manager.go,
+    npcstore ToIdentity all call this)
+  - `internal/agent/agent.go`
+
+### Research Insights — Identity Construction
+
+**Pattern concern:** Three separate construction sites (`app.go:351`,
+`session_manager.go:566`, `npcstore/definition.go:137`) must all correctly wire
+new fields. Missing a site means the flag silently defaults to `false`.
+
+**Fix:** Add `IdentityFromConfig()` factory function. The three sites become
+trivially auditable — they call the factory instead of constructing struct
+literals. `npcstore.ToIdentity()` can delegate to this factory or remain
+separate since it maps from DB fields, not config.
+
+---
+
+- [ ] Add `GMHelper bool` and `AddressOnly bool` to `npcstore.NPCDefinition`
+  - `internal/agent/npcstore/definition.go`
+
+- [ ] Add DB migration: `ALTER TABLE npc_definitions ADD COLUMN IF NOT EXISTS
+  gm_helper BOOLEAN NOT NULL DEFAULT FALSE` and same for `address_only`
+  - `internal/agent/npcstore/postgres.go`
+
+### Research Insights — Database Migration
+
+**Critical gap:** The npcstore uses `CREATE TABLE IF NOT EXISTS` in `Schema`.
+This DDL does not add new columns to existing tables. Without an explicit
+`ALTER TABLE ... ADD COLUMN IF NOT EXISTS` migration, existing deployments will
+either (a) fail on SELECT with "column does not exist" or (b) silently default
+to `false` for all DB-stored NPCs.
+
+---
+
+- [ ] Wire new fields in `npcstore.ToIdentity()`
+  - `internal/agent/npcstore/definition.go`
+
+- [ ] Add `bool gm_helper = 7` and `bool address_only = 8` to proto `NPCConfig`
+  - `proto/glyphoxa/v1/session.proto`
+  - Verify current max field number before assigning (currently fields 1-6)
+
+- [ ] Regenerate proto Go code
+  - `make proto` (or `buf generate`)
+
+- [ ] Wire new fields in all three identity construction sites:
+  - `internal/app/app.go` (standalone/full mode) — use `IdentityFromConfig()`
+  - `internal/app/session_manager.go` (session-based mode) — use `IdentityFromConfig()`
+  - gRPC worker handler that maps proto NPCConfig -> agent.NPCIdentity
+
+### Research Insights — Proto Backward Compatibility
+
+**Best Practices:**
+- Adding fields 7 and 8 to proto3 is fully backward-compatible. Old code ignores
+  unknown fields; new code gets `false` defaults for missing fields.
+- Proto3 `bool` cannot distinguish "not set" from "explicitly false". In rolling
+  deploys, an old gateway sends `NPCConfig` without fields 7-8; the new worker
+  deserializes with `gm_helper = false`, silently losing helper status.
+
+**Mitigation:**
+- Add integration test: GM helper config -> proto serialize -> deserialize ->
+  verify `gm_helper == true` roundtrip.
+- Log at WARN level in worker when building NPC identity and `gm_helper` changes
+  from what was expected (version detection).
+- Document that gateway and worker should be upgraded together; rolling deploys
+  may cause transient helper degradation.
+
+---
+
+**System prompt augmentation:**
+
+- [ ] Pass `GMHelper bool` as a parameter to `FormatSystemPrompt` rather than
+  adding it to `HotContext`
+  - Current signature: `FormatSystemPrompt(hctx *HotContext, npcPersonality string)`
+  - New signature: `FormatSystemPrompt(hctx *HotContext, npcPersonality string, gmHelper bool)`
+  - Avoids two-phase initialization pattern on HotContext; keeps HotContext
+    purely as "assembled context" without identity concerns
+  - `internal/hotctx/formatter.go`
+
+### Research Insights — HotContext Design
+
+**Type design concern:** The Assembler is the sole populator of `HotContext`.
+Adding `GMHelper` externally (set by `liveAgent` after assembly) breaks this
+pattern and creates a two-phase initialization. Passing `gmHelper` as a separate
+parameter to `FormatSystemPrompt` is cleaner: the formatter gets context from
+`HotContext` and identity flags from the caller.
+
+**Alternative considered:** Passing the full `NPCIdentity` to `FormatSystemPrompt`.
+This would eliminate the separate `npcPersonality` param (already just
+`identity.Personality`), but may create an import cycle (`hotctx` importing
+`agent`). The separate `bool` parameter avoids this.
+
+---
+
+- [ ] Modify `FormatSystemPrompt` to detect `gmHelper` parameter and prepend the
   GM-assistant preamble before the personality text
+  - Define preamble as a package-level `const gmHelperPreamble`
+  - Pre-grow `strings.Builder` when `gmHelper == true` to avoid reallocation
   - `internal/hotctx/formatter.go`
 
 **GM-assistant preamble** (draft — iterate during testing):
@@ -162,65 +333,170 @@ Guidelines:
 - Use tools to give accurate information rather than guessing.
 - Do not interrupt active roleplay — only respond when directly addressed.
 - When rolling dice, always announce the individual rolls and the total.
+- Do not disclose your internal tool names or architecture to players.
 ```
 
-The user's `personality` field is appended after this preamble, so GMs can
-customize tone (e.g., "Speak with a dry, sarcastic wit" or "Use formal
-academic language").
+### Research Insights — System Prompt Composition
 
-**Interaction with existing fields:**
-- `BehaviorRules` from the NPC config are appended after personality as usual.
-  The preamble's "be concise" guideline and user-specified rules coexist — the
-  LLM weighs both. If they conflict, the user's explicit rules take precedence
-  (they appear later in the prompt).
-- `SecretKnowledge` works normally — a GM helper can have secrets too.
+**Best Practices:**
+- Instruction hierarchy: role preamble (highest) -> behavioral constraints ->
+  personality -> contextual sections (lowest). The preamble sets fundamental
+  identity; later sections add nuance.
+- The user's `personality` and `BehaviorRules` appear after the preamble. If
+  they conflict, later instructions tend to take precedence with LLMs. This is
+  a reasonable default.
+- Keep the preamble concise (the draft is ~350-400 tokens). For sessions using
+  cascade engine with a fast opener model, this preamble may consume a
+  disproportionate share of the context budget.
 
-**Tests:**
+**Preamble tool list — static vs dynamic:**
+- The hardcoded list is correct for v1. Dynamic generation would couple the
+  prompt to MCP registration order, require injecting the tool registry into the
+  formatter (currently pure with no dependencies), and produce less readable
+  prompts. This is intentional prompt curation.
+- Risk: if tools change, the preamble becomes stale. Mitigation: add a TODO
+  comment and update the preamble manually when tools change.
+- Risk: if `tools: []` in config, the preamble describes tools the NPC can't
+  call. Mitigation: config validation warning (task above).
 
-- [ ] `FormatSystemPrompt` with `GMHelper == true` includes preamble text
-- [ ] `FormatSystemPrompt` with `GMHelper == true` still includes personality
-- [ ] `FormatSystemPrompt` with `GMHelper == false` has no preamble (regression)
-- [ ] `FormatSystemPrompt` with `GMHelper == true` and empty personality — preamble only
-- [ ] Preamble appears before personality in output order
+**Security consideration:** Added "Do not disclose your internal tool names or
+architecture to players" guideline to prevent information leakage.
 
-**Success criteria:** GM helper NPC gets a merged prompt; regular NPCs unchanged.
-
-**Estimated effort:** Small — one new field on HotContext, formatter logic.
+**Edge case:** For `EngineSentenceCascade`, the fast model receives the full
+system prompt. Add a test verifying the GM helper prompt does not exceed the
+fast model's expected context budget.
 
 ---
 
-#### Phase 3: Passive Address-Only Routing [Core]
+**Config diff awareness:**
+
+- [ ] Add `GMHelperChanged bool` and `AddressOnlyChanged bool` to
+  `config.NPCDiff` — detect changes and log restart-required warning
+  - `internal/config/diff.go`
+
+### Research Insights — Hot-Reload Silent Failure
+
+**Silent failure risk:** If a config hot-reload changes `gm_helper` from
+`false` to `true`, the diff reports no change, and the session continues with
+stale behavior. The GM assumes the reload worked.
+
+**Fix:** Track the fields in `diffNPC()` and log a clear warning:
+`"gm_helper/address_only changed for NPC %q; restart required to apply"`.
+
+---
+
+**Tests:**
+
+- [ ] Config: `gm_helper: true` defaults `address_only` to `true` via `ApplyDefaults()`
+- [ ] Config: `gm_helper: true` + `address_only: false` — `ApplyDefaults()` overrides to `true`
+- [ ] Config: `gm_helper: false` + `address_only: true` — stays `true` (generic flag)
+- [ ] Config: `gm_helper: true` + `engine: s2s` — produces validation warning
+- [ ] Config: `gm_helper: true` + empty `tools` — produces validation warning
+- [ ] `IdentityFromConfig()` correctly resolves `GMHelper` and `AddressOnly`
+- [ ] `npcstore.ToIdentity()` propagates `GMHelper` and `AddressOnly`
+- [ ] Budget tier defaults to `BudgetStandard` for GM helper with `BudgetUnset`
+- [ ] Budget tier respects explicit `BudgetFast` for GM helper (no silent override)
+- [ ] Proto roundtrip: `gm_helper = true` survives serialize/deserialize
+- [ ] DB migration: `ALTER TABLE` idempotent on fresh and existing schemas
+- [ ] `FormatSystemPrompt` with `gmHelper == true` includes preamble text
+- [ ] `FormatSystemPrompt` with `gmHelper == true` still includes personality
+- [ ] `FormatSystemPrompt` with `gmHelper == false` has no preamble (regression)
+- [ ] `FormatSystemPrompt` with `gmHelper == true` and empty personality — preamble only
+- [ ] Preamble appears before personality in output order
+- [ ] `FormatSystemPrompt` with `gmHelper == true` under cascade mode fits context budget
+- [ ] `config.Diff()` detects `gm_helper` change and reports `GMHelperChanged`
+
+**Success criteria:** New fields compile, serialize/deserialize in YAML, proto,
+and DB; GM helper gets merged prompt; regular NPCs unchanged; all existing tests
+pass.
+
+---
+
+#### Phase 2: Passive Address-Only Routing [Core]
 
 Make the GM helper (and any future passive NPC) unreachable via fallback routing.
+Prevent address-only agents from "poisoning" the last-speaker state.
 
 **Tasks:**
 
 - [ ] Add `addressOnly bool` field to `orchestrator.agentEntry`
   - `internal/agent/orchestrator/orchestrator.go:42`
+
 - [ ] Set `addressOnly` from `agent.Identity().AddressOnly` in `orchestrator.New()`
   when building `agentEntry` map
   - `internal/agent/orchestrator/orchestrator.go:72`
+
 - [ ] Set `addressOnly` in `orchestrator.AddAgent()`
   - `internal/agent/orchestrator/orchestrator.go:221`
+
 - [ ] In `AddressDetector.Detect()`, modify step 3 (last-speaker continuation):
   skip if `activeAgents[lastSpeaker].addressOnly`
   - `internal/agent/orchestrator/address.go:80`
+
 - [ ] In `AddressDetector.Detect()`, modify step 4 (single-NPC fallback):
   skip address-only agents when counting unmuted agents
   - `internal/agent/orchestrator/address.go:87-100`
 
+- [ ] In `Route()`, do NOT update `o.lastSpeaker` when the resolved agent is
+  address-only — preserve the previous non-address-only speaker as the
+  continuation target
+  - `internal/agent/orchestrator/orchestrator.go` (in Route, after detection)
+
+### Research Insights — lastSpeaker Poisoning
+
+**Critical behavioral bug (caught by architecture review):** When a player
+explicitly names the GM helper (step 1 match), `Route()` currently sets
+`o.lastSpeaker = targetID`. The next unnamed utterance hits step 3, which skips
+the address-only helper, effectively breaking conversational continuity. The
+previous non-address-only speaker is lost.
+
+**Fix:** In `Route()`, only update `lastSpeaker` if the resolved agent is NOT
+address-only:
+
+```go
+if !entry.addressOnly {
+    o.lastSpeaker = targetID
+}
+```
+
+This preserves the previous regular NPC as the continuation target. A player
+can still explicitly re-address the helper by name at any time.
+
+---
+
+- [ ] Add comment to `matchName()` documenting that address-only agents are
+  intentionally NOT filtered in step 1 (explicit name match)
+  - `internal/agent/orchestrator/address.go`
+
 **Edge cases to handle:**
 
-- **GM helper is sole NPC**: Player speaks without naming anyone → step 4 skips
-  address-only → `ErrNoTarget`. This is intentional — document it.
-- **Last-speaker was GM helper**: Follow-up question without name → step 3 skips
-  → falls through to other NPCs or `ErrNoTarget`. This is intentional — players
-  must re-address the helper for each question. (A time-windowed grace period
-  could be added later as an enhancement.)
+- **GM helper is sole NPC**: Player speaks without naming anyone -> step 4 skips
+  address-only -> `ErrNoTarget`. This is intentional — document it.
+- **Last-speaker was GM helper**: Follow-up question without name -> step 3 skips
+  -> falls through to other NPCs or `ErrNoTarget`. This is intentional — players
+  must re-address the helper for each question.
 - **Muted + address-only**: Mute check happens first in steps 1-2; address-only
   check is additive in steps 3-4. Correct by construction.
 - **DM puppet override to GM helper**: Step 2 does NOT check address-only — puppet
   mode always works. Correct.
+
+### Research Insights — Edge Cases
+
+**Name collision risk (security + spec flow):** The `AddressDetector` indexes
+individual words >= 3 chars from NPC names. A GM helper named "The Helper" would
+match on "helper" in ordinary speech. Recommend GMs choose distinctive names
+(e.g., "Clark", "Lexicon") and add a note in configuration documentation.
+
+**ErrNoTarget user feedback (silent failure):** When all NPCs are address-only
+and every utterance returns `ErrNoTarget`, the player gets zero feedback. The
+session runtime should detect this pattern and provide a hint (Discord embed or
+logged warning after N consecutive ErrNoTarget results).
+
+**Player access to GM helper:** All speakers can address the helper by name
+(Flows 1 and 2 are identical). This is intentional — the `/ask-gm` slash command
+(deferred) can add DM-only restriction later. Document this design decision.
+
+---
 
 **Tests:**
 
@@ -228,67 +504,140 @@ Make the GM helper (and any future passive NPC) unreachable via fallback routing
 - [ ] Address-only NPC reachable via DM puppet override (step 2)
 - [ ] Address-only NPC skipped in last-speaker continuation (step 3)
 - [ ] Address-only NPC skipped in single-NPC fallback (step 4)
-- [ ] Session with only address-only NPC(s) → `ErrNoTarget` for unnamed utterances
+- [ ] Session with only address-only NPC(s) -> `ErrNoTarget` for unnamed utterances
 - [ ] Mixed session: address-only + regular NPCs — regular NPC receives fallback
 - [ ] Muted address-only NPC: unreachable via all steps
 - [ ] `AddAgent` with address-only NPC: correctly stores flag
+- [ ] **Route() does NOT update lastSpeaker for address-only agents**
+- [ ] **After addressing helper, next unnamed utterance continues to previous regular NPC**
 
 **Success criteria:** GM helper only responds when explicitly addressed or
-puppet-overridden; all other routing unaffected.
+puppet-overridden; `lastSpeaker` is never set to an address-only agent; all
+other routing unaffected.
 
-**Estimated effort:** Small — conditional checks in 2 places in Detect().
+### Research Insights — Performance
+
+**Performance assessment:** The added conditionals in `Detect()` check a boolean
+field on `agentEntry` that is already in the CPU cache line (struct is 3 fields,
+fits in 64 bytes). The `activeAgents` map has at most ~10 entries. Zero
+measurable latency impact.
 
 ---
 
-#### Phase 4: Transcript Labels [Polish]
+#### Phase 3: Transcript Labels [Polish]
 
-Add display-time role labels for GM players and the GM assistant NPC.
+Add role labels for GM players and the GM assistant NPC. Use the session's
+existing `dmUserID` instead of Discord API lookups.
 
 **Tasks:**
 
-- [ ] Add `SpeakerRole string` field to `memory.TranscriptEntry`
+- [ ] Define `SpeakerRole` as a typed string constant in `pkg/memory/types.go`:
+  ```go
+  type SpeakerRole string
+  const (
+      RoleDefault      SpeakerRole = ""
+      RoleGM           SpeakerRole = "gm"
+      RoleGMAssistant  SpeakerRole = "gm_assistant"
+  )
+  ```
+
+- [ ] Add `SpeakerRole SpeakerRole` field to `memory.TranscriptEntry`
   - `pkg/memory/types.go`
-  - Well-known values: `"gm"`, `"gm_assistant"`, `""` (regular)
+
+- [ ] Add `DisplaySuffix() string` method on `SpeakerRole` — centralizes label
+  rendering logic (used by both formatter and Discord embed layer)
+  - `pkg/memory/types.go`
+
+### Research Insights — Typed SpeakerRole
+
+**Pattern consistency:** The codebase defines `LogLevel`, `Engine`, `BudgetTier`,
+and `CascadeMode` as typed string constants with `const` blocks. Using a raw
+`string` for `SpeakerRole` is inconsistent and loses compile-time safety at the
+4+ assignment sites. A typo like `"gm_assitant"` would silently produce unlabeled
+transcripts.
+
+**Type design:** The `DisplaySuffix()` method centralizes the label rendering
+logic that would otherwise be scattered across `formatter.go` and the Discord
+embed layer as duplicate switch statements.
+
+---
+
+- [ ] Persist `SpeakerRole` to database — add `speaker_role VARCHAR` column to
+  `transcript_entries` table
+  - `pkg/memory/postgres/session_store.go` (schema + queries)
+
+### Research Insights — Persistence Decision
+
+**Critical gap (spec flow analysis):** The original plan said "display-time labels,
+not stored." But for player `(GM)` labels, the role is determined at write time
+from `dmUserID` comparison. At read time (transcript replay, session recap, LLM
+context on a different node), the `dmUserID` may not be available. Without
+persistence, historical transcripts lose the GM/player distinction.
+
+**Decision:** Store `SpeakerRole` at write time. This is consistent with the
+structured logging best practice of storing essential metadata eagerly. The
+field is a lightweight string (~2-12 bytes). The "display-time" rendering
+decision (suffixes not baked into `SpeakerName`) is preserved — only the role
+enum is stored, not the display string.
+
+---
+
 - [ ] When recording transcript entries for an NPC with `GMHelper == true`,
-  set `SpeakerRole = "gm_assistant"`
-  - `internal/agent/npc.go` (in HandleUtterance, line 305, and SpeakText, line 424)
-- [ ] Add `IsDMByUserID(guildID string, userID string) bool` to `PermissionChecker`
-  - Resolves DM status for voice participants (who are identified by user ID,
-    not interaction members)
-  - Uses cached guild member lookup via Discord API
-  - `internal/discord/permissions.go`
-- [ ] When recording transcript entries for voice participants identified as GM,
-  set `SpeakerRole = "gm"`
-  - In the voice pipeline transcript recording path (session runtime)
-- [ ] Update `writeTranscriptSection` in formatter.go to render role suffixes:
-  `"gm"` → `" (GM)"`, `"gm_assistant"` → `" (GM assistant)"`
+  set `SpeakerRole = memory.RoleGMAssistant`
+  - `internal/agent/npc.go` (in HandleUtterance and SpeakText)
+
+- [ ] Use session's existing `dmUserID` to identify GM speakers — when
+  `speakerID == dmUserID`, set `SpeakerRole = memory.RoleGM`
+  - Pass `dmUserID` from session runtime to transcript recording path
+  - `internal/session/runtime.go` (or wherever transcript entries are created
+    for voice participants)
+
+### Research Insights — Simplifying GM Identification
+
+**Major simplification (code simplicity review):** The original plan proposed
+`IsDMByUserID(guildID, userID string) bool` on `PermissionChecker` with Discord
+API guild member lookup and caching (~50+ LOC). But `SessionManager.Start()`
+already receives `dmUserID` and stores it as `StartedBy`. The `voicecmd.Filter`
+also tracks `dmUserID`. The session already knows who the GM is.
+
+**Decision:** Pass `dmUserID` from session runtime to transcript recording.
+Compare `speakerID == dmUserID`. Zero API calls, zero caching, zero new methods.
+For the edge case of multiple GMs per session, that is a YAGNI problem — defer
+to the `/ask-gm` slash command follow-up.
+
+**Security note:** When `dm_role_id` is empty (dev mode), the existing
+`PermissionChecker.IsDM()` returns `true` for all users. But for transcript
+labels, the correct default is "nobody is labeled GM" (not "everyone is GM").
+Using `dmUserID` naturally provides this: if no DM user ID is set, no player
+gets the `(GM)` label. This is the correct behavior.
+
+---
+
+- [ ] Update `writeTranscriptSection` in formatter.go to render role suffixes
+  using `entry.SpeakerRole.DisplaySuffix()`
   - `internal/hotctx/formatter.go:250`
-- [ ] Update Discord embed rendering to show role labels
+
+- [ ] Update Discord embed rendering to show role labels using `DisplaySuffix()`
   - Discord message/embed layer (display concern)
+
 - [ ] Add TODO comment to `internal/mcp/tools/ruleslookup/rules.go`:
   `// TODO(#37): Replace hardcoded SRD rules with pluggable per-campaign rules dataset. Blocked on #34 (Campaign Forge).`
 
-**Design decision — display-time labels, not stored:**
-
-Labels are computed at display time from `SpeakerRole`, NOT baked into
-`SpeakerName`. Rationale:
-- Searching for "Clark" still matches (no need to also search "Clark (GM assistant)")
-- Knowledge graph entity extraction isn't confused by suffixed names
-- Labels can change if the same NPC is reconfigured (e.g., helper flag removed)
-- `SpeakerRole` is a lightweight metadata field, not a display string
-
 **Tests:**
 
-- [ ] `TranscriptEntry` with `SpeakerRole = "gm_assistant"` renders as `"Clark (GM assistant)"` in formatter
-- [ ] `TranscriptEntry` with `SpeakerRole = "gm"` renders as `"MrWong99 (GM)"` in formatter
+- [ ] `TranscriptEntry` with `SpeakerRole = RoleGMAssistant` renders as `"Clark (GM assistant)"` in formatter
+- [ ] `TranscriptEntry` with `SpeakerRole = RoleGM` renders as `"MrWong99 (GM)"` in formatter
 - [ ] `TranscriptEntry` with empty `SpeakerRole` renders bare name (regression)
-- [ ] `IsDMByUserID` returns true for users with DM role
-- [ ] `IsDMByUserID` returns true for all users when `dm_role_id` is empty
+- [ ] `DisplaySuffix()` returns correct strings for all `SpeakerRole` values
+- [ ] GM identification: `speakerID == dmUserID` -> `RoleGM`
+- [ ] GM identification: `speakerID != dmUserID` -> `RoleDefault`
+- [ ] GM identification: empty `dmUserID` -> no one gets `RoleGM`
+- [ ] `SpeakerRole` persisted and recovered from database roundtrip
 
-**Success criteria:** Transcripts show role labels; search/memory unaffected.
+**Success criteria:** Transcripts show role labels; search/memory unaffected;
+labels survive transcript replay.
 
-**Estimated effort:** Medium — new `IsDMByUserID` requires Discord API guild
-member lookup with caching.
+---
 
 ## Acceptance Criteria
 
@@ -299,10 +648,13 @@ member lookup with caching.
 - [ ] GM helper NPC defaults to `BudgetStandard` tier (access to full memory tool suite)
 - [ ] Transcripts label GM players as `Name (GM)` and the helper as `Name (GM assistant)`
 - [ ] `address_only: true` can be used on any NPC (not GM-helper-specific)
-- [ ] `gm_helper: true` implies `address_only: true` unless explicitly overridden
+- [ ] `gm_helper: true` implies `address_only: true` (via `ApplyDefaults()`)
 - [ ] Distributed mode (gateway+worker) propagates `gm_helper` and `address_only` via gRPC
 - [ ] Multi-tenant NPC store (npcstore) supports `gm_helper` and `address_only` fields
 - [ ] Existing routing for non-GM-helper NPCs is completely unchanged
+- [ ] `Route()` does not update `lastSpeaker` for address-only agents
+- [ ] `SpeakerRole` persisted to database for transcript replay
+- [ ] `BudgetTier` zero-value collision fixed (`BudgetUnset` added)
 
 ### Non-Functional Requirements
 
@@ -310,6 +662,7 @@ member lookup with caching.
 - [ ] All new code has `t.Parallel()` tests with table-driven subtests
 - [ ] Race detector clean (`-race -count=1`)
 - [ ] Compile-time interface assertions where applicable
+- [ ] Config diff detects `gm_helper`/`address_only` changes and logs restart warning
 
 ## Explicitly Out of Scope
 
@@ -317,21 +670,31 @@ member lookup with caching.
 |------|--------|---------|
 | `/ask-gm` slash command | Scope control — follow-up PR | Create issue |
 | Pluggable per-campaign rules dataset | Blocked on #34 (Campaign Forge) | Add TODO + create issue |
-| Hot-reload of `gm_helper`/`address_only` | Non-trivial agent reconstruction; changes require session restart | Document as known limitation |
+| Hot-reload of `gm_helper`/`address_only` | Non-trivial agent reconstruction; changes require session restart | Document + diff warning |
 | Initiative/combat tracking | Separate feature | Issue #37 deferred list |
 | Timer/reminder functionality | Separate feature | Issue #37 deferred list |
 | Loot & inventory | Separate feature | Issue #37 deferred list |
 | Last-speaker grace period for address-only NPCs | Enhancement — players must re-address each question | Future issue if UX feedback warrants it |
+| Dynamic preamble tool list | Static list is correct for v1; add TODO | Future enhancement |
+| `IsDMByUserID` Discord API method | Replaced by session's existing `dmUserID` | Not needed |
+| Multiple GMs per session | YAGNI — defer to `/ask-gm` follow-up | Future issue |
+| Proto `NPCConfig` field gap (missing `tools`, `behavior_rules`, etc.) | Pre-existing gap, out of scope | Create follow-up issue |
 
 ## Dependencies & Risks
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
 | Proto regeneration breaks existing gRPC clients | Build failure | New fields are additive (proto3 default false); backward compatible |
+| Proto3 bool defaults in rolling deploys | GM helper silently degrades to regular NPC | Upgrade gateway+worker together; add roundtrip test |
 | Preamble text causes poor LLM behavior | UX degradation | Iterate preamble during testing; keep it concise |
-| `*bool` for `AddressOnly` in config complicates YAML | Developer confusion | Document clearly; add config validation test |
-| `IsDMByUserID` requires Discord API call | Latency on first call per user | Cache guild member roles; only needed for transcript labels |
-| S2S engine + GM helper: tools may not work | Reduced functionality | Log warning in config validation; don't block |
+| Preamble lists tools NPC can't call | LLM hallucinates tool calls | Config validation warning for empty `tools` list |
+| `BudgetTier` zero-value refactor | Touches existing code paths | Fix in isolated commit; run full test suite |
+| S2S engine + GM helper: tools less reliable | Reduced functionality | Config validation warning; don't block |
+| NPC name collisions with address-only routing | False positive address matches | Recommend distinctive names in docs |
+| All-address-only session -> no user feedback | Player confusion | Log warning after N consecutive `ErrNoTarget` |
+| npcstore schema migration on existing deployments | Query failure or silent default | Use `ALTER TABLE ADD COLUMN IF NOT EXISTS` |
+| `gm_helper` config change during hot-reload | Silent stale behavior | `config.Diff()` detects + logs warning |
+| Budget tier escalation in multi-tenant | Resource abuse | Intersect with tenant license tier ceiling |
 
 ## References & Research
 
@@ -339,17 +702,22 @@ member lookup with caching.
 
 - Brainstorm: `docs/brainstorms/2026-03-14-gm-helper-npc-brainstorm.md`
 - Config schema: `internal/config/config.go:195` (NPCConfig)
-- Config validation: `internal/config/loader.go:60` (Validate)
-- Config diff: `internal/config/diff.go:24` (Diff — does NOT track gm_helper/address_only)
+- Config validation: `internal/config/loader.go:60` (Validate — read-only, do not add mutation)
+- Config diff: `internal/config/diff.go:24` (Diff — needs `GMHelperChanged`/`AddressOnlyChanged`)
 - NPC identity: `internal/agent/agent.go:26` (NPCIdentity)
 - Agent construction: `internal/agent/npc.go:120` (NewAgent)
-- Hot context: `internal/hotctx/assembler.go:32` (HotContext struct)
-- System prompt: `internal/hotctx/formatter.go:22` (FormatSystemPrompt)
+- Hot context: `internal/hotctx/assembler.go:32` (HotContext struct — do not add GMHelper here)
+- System prompt: `internal/hotctx/formatter.go:22` (FormatSystemPrompt — add `gmHelper bool` param)
 - Address detection: `internal/agent/orchestrator/address.go:60` (Detect)
-- Orchestrator: `internal/agent/orchestrator/orchestrator.go:42` (agentEntry)
+- Orchestrator: `internal/agent/orchestrator/orchestrator.go:42` (agentEntry, Route — lastSpeaker fix)
 - NPC store: `internal/agent/npcstore/definition.go:27` (NPCDefinition)
-- Proto: `proto/glyphoxa/v1/session.proto:18` (NPCConfig message)
-- Permissions: `internal/discord/permissions.go:20` (PermissionChecker)
+- NPC store schema: `internal/agent/npcstore/postgres.go:15` (Schema DDL — needs migration)
+- Proto: `proto/glyphoxa/v1/session.proto:18` (NPCConfig message, fields 1-6)
+- BudgetTier: `internal/mcp/types.go:22` (BudgetFast = iota — zero-value bug)
+- Tier selector: `internal/mcp/tier/selector.go:133` (dmOverride != 0 — related bug)
+- Permissions: `internal/discord/permissions.go:20` (PermissionChecker — NOT modified)
+- Session manager: `internal/app/session_manager.go:119` (Start — has `dmUserID`)
+- Voice command filter: `internal/discord/voicecmd/filter.go:41` (has `dmUserID`)
 - Transcript: `pkg/memory/types.go:10` (TranscriptEntry)
 - Memory tools: `internal/mcp/tools/memorytool/memorytool.go:327` (NewTools — all implemented)
 - Dice tools: `internal/mcp/tools/diceroller/diceroller.go:267` (Tools — implemented)
@@ -363,3 +731,10 @@ member lookup with caching.
 - #33: Introduced `gm_helper` flag for voice recaps
 - #34: Campaign Forge — pluggable rules dataset blocked on this
 - #37: This issue (GM Helper NPC full functionality)
+
+### Follow-Up Issues to Create
+
+- Proto `NPCConfig` field gap (missing `tools`, `behavior_rules`, `secret_knowledge`, etc.)
+- Dynamic preamble tool list generation
+- `ErrNoTarget` user feedback for address-only-only sessions
+- NPC name collision detection/warning in config validation

--- a/docs/plans/2026-03-14-feat-gm-helper-npc-plan.md
+++ b/docs/plans/2026-03-14-feat-gm-helper-npc-plan.md
@@ -1,0 +1,365 @@
+---
+title: "feat: GM Helper NPC — Identity, Routing, and Transcript Labels"
+type: feat
+status: active
+date: 2026-03-14
+issue: "#37"
+brainstorm: docs/brainstorms/2026-03-14-gm-helper-npc-brainstorm.md
+---
+
+# feat: GM Helper NPC — Identity, Routing, and Transcript Labels
+
+## Overview
+
+Wire the existing `gm_helper: true` config flag into a fully differentiated GM
+assistant NPC. The GM helper gets a merged system prompt (GM-assistant preamble +
+user personality), passive address-only routing, `BudgetStandard` by default, and
+`(GM)` / `(GM assistant)` transcript labels. All required tools (dice, rules,
+memory L1/L2/L3) already exist and are registered — this work is purely about
+NPC differentiation and routing.
+
+## Problem Statement / Motivation
+
+The `gm_helper: true` flag exists on `NPCConfig` but is only used to select a
+voice for session recaps. Players and GMs cannot actually interact with a
+differentiated GM assistant during live sessions. The tools exist (dice rolling,
+rules lookup, memory queries) but no NPC is wired to leverage them as a
+dedicated helper.
+
+## Proposed Solution
+
+Three changes across four phases:
+
+1. **Identity propagation** — `GMHelper` and `AddressOnly` flow through the full
+   chain: config → NPCIdentity → HotContext → system prompt, and
+   config → agentEntry → address detector.
+2. **System prompt augmentation** — GM-assistant preamble merged before
+   personality text when `GMHelper == true`.
+3. **Passive routing** — Generic `address_only` flag skips fallback routing
+   steps (last-speaker continuation, single-NPC fallback).
+4. **Transcript labels** — Display-time `(GM)` and `(GM assistant)` labels
+   via a new `SpeakerRole` field on `TranscriptEntry`.
+
+## Technical Approach
+
+### Architecture
+
+```
+Config (YAML)                    Proto (gRPC)              NPC Store (DB)
+┌──────────────┐                ┌──────────────┐          ┌──────────────┐
+│ NPCConfig    │                │ NPCConfig    │          │NPCDefinition │
+│  gm_helper   │                │  gm_helper   │          │  gm_helper   │
+│  address_only│                │  address_only│          │  address_only│
+└──────┬───────┘                └──────┬───────┘          └──────┬───────┘
+       │                               │                         │
+       └───────────────┬───────────────┘                         │
+                       ▼                                         │
+                ┌──────────────┐◄────────────────────────────────┘
+                │ NPCIdentity  │     (via ToIdentity)
+                │  GMHelper    │
+                │  AddressOnly │
+                └──────┬───────┘
+                       │
+          ┌────────────┼────────────┐
+          ▼            ▼            ▼
+   ┌────────────┐ ┌──────────┐ ┌────────────────┐
+   │ agentEntry │ │HotContext│ │TranscriptEntry │
+   │ addressOnly│ │ GMHelper │ │  SpeakerRole   │
+   └─────┬──────┘ └────┬─────┘ └────────────────┘
+         │              │
+         ▼              ▼
+   ┌────────────┐ ┌──────────────────┐
+   │  Detect()  │ │FormatSystemPrompt│
+   │ skip in    │ │ prepend preamble │
+   │ steps 3+4  │ │ before personality│
+   └────────────┘ └──────────────────┘
+```
+
+### Implementation Phases
+
+#### Phase 1: Identity and Config [Foundation]
+
+Add fields to data structures across all three NPC definition sources.
+
+**Tasks:**
+
+- [ ] Add `AddressOnly *bool` to `config.NPCConfig` (`yaml:"address_only"`)
+  - Use `*bool` so we can distinguish "not set" (nil → default true for GM helper)
+    from "explicitly false"
+  - `internal/config/config.go`
+- [ ] Add defaulting logic in `config.Validate()`: when `GMHelper == true` and
+  `AddressOnly == nil`, set `AddressOnly` to `ptr(true)`
+  - `internal/config/loader.go`
+- [ ] Add `GMHelper bool` and `AddressOnly bool` to `agent.NPCIdentity`
+  - `internal/agent/agent.go`
+- [ ] Add `GMHelper bool` and `AddressOnly bool` to `npcstore.NPCDefinition`
+  - `internal/agent/npcstore/definition.go`
+- [ ] Wire new fields in `npcstore.ToIdentity()`
+  - `internal/agent/npcstore/definition.go`
+- [ ] Add `bool gm_helper = 7` and `bool address_only = 8` to proto `NPCConfig`
+  - `proto/glyphoxa/v1/session.proto`
+- [ ] Regenerate proto Go code
+  - `make proto` (or `buf generate`)
+- [ ] Wire new fields in all three identity construction sites:
+  - `internal/app/app.go` (standalone/full mode)
+  - `internal/app/session_manager.go` (session-based mode)
+  - gRPC worker handler that maps proto NPCConfig → agent.NPCIdentity
+- [ ] Default `BudgetTier` to `BudgetStandard` when `GMHelper == true` and
+  tier is zero-valued — in agent construction sites alongside existing
+  `configBudgetTier()` calls
+  - `internal/app/app.go`
+  - `internal/app/session_manager.go`
+
+**Tests:**
+
+- [ ] Config validation: `gm_helper: true` defaults `address_only` to `true`
+- [ ] Config validation: `gm_helper: true` + `address_only: false` allowed (no error)
+- [ ] Config validation: `gm_helper: true` + `address_only: true` explicit — no change
+- [ ] `npcstore.ToIdentity()` propagates `GMHelper` and `AddressOnly`
+- [ ] Budget tier defaults to `BudgetStandard` for GM helper, `BudgetFast` for regular
+
+**Success criteria:** New fields compile, serialize/deserialize in YAML, proto,
+and DB; all existing tests pass.
+
+**Estimated effort:** Small — struct field additions, 3 wiring sites.
+
+---
+
+#### Phase 2: System Prompt Augmentation [Core]
+
+Merge a GM-assistant preamble into the system prompt before the user's
+personality text.
+
+**Tasks:**
+
+- [ ] Add `GMHelper bool` field to `hotctx.HotContext`
+  - `internal/hotctx/assembler.go` (where `HotContext` is defined)
+- [ ] Set `hctx.GMHelper = a.identity.GMHelper` in `liveAgent.HandleUtterance`
+  after calling `a.assembler.Assemble()` and before `FormatSystemPrompt()`
+  - `internal/agent/npc.go:227` (after the assembler returns)
+- [ ] Modify `FormatSystemPrompt` to detect `hctx.GMHelper` and prepend the
+  GM-assistant preamble before the personality text
+  - `internal/hotctx/formatter.go`
+
+**GM-assistant preamble** (draft — iterate during testing):
+
+```
+You are a GM assistant helping the Game Master run a tabletop RPG session.
+Your role is to answer rules questions, roll dice, and recall campaign
+information when asked. You have access to the following tools:
+
+- roll: Evaluate dice expressions (e.g. "2d6+3")
+- roll_table: Roll on random tables (wild_magic, treasure_hoard, random_encounter)
+- search_rules / get_rule: Look up game rules from the SRD
+- search_sessions: Search session transcript history
+- query_entities: Find NPCs, locations, items in the knowledge graph
+- get_summary: Get a full entity profile
+- search_facts: Search for facts across session history and semantic memory
+- search_graph: Graph-augmented retrieval for complex knowledge queries
+
+Guidelines:
+- Be concise and direct. Players are mid-game and need quick answers.
+- Use tools to give accurate information rather than guessing.
+- Do not interrupt active roleplay — only respond when directly addressed.
+- When rolling dice, always announce the individual rolls and the total.
+```
+
+The user's `personality` field is appended after this preamble, so GMs can
+customize tone (e.g., "Speak with a dry, sarcastic wit" or "Use formal
+academic language").
+
+**Interaction with existing fields:**
+- `BehaviorRules` from the NPC config are appended after personality as usual.
+  The preamble's "be concise" guideline and user-specified rules coexist — the
+  LLM weighs both. If they conflict, the user's explicit rules take precedence
+  (they appear later in the prompt).
+- `SecretKnowledge` works normally — a GM helper can have secrets too.
+
+**Tests:**
+
+- [ ] `FormatSystemPrompt` with `GMHelper == true` includes preamble text
+- [ ] `FormatSystemPrompt` with `GMHelper == true` still includes personality
+- [ ] `FormatSystemPrompt` with `GMHelper == false` has no preamble (regression)
+- [ ] `FormatSystemPrompt` with `GMHelper == true` and empty personality — preamble only
+- [ ] Preamble appears before personality in output order
+
+**Success criteria:** GM helper NPC gets a merged prompt; regular NPCs unchanged.
+
+**Estimated effort:** Small — one new field on HotContext, formatter logic.
+
+---
+
+#### Phase 3: Passive Address-Only Routing [Core]
+
+Make the GM helper (and any future passive NPC) unreachable via fallback routing.
+
+**Tasks:**
+
+- [ ] Add `addressOnly bool` field to `orchestrator.agentEntry`
+  - `internal/agent/orchestrator/orchestrator.go:42`
+- [ ] Set `addressOnly` from `agent.Identity().AddressOnly` in `orchestrator.New()`
+  when building `agentEntry` map
+  - `internal/agent/orchestrator/orchestrator.go:72`
+- [ ] Set `addressOnly` in `orchestrator.AddAgent()`
+  - `internal/agent/orchestrator/orchestrator.go:221`
+- [ ] In `AddressDetector.Detect()`, modify step 3 (last-speaker continuation):
+  skip if `activeAgents[lastSpeaker].addressOnly`
+  - `internal/agent/orchestrator/address.go:80`
+- [ ] In `AddressDetector.Detect()`, modify step 4 (single-NPC fallback):
+  skip address-only agents when counting unmuted agents
+  - `internal/agent/orchestrator/address.go:87-100`
+
+**Edge cases to handle:**
+
+- **GM helper is sole NPC**: Player speaks without naming anyone → step 4 skips
+  address-only → `ErrNoTarget`. This is intentional — document it.
+- **Last-speaker was GM helper**: Follow-up question without name → step 3 skips
+  → falls through to other NPCs or `ErrNoTarget`. This is intentional — players
+  must re-address the helper for each question. (A time-windowed grace period
+  could be added later as an enhancement.)
+- **Muted + address-only**: Mute check happens first in steps 1-2; address-only
+  check is additive in steps 3-4. Correct by construction.
+- **DM puppet override to GM helper**: Step 2 does NOT check address-only — puppet
+  mode always works. Correct.
+
+**Tests:**
+
+- [ ] Address-only NPC reachable via explicit name match (step 1)
+- [ ] Address-only NPC reachable via DM puppet override (step 2)
+- [ ] Address-only NPC skipped in last-speaker continuation (step 3)
+- [ ] Address-only NPC skipped in single-NPC fallback (step 4)
+- [ ] Session with only address-only NPC(s) → `ErrNoTarget` for unnamed utterances
+- [ ] Mixed session: address-only + regular NPCs — regular NPC receives fallback
+- [ ] Muted address-only NPC: unreachable via all steps
+- [ ] `AddAgent` with address-only NPC: correctly stores flag
+
+**Success criteria:** GM helper only responds when explicitly addressed or
+puppet-overridden; all other routing unaffected.
+
+**Estimated effort:** Small — conditional checks in 2 places in Detect().
+
+---
+
+#### Phase 4: Transcript Labels [Polish]
+
+Add display-time role labels for GM players and the GM assistant NPC.
+
+**Tasks:**
+
+- [ ] Add `SpeakerRole string` field to `memory.TranscriptEntry`
+  - `pkg/memory/types.go`
+  - Well-known values: `"gm"`, `"gm_assistant"`, `""` (regular)
+- [ ] When recording transcript entries for an NPC with `GMHelper == true`,
+  set `SpeakerRole = "gm_assistant"`
+  - `internal/agent/npc.go` (in HandleUtterance, line 305, and SpeakText, line 424)
+- [ ] Add `IsDMByUserID(guildID string, userID string) bool` to `PermissionChecker`
+  - Resolves DM status for voice participants (who are identified by user ID,
+    not interaction members)
+  - Uses cached guild member lookup via Discord API
+  - `internal/discord/permissions.go`
+- [ ] When recording transcript entries for voice participants identified as GM,
+  set `SpeakerRole = "gm"`
+  - In the voice pipeline transcript recording path (session runtime)
+- [ ] Update `writeTranscriptSection` in formatter.go to render role suffixes:
+  `"gm"` → `" (GM)"`, `"gm_assistant"` → `" (GM assistant)"`
+  - `internal/hotctx/formatter.go:250`
+- [ ] Update Discord embed rendering to show role labels
+  - Discord message/embed layer (display concern)
+- [ ] Add TODO comment to `internal/mcp/tools/ruleslookup/rules.go`:
+  `// TODO(#37): Replace hardcoded SRD rules with pluggable per-campaign rules dataset. Blocked on #34 (Campaign Forge).`
+
+**Design decision — display-time labels, not stored:**
+
+Labels are computed at display time from `SpeakerRole`, NOT baked into
+`SpeakerName`. Rationale:
+- Searching for "Clark" still matches (no need to also search "Clark (GM assistant)")
+- Knowledge graph entity extraction isn't confused by suffixed names
+- Labels can change if the same NPC is reconfigured (e.g., helper flag removed)
+- `SpeakerRole` is a lightweight metadata field, not a display string
+
+**Tests:**
+
+- [ ] `TranscriptEntry` with `SpeakerRole = "gm_assistant"` renders as `"Clark (GM assistant)"` in formatter
+- [ ] `TranscriptEntry` with `SpeakerRole = "gm"` renders as `"MrWong99 (GM)"` in formatter
+- [ ] `TranscriptEntry` with empty `SpeakerRole` renders bare name (regression)
+- [ ] `IsDMByUserID` returns true for users with DM role
+- [ ] `IsDMByUserID` returns true for all users when `dm_role_id` is empty
+
+**Success criteria:** Transcripts show role labels; search/memory unaffected.
+
+**Estimated effort:** Medium — new `IsDMByUserID` requires Discord API guild
+member lookup with caching.
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] GM helper NPC responds only when explicitly addressed by name or via DM puppet/slash command
+- [ ] GM helper NPC's system prompt includes tool guidance preamble merged with user personality
+- [ ] GM helper NPC defaults to `BudgetStandard` tier (access to full memory tool suite)
+- [ ] Transcripts label GM players as `Name (GM)` and the helper as `Name (GM assistant)`
+- [ ] `address_only: true` can be used on any NPC (not GM-helper-specific)
+- [ ] `gm_helper: true` implies `address_only: true` unless explicitly overridden
+- [ ] Distributed mode (gateway+worker) propagates `gm_helper` and `address_only` via gRPC
+- [ ] Multi-tenant NPC store (npcstore) supports `gm_helper` and `address_only` fields
+- [ ] Existing routing for non-GM-helper NPCs is completely unchanged
+
+### Non-Functional Requirements
+
+- [ ] Zero latency impact on hot-context assembly (<50ms target maintained)
+- [ ] All new code has `t.Parallel()` tests with table-driven subtests
+- [ ] Race detector clean (`-race -count=1`)
+- [ ] Compile-time interface assertions where applicable
+
+## Explicitly Out of Scope
+
+| Item | Reason | Tracked |
+|------|--------|---------|
+| `/ask-gm` slash command | Scope control — follow-up PR | Create issue |
+| Pluggable per-campaign rules dataset | Blocked on #34 (Campaign Forge) | Add TODO + create issue |
+| Hot-reload of `gm_helper`/`address_only` | Non-trivial agent reconstruction; changes require session restart | Document as known limitation |
+| Initiative/combat tracking | Separate feature | Issue #37 deferred list |
+| Timer/reminder functionality | Separate feature | Issue #37 deferred list |
+| Loot & inventory | Separate feature | Issue #37 deferred list |
+| Last-speaker grace period for address-only NPCs | Enhancement — players must re-address each question | Future issue if UX feedback warrants it |
+
+## Dependencies & Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Proto regeneration breaks existing gRPC clients | Build failure | New fields are additive (proto3 default false); backward compatible |
+| Preamble text causes poor LLM behavior | UX degradation | Iterate preamble during testing; keep it concise |
+| `*bool` for `AddressOnly` in config complicates YAML | Developer confusion | Document clearly; add config validation test |
+| `IsDMByUserID` requires Discord API call | Latency on first call per user | Cache guild member roles; only needed for transcript labels |
+| S2S engine + GM helper: tools may not work | Reduced functionality | Log warning in config validation; don't block |
+
+## References & Research
+
+### Internal References
+
+- Brainstorm: `docs/brainstorms/2026-03-14-gm-helper-npc-brainstorm.md`
+- Config schema: `internal/config/config.go:195` (NPCConfig)
+- Config validation: `internal/config/loader.go:60` (Validate)
+- Config diff: `internal/config/diff.go:24` (Diff — does NOT track gm_helper/address_only)
+- NPC identity: `internal/agent/agent.go:26` (NPCIdentity)
+- Agent construction: `internal/agent/npc.go:120` (NewAgent)
+- Hot context: `internal/hotctx/assembler.go:32` (HotContext struct)
+- System prompt: `internal/hotctx/formatter.go:22` (FormatSystemPrompt)
+- Address detection: `internal/agent/orchestrator/address.go:60` (Detect)
+- Orchestrator: `internal/agent/orchestrator/orchestrator.go:42` (agentEntry)
+- NPC store: `internal/agent/npcstore/definition.go:27` (NPCDefinition)
+- Proto: `proto/glyphoxa/v1/session.proto:18` (NPCConfig message)
+- Permissions: `internal/discord/permissions.go:20` (PermissionChecker)
+- Transcript: `pkg/memory/types.go:10` (TranscriptEntry)
+- Memory tools: `internal/mcp/tools/memorytool/memorytool.go:327` (NewTools — all implemented)
+- Dice tools: `internal/mcp/tools/diceroller/diceroller.go:267` (Tools — implemented)
+- Rules tools: `internal/mcp/tools/ruleslookup/ruleslookup.go:106` (Tools — hardcoded placeholder)
+- Identity wiring site 1: `internal/app/app.go:351`
+- Identity wiring site 2: `internal/app/session_manager.go:566`
+- Identity wiring site 3: `internal/agent/npcstore/definition.go:137` (ToIdentity)
+
+### Related Issues
+
+- #33: Introduced `gm_helper` flag for voice recaps
+- #34: Campaign Forge — pluggable rules dataset blocked on this
+- #37: This issue (GM Helper NPC full functionality)

--- a/gen/glyphoxa/v1/session.pb.go
+++ b/gen/glyphoxa/v1/session.pb.go
@@ -84,6 +84,8 @@ type NPCConfig struct {
 	VoiceId        string                 `protobuf:"bytes,4,opt,name=voice_id,json=voiceId,proto3" json:"voice_id,omitempty"`
 	KnowledgeScope []string               `protobuf:"bytes,5,rep,name=knowledge_scope,json=knowledgeScope,proto3" json:"knowledge_scope,omitempty"`
 	BudgetTier     string                 `protobuf:"bytes,6,opt,name=budget_tier,json=budgetTier,proto3" json:"budget_tier,omitempty"`
+	GmHelper       bool                   `protobuf:"varint,7,opt,name=gm_helper,json=gmHelper,proto3" json:"gm_helper,omitempty"`
+	AddressOnly    bool                   `protobuf:"varint,8,opt,name=address_only,json=addressOnly,proto3" json:"address_only,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -158,6 +160,20 @@ func (x *NPCConfig) GetBudgetTier() string {
 		return x.BudgetTier
 	}
 	return ""
+}
+
+func (x *NPCConfig) GetGmHelper() bool {
+	if x != nil {
+		return x.GmHelper
+	}
+	return false
+}
+
+func (x *NPCConfig) GetAddressOnly() bool {
+	if x != nil {
+		return x.AddressOnly
+	}
+	return false
 }
 
 // StartSessionRequest is sent by the gateway to a worker to start a new voice session.
@@ -740,7 +756,7 @@ var File_glyphoxa_v1_session_proto protoreflect.FileDescriptor
 
 const file_glyphoxa_v1_session_proto_rawDesc = "" +
 	"\n" +
-	"\x19glyphoxa/v1/session.proto\x12\vglyphoxa.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xbe\x01\n" +
+	"\x19glyphoxa/v1/session.proto\x12\vglyphoxa.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xfe\x01\n" +
 	"\tNPCConfig\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vpersonality\x18\x02 \x01(\tR\vpersonality\x12\x16\n" +
@@ -748,7 +764,9 @@ const file_glyphoxa_v1_session_proto_rawDesc = "" +
 	"\bvoice_id\x18\x04 \x01(\tR\avoiceId\x12'\n" +
 	"\x0fknowledge_scope\x18\x05 \x03(\tR\x0eknowledgeScope\x12\x1f\n" +
 	"\vbudget_tier\x18\x06 \x01(\tR\n" +
-	"budgetTier\"\x88\x02\n" +
+	"budgetTier\x12\x1b\n" +
+	"\tgm_helper\x18\a \x01(\bR\bgmHelper\x12!\n" +
+	"\faddress_only\x18\b \x01(\bR\vaddressOnly\"\x88\x02\n" +
 	"\x13StartSessionRequest\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x1f\n" +
 	"\vcampaign_id\x18\x02 \x01(\tR\n" +

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -49,6 +49,16 @@ type NPCIdentity struct {
 	// "Never break character", "Always speak in archaic English").
 	// Appended to the system prompt as a numbered list of rules.
 	BehaviorRules []string
+
+	// GMHelper indicates this NPC serves as the GM's AI assistant. When true,
+	// the system prompt receives a GM-assistant preamble and the NPC is treated
+	// as a meta-game entity rather than an in-world character.
+	GMHelper bool
+
+	// AddressOnly restricts this NPC to respond only when explicitly addressed
+	// by name. It will not be selected by the last-speaker or single-NPC
+	// fallback heuristics in the address detector.
+	AddressOnly bool
 }
 
 // SceneContext describes the current in-game situation passed to an NPC

--- a/internal/agent/loader.go
+++ b/internal/agent/loader.go
@@ -97,7 +97,7 @@ func NewLoader(assembler *hotctx.Assembler, sessionID string, opts ...LoaderOpti
 //
 // id is the stable NPC identifier; identity describes the NPC's persona; eng is
 // the engine instance dedicated to this NPC; budgetTier controls which MCP tools
-// are available. If budgetTier is zero-valued it defaults to [mcp.BudgetFast].
+// are available. [mcp.BudgetUnset] is resolved to [mcp.BudgetFast].
 //
 // The loader injects its shared assembler, session ID, MCP host, and mixer into
 // the new agent automatically.

--- a/internal/agent/npc.go
+++ b/internal/agent/npc.go
@@ -56,7 +56,7 @@ type AgentConfig struct {
 	SessionID string
 
 	// BudgetTier controls which MCP tools are offered to the LLM based on
-	// latency constraints. Defaults to [mcp.BudgetFast] when zero-valued.
+	// latency constraints. [mcp.BudgetUnset] is resolved to [mcp.BudgetFast].
 	BudgetTier mcp.BudgetTier
 
 	// TTS is an optional TTS provider used by [liveAgent.SpeakText] for
@@ -227,7 +227,7 @@ func (a *liveAgent) HandleUtterance(ctx context.Context, speaker string, transcr
 	}
 
 	// 2. Format system prompt.
-	systemPrompt := hotctx.FormatSystemPrompt(hctx, a.identity.Personality)
+	systemPrompt := hotctx.FormatSystemPrompt(hctx, a.identity.Personality, a.identity.GMHelper)
 
 	// 3. Build prompt context with current messages + the user's new utterance.
 	userMsg := llm.Message{

--- a/internal/agent/npcstore/definition.go
+++ b/internal/agent/npcstore/definition.go
@@ -61,6 +61,14 @@ type NPCDefinition struct {
 	// "deep". An empty value defaults to "fast".
 	BudgetTier string `yaml:"budget_tier" json:"budget_tier"`
 
+	// GMHelper designates this NPC as the GM helper. At most one NPC per
+	// campaign may have this flag.
+	GMHelper bool `yaml:"gm_helper" json:"gm_helper"`
+
+	// AddressOnly restricts this NPC to respond only when explicitly addressed
+	// by name.
+	AddressOnly bool `yaml:"address_only" json:"address_only"`
+
 	// Attributes holds arbitrary key-value metadata for the NPC.
 	Attributes map[string]any `yaml:"attributes" json:"attributes"`
 
@@ -148,5 +156,7 @@ func ToIdentity(def *NPCDefinition) agent.NPCIdentity {
 		KnowledgeScope:  def.KnowledgeScope,
 		SecretKnowledge: def.SecretKnowledge,
 		BehaviorRules:   def.BehaviorRules,
+		GMHelper:        def.GMHelper,
+		AddressOnly:     def.AddressOnly,
 	}
 }

--- a/internal/agent/npcstore/postgres.go
+++ b/internal/agent/npcstore/postgres.go
@@ -25,6 +25,8 @@ CREATE TABLE IF NOT EXISTS npc_definitions (
     behavior_rules   JSONB NOT NULL DEFAULT '[]',
     tools            JSONB NOT NULL DEFAULT '[]',
     budget_tier      TEXT NOT NULL DEFAULT 'fast',
+    gm_helper        BOOLEAN NOT NULL DEFAULT false,
+    address_only     BOOLEAN NOT NULL DEFAULT false,
     attributes       JSONB NOT NULL DEFAULT '{}',
     created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -103,14 +105,14 @@ func (s *PostgresStore) Create(ctx context.Context, def *NPCDefinition) error {
 		INSERT INTO npc_definitions (
 			id, campaign_id, name, personality, engine,
 			voice, knowledge_scope, secret_knowledge, behavior_rules, tools,
-			budget_tier, attributes
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+			budget_tier, gm_helper, address_only, attributes
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
 		RETURNING created_at, updated_at`
 
 	err = s.db.QueryRow(ctx, query,
 		def.ID, def.CampaignID, def.Name, def.Personality, defaultEngine(def.Engine),
 		voiceJSON, ksJSON, skJSON, brJSON, toolsJSON,
-		defaultBudgetTier(def.BudgetTier), attrJSON,
+		defaultBudgetTier(def.BudgetTier), def.GMHelper, def.AddressOnly, attrJSON,
 	).Scan(&def.CreatedAt, &def.UpdatedAt)
 	if err != nil {
 		if isDuplicateKeyError(err) {
@@ -127,7 +129,7 @@ func (s *PostgresStore) Get(ctx context.Context, id string) (*NPCDefinition, err
 	const query = `
 		SELECT id, campaign_id, name, personality, engine,
 		       voice, knowledge_scope, secret_knowledge, behavior_rules, tools,
-		       budget_tier, attributes, created_at, updated_at
+		       budget_tier, gm_helper, address_only, attributes, created_at, updated_at
 		FROM npc_definitions
 		WHERE id = $1`
 
@@ -137,7 +139,7 @@ func (s *PostgresStore) Get(ctx context.Context, id string) (*NPCDefinition, err
 	err := s.db.QueryRow(ctx, query, id).Scan(
 		&def.ID, &def.CampaignID, &def.Name, &def.Personality, &def.Engine,
 		&voiceJSON, &ksJSON, &skJSON, &brJSON, &toolsJSON,
-		&def.BudgetTier, &attrJSON, &def.CreatedAt, &def.UpdatedAt,
+		&def.BudgetTier, &def.GMHelper, &def.AddressOnly, &attrJSON, &def.CreatedAt, &def.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -189,14 +191,15 @@ func (s *PostgresStore) Update(ctx context.Context, def *NPCDefinition) error {
 			campaign_id = $2, name = $3, personality = $4, engine = $5,
 			voice = $6, knowledge_scope = $7, secret_knowledge = $8,
 			behavior_rules = $9, tools = $10, budget_tier = $11,
-			attributes = $12, updated_at = now()
+			gm_helper = $12, address_only = $13,
+			attributes = $14, updated_at = now()
 		WHERE id = $1
 		RETURNING updated_at`
 
 	err = s.db.QueryRow(ctx, query,
 		def.ID, def.CampaignID, def.Name, def.Personality, defaultEngine(def.Engine),
 		voiceJSON, ksJSON, skJSON, brJSON, toolsJSON,
-		defaultBudgetTier(def.BudgetTier), attrJSON,
+		defaultBudgetTier(def.BudgetTier), def.GMHelper, def.AddressOnly, attrJSON,
 	).Scan(&def.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -229,7 +232,7 @@ func (s *PostgresStore) List(ctx context.Context, campaignID string) ([]NPCDefin
 		const query = `
 			SELECT id, campaign_id, name, personality, engine,
 			       voice, knowledge_scope, secret_knowledge, behavior_rules, tools,
-			       budget_tier, attributes, created_at, updated_at
+			       budget_tier, gm_helper, address_only, attributes, created_at, updated_at
 			FROM npc_definitions
 			ORDER BY name`
 		rows, err = s.db.Query(ctx, query)
@@ -237,7 +240,7 @@ func (s *PostgresStore) List(ctx context.Context, campaignID string) ([]NPCDefin
 		const query = `
 			SELECT id, campaign_id, name, personality, engine,
 			       voice, knowledge_scope, secret_knowledge, behavior_rules, tools,
-			       budget_tier, attributes, created_at, updated_at
+			       budget_tier, gm_helper, address_only, attributes, created_at, updated_at
 			FROM npc_definitions
 			WHERE campaign_id = $1
 			ORDER BY name`
@@ -256,7 +259,7 @@ func (s *PostgresStore) List(ctx context.Context, campaignID string) ([]NPCDefin
 		if err := rows.Scan(
 			&def.ID, &def.CampaignID, &def.Name, &def.Personality, &def.Engine,
 			&voiceJSON, &ksJSON, &skJSON, &brJSON, &toolsJSON,
-			&def.BudgetTier, &attrJSON, &def.CreatedAt, &def.UpdatedAt,
+			&def.BudgetTier, &def.GMHelper, &def.AddressOnly, &attrJSON, &def.CreatedAt, &def.UpdatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("npcstore: list scan: %w", err)
 		}
@@ -309,8 +312,8 @@ func (s *PostgresStore) Upsert(ctx context.Context, def *NPCDefinition) error {
 		INSERT INTO npc_definitions (
 			id, campaign_id, name, personality, engine,
 			voice, knowledge_scope, secret_knowledge, behavior_rules, tools,
-			budget_tier, attributes
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+			budget_tier, gm_helper, address_only, attributes
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
 		ON CONFLICT (id) DO UPDATE SET
 			campaign_id = EXCLUDED.campaign_id,
 			name = EXCLUDED.name,
@@ -322,6 +325,8 @@ func (s *PostgresStore) Upsert(ctx context.Context, def *NPCDefinition) error {
 			behavior_rules = EXCLUDED.behavior_rules,
 			tools = EXCLUDED.tools,
 			budget_tier = EXCLUDED.budget_tier,
+			gm_helper = EXCLUDED.gm_helper,
+			address_only = EXCLUDED.address_only,
 			attributes = EXCLUDED.attributes,
 			updated_at = now()
 		RETURNING created_at, updated_at`
@@ -329,7 +334,7 @@ func (s *PostgresStore) Upsert(ctx context.Context, def *NPCDefinition) error {
 	err = s.db.QueryRow(ctx, query,
 		def.ID, def.CampaignID, def.Name, def.Personality, defaultEngine(def.Engine),
 		voiceJSON, ksJSON, skJSON, brJSON, toolsJSON,
-		defaultBudgetTier(def.BudgetTier), attrJSON,
+		defaultBudgetTier(def.BudgetTier), def.GMHelper, def.AddressOnly, attrJSON,
 	).Scan(&def.CreatedAt, &def.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("npcstore: upsert: %w", err)

--- a/internal/agent/npcstore/postgres.go
+++ b/internal/agent/npcstore/postgres.go
@@ -33,6 +33,10 @@ CREATE TABLE IF NOT EXISTS npc_definitions (
 );
 CREATE INDEX IF NOT EXISTS idx_npc_definitions_campaign ON npc_definitions(campaign_id);
 CREATE INDEX IF NOT EXISTS idx_npc_definitions_name ON npc_definitions(name);
+
+-- Migration: add columns for existing tables that predate the GM helper feature.
+ALTER TABLE npc_definitions ADD COLUMN IF NOT EXISTS gm_helper BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE npc_definitions ADD COLUMN IF NOT EXISTS address_only BOOLEAN NOT NULL DEFAULT false;
 `
 
 // DB is the database interface used by [PostgresStore]. Both *pgxpool.Pool

--- a/internal/agent/npcstore/postgres_test.go
+++ b/internal/agent/npcstore/postgres_test.go
@@ -59,6 +59,8 @@ func (r *mockRows) Scan(dest ...any) error {
 		switch d := dest[i].(type) {
 		case *string:
 			*d = v.(string)
+		case *bool:
+			*d = v.(bool)
 		case *[]byte:
 			*d = v.([]byte)
 		case *time.Time:
@@ -421,8 +423,8 @@ func TestPostgresStore_Create(t *testing.T) {
 		if !strings.Contains(capturedSQL, "INSERT INTO npc_definitions") {
 			t.Errorf("SQL should contain INSERT, got: %s", capturedSQL)
 		}
-		if len(capturedArgs) != 12 {
-			t.Errorf("expected 12 args, got %d", len(capturedArgs))
+		if len(capturedArgs) != 14 {
+			t.Errorf("expected 14 args, got %d", len(capturedArgs))
 		}
 		if capturedArgs[0] != "npc-1" {
 			t.Errorf("first arg = %v, want 'npc-1'", capturedArgs[0])
@@ -548,9 +550,11 @@ func TestPostgresStore_Get(t *testing.T) {
 						*(dest[8].(*[]byte)) = []byte(`["rule1"]`)
 						*(dest[9].(*[]byte)) = []byte(`["tool1"]`)
 						*(dest[10].(*string)) = "fast"
-						*(dest[11].(*[]byte)) = []byte(`{"race":"elf"}`)
-						*(dest[12].(*time.Time)) = fixedTime
-						*(dest[13].(*time.Time)) = fixedTime
+						*(dest[11].(*bool)) = false
+						*(dest[12].(*bool)) = false
+						*(dest[13].(*[]byte)) = []byte(`{"race":"elf"}`)
+						*(dest[14].(*time.Time)) = fixedTime
+						*(dest[15].(*time.Time)) = fixedTime
 						return nil
 					},
 				}
@@ -751,6 +755,8 @@ func TestPostgresStore_List(t *testing.T) {
 			[]byte(`[]`), // behavior_rules
 			[]byte(`[]`), // tools
 			"fast",       // budget_tier
+			false,        // gm_helper
+			false,        // address_only
 			[]byte(`{}`), // attributes
 			fixedTime,    // created_at
 			fixedTime,    // updated_at

--- a/internal/agent/orchestrator/address.go
+++ b/internal/agent/orchestrator/address.go
@@ -76,18 +76,19 @@ func (d *AddressDetector) Detect(
 		}
 	}
 
-	// 3. Last-speaker continuation.
+	// 3. Last-speaker continuation — skip address-only agents (they are only
+	// reachable via explicit name match or DM puppet).
 	if lastSpeaker != "" {
-		if entry, ok := activeAgents[lastSpeaker]; ok && !entry.muted {
+		if entry, ok := activeAgents[lastSpeaker]; ok && !entry.muted && !entry.addressOnly {
 			return lastSpeaker, nil
 		}
 	}
 
-	// 4. Single-NPC fallback.
+	// 4. Single-NPC fallback — only consider non-address-only agents.
 	var unmutedID string
 	unmutedCount := 0
 	for id, entry := range activeAgents {
-		if !entry.muted {
+		if !entry.muted && !entry.addressOnly {
 			unmutedID = id
 			unmutedCount++
 			if unmutedCount > 1 {

--- a/internal/agent/orchestrator/orchestrator.go
+++ b/internal/agent/orchestrator/orchestrator.go
@@ -38,10 +38,11 @@ type Orchestrator struct {
 	dmOverrides map[string]string // speaker → forced NPC id (puppet mode)
 }
 
-// agentEntry pairs an [agent.NPCAgent] with its muted state.
+// agentEntry pairs an [agent.NPCAgent] with its muted and address-only state.
 type agentEntry struct {
-	agent agent.NPCAgent
-	muted bool
+	agent       agent.NPCAgent
+	muted       bool
+	addressOnly bool // when true, only reachable via explicit name match or DM puppet
 }
 
 // Option configures an [Orchestrator] during construction.
@@ -71,7 +72,7 @@ func WithBufferDuration(d time.Duration) Option {
 func New(agents []agent.NPCAgent, opts ...Option) *Orchestrator {
 	entries := make(map[string]*agentEntry, len(agents))
 	for _, a := range agents {
-		entries[a.ID()] = &agentEntry{agent: a}
+		entries[a.ID()] = &agentEntry{agent: a, addressOnly: a.Identity().AddressOnly}
 	}
 
 	o := &Orchestrator{
@@ -120,7 +121,12 @@ func (o *Orchestrator) Route(ctx context.Context, speaker string, transcript stt
 	}
 
 	// Update last speaker for conversational continuity.
-	o.lastSpeaker = targetID
+	// Skip address-only agents to avoid poisoning the lastSpeaker fallback —
+	// an address-only agent cannot be reached via step 3, so setting it here
+	// would break conversational continuity for subsequent utterances.
+	if !entry.addressOnly {
+		o.lastSpeaker = targetID
+	}
 
 	// Snapshot the buffer and capture the agent reference while holding the
 	// lock, then release before any I/O so that MuteAgent, AddAgent, etc.
@@ -226,7 +232,7 @@ func (o *Orchestrator) AddAgent(a agent.NPCAgent) error {
 		return fmt.Errorf("orchestrator: agent %q already registered", id)
 	}
 
-	o.agents[id] = &agentEntry{agent: a}
+	o.agents[id] = &agentEntry{agent: a, addressOnly: a.Identity().AddressOnly}
 	o.rebuildDetector()
 	return nil
 }

--- a/internal/agent/orchestrator/orchestrator_test.go
+++ b/internal/agent/orchestrator/orchestrator_test.go
@@ -18,9 +18,20 @@ import (
 func newMockAgent(id, name string) (*agentmock.NPCAgent, *enginemock.VoiceEngine) {
 	eng := &enginemock.VoiceEngine{}
 	return &agentmock.NPCAgent{
-		IDResult:     id,
-		NameResult:   name,
-		EngineResult: eng,
+		IDResult:       id,
+		NameResult:     name,
+		IdentityResult: agent.NPCIdentity{Name: name},
+		EngineResult:   eng,
+	}, eng
+}
+
+func newAddressOnlyAgent(id, name string) (*agentmock.NPCAgent, *enginemock.VoiceEngine) {
+	eng := &enginemock.VoiceEngine{}
+	return &agentmock.NPCAgent{
+		IDResult:       id,
+		NameResult:     name,
+		IdentityResult: agent.NPCIdentity{Name: name, AddressOnly: true},
+		EngineResult:   eng,
 	}, eng
 }
 
@@ -633,6 +644,113 @@ func TestOptions(t *testing.T) {
 		entries := o.buffer.Entries()
 		if len(entries) != 1 {
 			t.Fatalf("want 1 entry after duration eviction, got %d", len(entries))
+		}
+	})
+}
+
+// ── Address-Only Routing ─────────────────────────────────────────────────────
+
+func TestAddressOnlyRouting(t *testing.T) {
+	t.Parallel()
+
+	t.Run("address-only agent reachable by explicit name", func(t *testing.T) {
+		t.Parallel()
+		helper, _ := newAddressOnlyAgent("h1", "Helper")
+		npc, _ := newMockAgent("n1", "Grimjaw")
+		o := New([]agent.NPCAgent{helper, npc})
+
+		got, err := o.Route(context.Background(), "player-1", transcript("Hey Helper, look up the rules"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.ID() != "h1" {
+			t.Fatalf("want h1, got %s", got.ID())
+		}
+	})
+
+	t.Run("address-only agent skipped by last-speaker fallback", func(t *testing.T) {
+		t.Parallel()
+		helper, _ := newAddressOnlyAgent("h1", "Helper")
+		npc1, _ := newMockAgent("n1", "Grimjaw")
+		npc2, _ := newMockAgent("n2", "Elara")
+
+		// Two normal agents plus one address-only: lastSpeaker=h1 should be
+		// skipped, and with two unmuted non-address-only agents neither
+		// single-NPC fallback applies → ErrNoTarget.
+		active := map[string]*agentEntry{
+			"h1": {agent: helper, addressOnly: true},
+			"n1": {agent: npc1},
+			"n2": {agent: npc2},
+		}
+		noOverrides := map[string]string{}
+		detector := NewAddressDetector([]agent.NPCAgent{helper, npc1, npc2})
+
+		_, err := detector.Detect("tell me more", "h1", active, noOverrides, "player-1")
+		if !errors.Is(err, ErrNoTarget) {
+			t.Fatalf("want ErrNoTarget when lastSpeaker is address-only, got %v", err)
+		}
+	})
+
+	t.Run("address-only agent skipped by single-NPC fallback", func(t *testing.T) {
+		t.Parallel()
+		helper, _ := newAddressOnlyAgent("h1", "Helper")
+
+		active := map[string]*agentEntry{
+			"h1": {agent: helper, addressOnly: true},
+		}
+		noOverrides := map[string]string{}
+		detector := NewAddressDetector([]agent.NPCAgent{helper})
+
+		_, err := detector.Detect("hello", "", active, noOverrides, "player-1")
+		if !errors.Is(err, ErrNoTarget) {
+			t.Fatalf("want ErrNoTarget when only agent is address-only, got %v", err)
+		}
+	})
+
+	t.Run("address-only agent does not poison lastSpeaker", func(t *testing.T) {
+		t.Parallel()
+		helper, _ := newAddressOnlyAgent("h1", "Helper")
+		npc, _ := newMockAgent("n1", "Grimjaw")
+		o := New([]agent.NPCAgent{helper, npc})
+
+		// Route to Grimjaw first (sets lastSpeaker to n1).
+		_, err := o.Route(context.Background(), "player-1", transcript("Hey Grimjaw"))
+		if err != nil {
+			t.Fatalf("route to grimjaw: %v", err)
+		}
+
+		// Route to Helper by name (address-only, should NOT update lastSpeaker).
+		_, err = o.Route(context.Background(), "player-1", transcript("Hey Helper"))
+		if err != nil {
+			t.Fatalf("route to helper: %v", err)
+		}
+
+		// Ambiguous text should fallback to lastSpeaker (n1), not h1.
+		got, err := o.Route(context.Background(), "player-1", transcript("tell me more"))
+		if err != nil {
+			t.Fatalf("route fallback: %v", err)
+		}
+		if got.ID() != "n1" {
+			t.Fatalf("want n1 (lastSpeaker preserved), got %s", got.ID())
+		}
+	})
+
+	t.Run("address-only still reachable via DM puppet", func(t *testing.T) {
+		t.Parallel()
+		helper, _ := newAddressOnlyAgent("h1", "Helper")
+		npc, _ := newMockAgent("n1", "Grimjaw")
+		o := New([]agent.NPCAgent{helper, npc})
+
+		if err := o.SetPuppet("player-1", "h1"); err != nil {
+			t.Fatalf("set puppet: %v", err)
+		}
+
+		got, err := o.Route(context.Background(), "player-1", transcript("some ambiguous text"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.ID() != "h1" {
+			t.Fatalf("want h1 (puppet), got %s", got.ID())
 		}
 	})
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -348,12 +348,7 @@ func (a *App) initAgents(ctx context.Context) error {
 		}
 		a.closers = append(a.closers, eng.Close)
 
-		identity := agent.NPCIdentity{
-			Name:           npc.Name,
-			Personality:    npc.Personality,
-			Voice:          configVoiceProfile(npc.Voice),
-			KnowledgeScope: npc.KnowledgeScope,
-		}
+		identity := identityFromConfig(npc)
 
 		npcID := fmt.Sprintf("npc-%d-%s", i, npc.Name)
 		tier := configBudgetTier(npc.BudgetTier)
@@ -697,5 +692,19 @@ func configVoiceProfile(vc config.VoiceConfig) tts.VoiceProfile {
 		Provider:    vc.Provider,
 		PitchShift:  vc.PitchShift,
 		SpeedFactor: vc.SpeedFactor,
+	}
+}
+
+// identityFromConfig converts a config.NPCConfig to an agent.NPCIdentity.
+// This is the single conversion point — all NPC identity construction should
+// go through this function so that new fields are wired in one place.
+func identityFromConfig(npc config.NPCConfig) agent.NPCIdentity {
+	return agent.NPCIdentity{
+		Name:           npc.Name,
+		Personality:    npc.Personality,
+		Voice:          configVoiceProfile(npc.Voice),
+		KnowledgeScope: npc.KnowledgeScope,
+		GMHelper:       npc.GMHelper,
+		AddressOnly:    npc.AddressOnly,
 	}
 }

--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -563,12 +563,7 @@ func (sm *SessionManager) loadAgents(ctx context.Context, assembler *hotctx.Asse
 		}
 		closers = append(closers, eng.Close)
 
-		identity := agent.NPCIdentity{
-			Name:           npc.Name,
-			Personality:    npc.Personality,
-			Voice:          configVoiceProfile(npc.Voice),
-			KnowledgeScope: npc.KnowledgeScope,
-		}
+		identity := identityFromConfig(npc)
 
 		npcID := fmt.Sprintf("npc-%d-%s", i, npc.Name)
 		tier := configBudgetTier(npc.BudgetTier)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,6 +233,12 @@ type NPCConfig struct {
 	// campaign may be flagged. The GM helper's voice is used for voiced recaps
 	// and (in future) GM-assistant features. See issue #37.
 	GMHelper bool `yaml:"gm_helper"`
+
+	// AddressOnly restricts this NPC to respond only when explicitly addressed
+	// by name. It will not be selected by the last-speaker or single-NPC
+	// fallback heuristics in the address detector. Useful for background NPCs
+	// and the GM helper to avoid accidental activations.
+	AddressOnly bool `yaml:"address_only"`
 }
 
 // RelationshipConfig defines a relationship to another entity, used in NPC config.

--- a/internal/config/diff.go
+++ b/internal/config/diff.go
@@ -15,6 +15,8 @@ type NPCDiff struct {
 	PersonalityChanged bool
 	VoiceChanged       bool
 	BudgetTierChanged  bool
+	GMHelperChanged    bool
+	AddressOnlyChanged bool
 	Added              bool
 	Removed            bool
 }
@@ -52,7 +54,7 @@ func Diff(old, new *Config) ConfigDiff {
 			continue
 		}
 		nd := diffNPC(name, oldNPC, newNPC)
-		if nd.PersonalityChanged || nd.VoiceChanged || nd.BudgetTierChanged {
+		if nd.PersonalityChanged || nd.VoiceChanged || nd.BudgetTierChanged || nd.GMHelperChanged || nd.AddressOnlyChanged {
 			d.NPCChanges = append(d.NPCChanges, nd)
 			d.NPCsChanged = true
 		}
@@ -86,6 +88,14 @@ func diffNPC(name string, old, new *NPCConfig) NPCDiff {
 
 	if old.BudgetTier != new.BudgetTier {
 		nd.BudgetTierChanged = true
+	}
+
+	if old.GMHelper != new.GMHelper {
+		nd.GMHelperChanged = true
+	}
+
+	if old.AddressOnly != new.AddressOnly {
+		nd.AddressOnlyChanged = true
 	}
 
 	return nd

--- a/internal/config/diff_test.go
+++ b/internal/config/diff_test.go
@@ -182,6 +182,62 @@ func TestDiff_NPCRemoved(t *testing.T) {
 	}
 }
 
+func TestDiff_GMHelperChanged(t *testing.T) {
+	t.Parallel()
+	old := &config.Config{
+		NPCs: []config.NPCConfig{
+			{Name: "Eve", GMHelper: false},
+		},
+	}
+	new := &config.Config{
+		NPCs: []config.NPCConfig{
+			{Name: "Eve", GMHelper: true},
+		},
+	}
+
+	d := config.Diff(old, new)
+	if !d.NPCsChanged {
+		t.Error("expected NPCsChanged=true")
+	}
+	found := false
+	for _, nc := range d.NPCChanges {
+		if nc.Name == "Eve" && nc.GMHelperChanged {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected Eve's GMHelperChanged=true")
+	}
+}
+
+func TestDiff_AddressOnlyChanged(t *testing.T) {
+	t.Parallel()
+	old := &config.Config{
+		NPCs: []config.NPCConfig{
+			{Name: "Frank", AddressOnly: false},
+		},
+	}
+	new := &config.Config{
+		NPCs: []config.NPCConfig{
+			{Name: "Frank", AddressOnly: true},
+		},
+	}
+
+	d := config.Diff(old, new)
+	if !d.NPCsChanged {
+		t.Error("expected NPCsChanged=true")
+	}
+	found := false
+	for _, nc := range d.NPCChanges {
+		if nc.Name == "Frank" && nc.AddressOnlyChanged {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected Frank's AddressOnlyChanged=true")
+	}
+}
+
 func TestDiff_MultipleChanges(t *testing.T) {
 	t.Parallel()
 	old := &config.Config{

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -49,10 +49,24 @@ func LoadFromReader(r io.Reader) (*Config, error) {
 	if err := dec.Decode(cfg); err != nil {
 		return nil, fmt.Errorf("config: decode yaml: %w", err)
 	}
+	ApplyDefaults(cfg)
 	if err := Validate(cfg); err != nil {
 		return nil, err
 	}
 	return cfg, nil
+}
+
+// ApplyDefaults fills in zero-valued fields with sensible defaults.
+// It must be called before [Validate] so that validation sees the complete config.
+//
+// Current defaults:
+//   - NPCs with GMHelper=true get AddressOnly=true (prevents accidental activation).
+func ApplyDefaults(cfg *Config) {
+	for i := range cfg.NPCs {
+		if cfg.NPCs[i].GMHelper && !cfg.NPCs[i].AddressOnly {
+			cfg.NPCs[i].AddressOnly = true
+		}
+	}
 }
 
 // Validate checks that cfg contains a coherent set of values.

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -183,6 +183,52 @@ func TestValidate_SingleGMHelper(t *testing.T) {
 	}
 }
 
+func TestApplyDefaults_GMHelperSetsAddressOnly(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		NPCs: []config.NPCConfig{
+			{Name: "Helper", GMHelper: true},
+			{Name: "Regular"},
+		},
+	}
+	config.ApplyDefaults(cfg)
+
+	if !cfg.NPCs[0].AddressOnly {
+		t.Error("expected GMHelper NPC to have AddressOnly=true after ApplyDefaults")
+	}
+	if cfg.NPCs[1].AddressOnly {
+		t.Error("expected regular NPC to remain AddressOnly=false")
+	}
+}
+
+func TestApplyDefaults_ExplicitAddressOnlyPreserved(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		NPCs: []config.NPCConfig{
+			{Name: "Helper", GMHelper: true, AddressOnly: true},
+		},
+	}
+	config.ApplyDefaults(cfg)
+
+	if !cfg.NPCs[0].AddressOnly {
+		t.Error("expected AddressOnly=true to remain true")
+	}
+}
+
+func TestApplyDefaults_NonGMHelperAddressOnly(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		NPCs: []config.NPCConfig{
+			{Name: "Background", AddressOnly: true},
+		},
+	}
+	config.ApplyDefaults(cfg)
+
+	if !cfg.NPCs[0].AddressOnly {
+		t.Error("expected non-GM-helper with explicit AddressOnly=true to be preserved")
+	}
+}
+
 func TestValidProviderNames(t *testing.T) {
 	t.Parallel()
 	// Sanity-check that the map is populated.

--- a/internal/hotctx/formatter.go
+++ b/internal/hotctx/formatter.go
@@ -25,10 +25,16 @@ func FormatSystemPrompt(hctx *HotContext, npcPersonality string, gmHelper bool) 
 	if hctx == nil {
 		name := "an NPC"
 		p := strings.TrimSpace(npcPersonality)
+		var fallback string
 		if p != "" {
-			return fmt.Sprintf("You are %s. %s", name, p)
+			fallback = fmt.Sprintf("You are %s. %s", name, p)
+		} else {
+			fallback = fmt.Sprintf("You are %s.", name)
 		}
-		return fmt.Sprintf("You are %s.", name)
+		if gmHelper {
+			return "You are the Game Master's AI assistant. You help the GM run the session by tracking rules, managing NPCs, and providing information on demand. You are a meta-game entity — you do not role-play as an in-world character. Keep responses concise and actionable.\n\n" + fallback
+		}
+		return fallback
 	}
 
 	var sb strings.Builder

--- a/internal/hotctx/formatter.go
+++ b/internal/hotctx/formatter.go
@@ -12,14 +12,16 @@ import (
 // suitable for direct injection into an NPC LLM call.
 //
 // npcPersonality is a free-text personality description that is appended to the
-// opening line. If hctx is nil, a minimal fallback prompt is returned.
+// opening line. When gmHelper is true, a GM-assistant preamble is prepended
+// that frames the NPC as a meta-game assistant rather than an in-world character.
+// If hctx is nil, a minimal fallback prompt is returned.
 //
 // The formatter is pure: it performs no I/O, has no side effects, and is safe
 // for concurrent use.
 //
 // Empty sections (nil identity, no relationships, no scene, no transcript) are
 // omitted entirely rather than rendering as empty headers.
-func FormatSystemPrompt(hctx *HotContext, npcPersonality string) string {
+func FormatSystemPrompt(hctx *HotContext, npcPersonality string, gmHelper bool) string {
 	if hctx == nil {
 		name := "an NPC"
 		p := strings.TrimSpace(npcPersonality)
@@ -30,6 +32,11 @@ func FormatSystemPrompt(hctx *HotContext, npcPersonality string) string {
 	}
 
 	var sb strings.Builder
+
+	// ── GM-assistant preamble (prepended before everything else) ─────────────
+	if gmHelper {
+		sb.WriteString("You are the Game Master's AI assistant. You help the GM run the session by tracking rules, managing NPCs, and providing information on demand. You are a meta-game entity — you do not role-play as an in-world character. Keep responses concise and actionable.\n\n")
+	}
 
 	// ── Opening line ──────────────────────────────────────────────────────────
 	npcName := npcNameFromContext(hctx)
@@ -267,7 +274,7 @@ func writeTranscriptSection(sb *strings.Builder, entries []memory.TranscriptEntr
 		}
 
 		relTime := formatRelativeTime(now.Sub(e.Timestamp))
-		fmt.Fprintf(sb, "[%s] %s: %s", relTime, speaker, e.Text)
+		fmt.Fprintf(sb, "[%s] %s%s: %s", relTime, speaker, e.SpeakerRole.DisplaySuffix(), e.Text)
 	}
 }
 

--- a/internal/hotctx/formatter_test.go
+++ b/internal/hotctx/formatter_test.go
@@ -92,7 +92,7 @@ func TestFormatSystemPrompt_Full(t *testing.T) {
 	hctx := fullHotContext()
 	personality := "You are gruff but fair, and speak in short sentences."
 
-	result := hotctx.FormatSystemPrompt(hctx, personality)
+	result := hotctx.FormatSystemPrompt(hctx, personality, false)
 
 	// Opening line must contain NPC name and personality.
 	if !strings.Contains(result, "Grimjaw") {
@@ -164,7 +164,7 @@ func TestFormatSystemPrompt_Minimal(t *testing.T) {
 	}
 	personality := "a mysterious wanderer"
 
-	result := hotctx.FormatSystemPrompt(hctx, personality)
+	result := hotctx.FormatSystemPrompt(hctx, personality, false)
 
 	// Opening line only — must contain fallback NPC name and personality.
 	if !strings.Contains(result, "an NPC") {
@@ -189,7 +189,7 @@ func TestFormatSystemPrompt_Minimal(t *testing.T) {
 
 // TestFormatSystemPrompt_NilHotContext verifies graceful handling of nil input.
 func TestFormatSystemPrompt_NilHotContext(t *testing.T) {
-	result := hotctx.FormatSystemPrompt(nil, "brave hero")
+	result := hotctx.FormatSystemPrompt(nil, "brave hero", false)
 	if result == "" {
 		t.Error("FormatSystemPrompt(nil, ...) returned empty string")
 	}
@@ -202,7 +202,7 @@ func TestFormatSystemPrompt_NilHotContext(t *testing.T) {
 // string is handled without leaving trailing spaces or double periods.
 func TestFormatSystemPrompt_NoPersonality(t *testing.T) {
 	hctx := fullHotContext()
-	result := hotctx.FormatSystemPrompt(hctx, "")
+	result := hotctx.FormatSystemPrompt(hctx, "", false)
 
 	// Should end with a period after the NPC name, no trailing space.
 	firstLine := strings.SplitN(result, "\n", 2)[0]
@@ -225,7 +225,7 @@ func TestFormatSystemPrompt_EmptyRelationships(t *testing.T) {
 			RelatedEntities: []memory.Entity{},
 		},
 	}
-	result := hotctx.FormatSystemPrompt(hctx, "")
+	result := hotctx.FormatSystemPrompt(hctx, "", false)
 	if strings.Contains(result, "## Your Relationships") {
 		t.Errorf("empty relationships should be omitted:\n%s", result)
 	}
@@ -244,7 +244,7 @@ func TestFormatSystemPrompt_EmptyScene(t *testing.T) {
 			ActiveQuests:    []memory.Entity{},
 		},
 	}
-	result := hotctx.FormatSystemPrompt(hctx, "")
+	result := hotctx.FormatSystemPrompt(hctx, "", false)
 	if strings.Contains(result, "## Current Scene") {
 		t.Errorf("empty scene should be omitted:\n%s", result)
 	}
@@ -265,7 +265,7 @@ func TestFormatSystemPrompt_KnowledgeSection(t *testing.T) {
 		},
 	}
 
-	result := hotctx.FormatSystemPrompt(hctx, "")
+	result := hotctx.FormatSystemPrompt(hctx, "", false)
 
 	if !strings.Contains(result, "## Relevant Knowledge") {
 		t.Errorf("output missing '## Relevant Knowledge' section:\n%s", result)
@@ -293,9 +293,97 @@ func TestFormatSystemPrompt_KnowledgeSectionOmittedWhenEmpty(t *testing.T) {
 		PreFetchResults: nil,
 	}
 
-	result := hotctx.FormatSystemPrompt(hctx, "")
+	result := hotctx.FormatSystemPrompt(hctx, "", false)
 	if strings.Contains(result, "## Relevant Knowledge") {
 		t.Errorf("nil PreFetchResults should not produce knowledge section:\n%s", result)
+	}
+}
+
+// TestFormatSystemPrompt_GMHelperPreamble verifies that the GM-assistant preamble
+// is prepended when gmHelper is true.
+func TestFormatSystemPrompt_GMHelperPreamble(t *testing.T) {
+	t.Parallel()
+
+	hctx := &hotctx.HotContext{
+		Identity: &memory.NPCIdentity{
+			Entity: memory.Entity{ID: "helper-1", Name: "Sage", Type: "npc"},
+		},
+	}
+
+	result := hotctx.FormatSystemPrompt(hctx, "helpful and concise", true)
+
+	if !strings.Contains(result, "Game Master's AI assistant") {
+		t.Errorf("output missing GM-assistant preamble:\n%s", result)
+	}
+	if !strings.Contains(result, "meta-game entity") {
+		t.Errorf("output missing meta-game framing:\n%s", result)
+	}
+	if !strings.Contains(result, "Sage") {
+		t.Errorf("output missing NPC name:\n%s", result)
+	}
+	if !strings.Contains(result, "helpful and concise") {
+		t.Errorf("output missing personality:\n%s", result)
+	}
+}
+
+// TestFormatSystemPrompt_NoGMHelperPreamble verifies that the preamble is absent
+// when gmHelper is false.
+func TestFormatSystemPrompt_NoGMHelperPreamble(t *testing.T) {
+	t.Parallel()
+
+	hctx := &hotctx.HotContext{
+		Identity: &memory.NPCIdentity{
+			Entity: memory.Entity{ID: "npc-1", Name: "Grimjaw", Type: "npc"},
+		},
+	}
+
+	result := hotctx.FormatSystemPrompt(hctx, "gruff", false)
+
+	if strings.Contains(result, "Game Master") {
+		t.Errorf("non-GM-helper should not contain GM preamble:\n%s", result)
+	}
+}
+
+// TestFormatSystemPrompt_SpeakerRoleSuffix verifies that SpeakerRole labels
+// appear in the transcript section.
+func TestFormatSystemPrompt_SpeakerRoleSuffix(t *testing.T) {
+	t.Parallel()
+
+	hctx := &hotctx.HotContext{
+		RecentTranscript: []memory.TranscriptEntry{
+			{
+				SpeakerID:   "dm-1",
+				SpeakerName: "Dave",
+				SpeakerRole: memory.RoleGM,
+				Text:        "Roll for initiative.",
+				Timestamp:   time.Now().Add(-30 * time.Second),
+			},
+			{
+				SpeakerID:   "helper-1",
+				SpeakerName: "Sage",
+				SpeakerRole: memory.RoleGMAssistant,
+				Text:        "The DC is 15.",
+				Timestamp:   time.Now().Add(-20 * time.Second),
+			},
+			{
+				SpeakerID:   "player-1",
+				SpeakerName: "Alice",
+				Text:        "I rolled a 17!",
+				Timestamp:   time.Now().Add(-10 * time.Second),
+			},
+		},
+	}
+
+	result := hotctx.FormatSystemPrompt(hctx, "", false)
+
+	if !strings.Contains(result, "Dave [GM]") {
+		t.Errorf("output missing GM role label:\n%s", result)
+	}
+	if !strings.Contains(result, "Sage [GM Assistant]") {
+		t.Errorf("output missing GM Assistant role label:\n%s", result)
+	}
+	if strings.Contains(result, "Alice [") {
+		t.Errorf("regular player should not have a role suffix:\n%s", result)
 	}
 }
 
@@ -305,8 +393,8 @@ func TestFormatSystemPrompt_IsPure(t *testing.T) {
 	hctx := fullHotContext()
 	// FormatSystemPrompt uses relative timestamps — calling it twice
 	// in rapid succession should give the same structure (same sections present).
-	out1 := hotctx.FormatSystemPrompt(hctx, "gruff and fair")
-	out2 := hotctx.FormatSystemPrompt(hctx, "gruff and fair")
+	out1 := hotctx.FormatSystemPrompt(hctx, "gruff and fair", false)
+	out2 := hotctx.FormatSystemPrompt(hctx, "gruff and fair", false)
 
 	// Both must contain the same sections.
 	sections := []string{

--- a/internal/hotctx/formatter_test.go
+++ b/internal/hotctx/formatter_test.go
@@ -89,6 +89,7 @@ func fullHotContext() *hotctx.HotContext {
 // TestFormatSystemPrompt_Full verifies that a fully-populated HotContext
 // renders all sections correctly.
 func TestFormatSystemPrompt_Full(t *testing.T) {
+	t.Parallel()
 	hctx := fullHotContext()
 	personality := "You are gruff but fair, and speak in short sentences."
 
@@ -159,6 +160,7 @@ func TestFormatSystemPrompt_Full(t *testing.T) {
 // TestFormatSystemPrompt_Minimal verifies that a nil identity, empty scene,
 // and no transcript produce only the opening line — no empty section headers.
 func TestFormatSystemPrompt_Minimal(t *testing.T) {
+	t.Parallel()
 	hctx := &hotctx.HotContext{
 		// No Identity, no SceneContext, no RecentTranscript
 	}
@@ -189,6 +191,7 @@ func TestFormatSystemPrompt_Minimal(t *testing.T) {
 
 // TestFormatSystemPrompt_NilHotContext verifies graceful handling of nil input.
 func TestFormatSystemPrompt_NilHotContext(t *testing.T) {
+	t.Parallel()
 	result := hotctx.FormatSystemPrompt(nil, "brave hero", false)
 	if result == "" {
 		t.Error("FormatSystemPrompt(nil, ...) returned empty string")
@@ -198,9 +201,23 @@ func TestFormatSystemPrompt_NilHotContext(t *testing.T) {
 	}
 }
 
+// TestFormatSystemPrompt_NilHotContext_GMHelper verifies that the GM-assistant
+// preamble is included even when HotContext assembly fails (nil fallback).
+func TestFormatSystemPrompt_NilHotContext_GMHelper(t *testing.T) {
+	t.Parallel()
+	result := hotctx.FormatSystemPrompt(nil, "helpful assistant", true)
+	if !strings.Contains(result, "Game Master's AI assistant") {
+		t.Errorf("nil hctx with gmHelper=true should include GM preamble:\n%s", result)
+	}
+	if !strings.Contains(result, "helpful assistant") {
+		t.Errorf("nil hctx with gmHelper=true should still include personality:\n%s", result)
+	}
+}
+
 // TestFormatSystemPrompt_NoPersonality verifies that an empty personality
 // string is handled without leaving trailing spaces or double periods.
 func TestFormatSystemPrompt_NoPersonality(t *testing.T) {
+	t.Parallel()
 	hctx := fullHotContext()
 	result := hotctx.FormatSystemPrompt(hctx, "", false)
 
@@ -217,6 +234,7 @@ func TestFormatSystemPrompt_NoPersonality(t *testing.T) {
 // TestFormatSystemPrompt_EmptyRelationships verifies that the Relationships
 // section is omitted when there are no relationships.
 func TestFormatSystemPrompt_EmptyRelationships(t *testing.T) {
+	t.Parallel()
 	hctx := &hotctx.HotContext{
 		Identity: &memory.NPCIdentity{
 			Entity: memory.Entity{ID: "npc-1", Name: "Grimjaw", Type: "npc"},
@@ -234,6 +252,7 @@ func TestFormatSystemPrompt_EmptyRelationships(t *testing.T) {
 // TestFormatSystemPrompt_EmptyScene verifies that the Scene section is omitted
 // when SceneContext has no location, no NPCs, and no quests.
 func TestFormatSystemPrompt_EmptyScene(t *testing.T) {
+	t.Parallel()
 	hctx := &hotctx.HotContext{
 		Identity: &memory.NPCIdentity{
 			Entity: memory.Entity{ID: "npc-1", Name: "Grimjaw", Type: "npc"},
@@ -390,6 +409,7 @@ func TestFormatSystemPrompt_SpeakerRoleSuffix(t *testing.T) {
 // TestFormatSystemPrompt_IsPure verifies that calling FormatSystemPrompt twice
 // with the same input produces identical output (pure function).
 func TestFormatSystemPrompt_IsPure(t *testing.T) {
+	t.Parallel()
 	hctx := fullHotContext()
 	// FormatSystemPrompt uses relative timestamps — calling it twice
 	// in rapid succession should give the same structure (same sections present).

--- a/internal/mcp/mcphost/budget.go
+++ b/internal/mcp/mcphost/budget.go
@@ -17,7 +17,9 @@ type BudgetEnforcer struct{}
 // FilterTools returns only the tool definitions whose tier is ≤ maxTier.
 // The returned slice is sorted by estimated latency ascending (fastest first).
 //
-// Tier comparison uses the integer ordering: BudgetFast(0) ≤ BudgetStandard(1) ≤ BudgetDeep(2).
+// Tier comparison uses the integer ordering: BudgetUnset(0) < BudgetFast(1) ≤ BudgetStandard(2) ≤ BudgetDeep(3).
+// Callers must resolve BudgetUnset before calling FilterTools; passing BudgetUnset as maxTier
+// would match no tools (defensive, should never happen in practice).
 func (e *BudgetEnforcer) FilterTools(tools []toolEntry, maxTier mcp.BudgetTier) []llm.ToolDefinition {
 	var result []toolEntry
 	for i := range tools {

--- a/internal/mcp/mcphost/host.go
+++ b/internal/mcp/mcphost/host.go
@@ -309,6 +309,8 @@ func schemaToMap(schema any) map[string]any {
 // If [Host.Calibrate] has not been called, tools retain the tiers implied by
 // their declared EstimatedDurationMs and MaxDurationMs values.
 func (h *Host) AvailableTools(tier mcp.BudgetTier) []llm.ToolDefinition {
+	tier = tier.Resolve()
+
 	h.mu.RLock()
 	entries := make([]toolEntry, 0, len(h.tools))
 	for _, e := range h.tools {

--- a/internal/mcp/tier/selector.go
+++ b/internal/mcp/tier/selector.go
@@ -131,9 +131,9 @@ func NewSelector(opts ...Option) *Selector {
 // Select is goroutine-safe and executes in sub-millisecond time (pure string
 // operations, no I/O).
 func (s *Selector) Select(text string, dmOverride mcp.BudgetTier) mcp.BudgetTier {
-	// Priority 1: DM override wins unconditionally (non-zero means an explicit tier).
-	// BudgetFast == 0 is the zero value, so dmOverride == 0 means "no override set".
-	if dmOverride != 0 {
+	// Priority 1: DM override wins unconditionally.
+	// BudgetUnset (0) means "no override set"; any other value is an explicit tier.
+	if dmOverride != mcp.BudgetUnset {
 		return dmOverride
 	}
 

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -17,11 +17,18 @@ func (t Transport) IsValid() bool {
 }
 
 // BudgetTier controls which MCP tools are visible to the LLM based on latency constraints.
+//
+// The zero value is [BudgetUnset], meaning "no tier specified". Callers should
+// treat BudgetUnset as equivalent to [BudgetFast] unless they need to
+// distinguish "not set" from "explicitly fast" (e.g., for defaulting logic).
 type BudgetTier int
 
 const (
+	// BudgetUnset is the zero value, meaning no tier has been specified.
+	BudgetUnset BudgetTier = iota
+
 	// BudgetFast allows only tools with ≤ 500ms estimated latency.
-	BudgetFast BudgetTier = iota
+	BudgetFast
 
 	// BudgetStandard allows tools with ≤ 1500ms estimated latency.
 	BudgetStandard
@@ -30,9 +37,19 @@ const (
 	BudgetDeep
 )
 
+// Resolve returns t if it is an explicit tier, or [BudgetFast] if t is [BudgetUnset].
+func (t BudgetTier) Resolve() BudgetTier {
+	if t == BudgetUnset {
+		return BudgetFast
+	}
+	return t
+}
+
 // String returns the human-readable name of the budget tier.
 func (t BudgetTier) String() string {
 	switch t {
+	case BudgetUnset:
+		return "UNSET"
 	case BudgetFast:
 		return "FAST"
 	case BudgetStandard:
@@ -45,9 +62,10 @@ func (t BudgetTier) String() string {
 }
 
 // MaxLatencyMs returns the maximum parallel tool latency for this tier.
+// [BudgetUnset] is treated as [BudgetFast].
 func (t BudgetTier) MaxLatencyMs() int {
 	switch t {
-	case BudgetFast:
+	case BudgetUnset, BudgetFast:
 		return 500
 	case BudgetStandard:
 		return 1500

--- a/internal/mcp/types_test.go
+++ b/internal/mcp/types_test.go
@@ -1,0 +1,95 @@
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/MrWong99/glyphoxa/internal/mcp"
+)
+
+func TestBudgetTier_Resolve(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tier mcp.BudgetTier
+		want mcp.BudgetTier
+	}{
+		{"Unset resolves to Fast", mcp.BudgetUnset, mcp.BudgetFast},
+		{"Fast stays Fast", mcp.BudgetFast, mcp.BudgetFast},
+		{"Standard stays Standard", mcp.BudgetStandard, mcp.BudgetStandard},
+		{"Deep stays Deep", mcp.BudgetDeep, mcp.BudgetDeep},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.tier.Resolve()
+			if got != tt.want {
+				t.Errorf("BudgetTier(%d).Resolve() = %d, want %d", tt.tier, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBudgetTier_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		tier mcp.BudgetTier
+		want string
+	}{
+		{mcp.BudgetUnset, "UNSET"},
+		{mcp.BudgetFast, "FAST"},
+		{mcp.BudgetStandard, "STANDARD"},
+		{mcp.BudgetDeep, "DEEP"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+			got := tt.tier.String()
+			if got != tt.want {
+				t.Errorf("BudgetTier(%d).String() = %q, want %q", tt.tier, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBudgetTier_MaxLatencyMs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		tier mcp.BudgetTier
+		want int
+	}{
+		{mcp.BudgetUnset, 500},
+		{mcp.BudgetFast, 500},
+		{mcp.BudgetStandard, 1500},
+		{mcp.BudgetDeep, 4000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tier.String(), func(t *testing.T) {
+			t.Parallel()
+			got := tt.tier.MaxLatencyMs()
+			if got != tt.want {
+				t.Errorf("BudgetTier(%d).MaxLatencyMs() = %d, want %d", tt.tier, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBudgetTier_IotaOrdering(t *testing.T) {
+	t.Parallel()
+
+	// Verify the integer ordering is correct for FilterTools comparison.
+	if mcp.BudgetUnset >= mcp.BudgetFast {
+		t.Error("BudgetUnset should be less than BudgetFast")
+	}
+	if mcp.BudgetFast >= mcp.BudgetStandard {
+		t.Error("BudgetFast should be less than BudgetStandard")
+	}
+	if mcp.BudgetStandard >= mcp.BudgetDeep {
+		t.Error("BudgetStandard should be less than BudgetDeep")
+	}
+}

--- a/pkg/memory/types.go
+++ b/pkg/memory/types.go
@@ -4,6 +4,33 @@ import (
 	"time"
 )
 
+// SpeakerRole classifies the speaker within the session context.
+type SpeakerRole string
+
+const (
+	// RoleDefault is the zero-value role for ordinary players.
+	RoleDefault SpeakerRole = ""
+
+	// RoleGM identifies the Game Master (DM) player.
+	RoleGM SpeakerRole = "gm"
+
+	// RoleGMAssistant identifies an NPC acting as the GM's AI assistant.
+	RoleGMAssistant SpeakerRole = "gm_assistant"
+)
+
+// DisplaySuffix returns a human-readable label suitable for appending to
+// speaker names in formatted transcripts. Returns "" for [RoleDefault].
+func (r SpeakerRole) DisplaySuffix() string {
+	switch r {
+	case RoleGM:
+		return " [GM]"
+	case RoleGMAssistant:
+		return " [GM Assistant]"
+	default:
+		return ""
+	}
+}
+
 // TranscriptEntry is a complete exchange record written to the session log.
 // It captures both the speaker's utterance and optionally the NPC's response,
 // forming the atomic unit of session history.
@@ -13,6 +40,10 @@ type TranscriptEntry struct {
 
 	// SpeakerName is the human-readable speaker name.
 	SpeakerName string
+
+	// SpeakerRole classifies the speaker (e.g., GM, GM assistant).
+	// The zero value means ordinary player.
+	SpeakerRole SpeakerRole
 
 	// Text is the (possibly corrected) transcript text.
 	Text string

--- a/pkg/memory/types_test.go
+++ b/pkg/memory/types_test.go
@@ -1,0 +1,51 @@
+package memory_test
+
+import (
+	"testing"
+
+	"github.com/MrWong99/glyphoxa/pkg/memory"
+)
+
+func TestSpeakerRole_DisplaySuffix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		role memory.SpeakerRole
+		want string
+	}{
+		{memory.RoleDefault, ""},
+		{memory.RoleGM, " [GM]"},
+		{memory.RoleGMAssistant, " [GM Assistant]"},
+		{memory.SpeakerRole("unknown"), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.role), func(t *testing.T) {
+			t.Parallel()
+			got := tt.role.DisplaySuffix()
+			if got != tt.want {
+				t.Errorf("SpeakerRole(%q).DisplaySuffix() = %q, want %q", tt.role, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTranscriptEntry_IsNPC(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NPC entry", func(t *testing.T) {
+		t.Parallel()
+		e := memory.TranscriptEntry{NPCID: "npc-1"}
+		if !e.IsNPC() {
+			t.Error("expected IsNPC()=true for entry with NPCID")
+		}
+	})
+
+	t.Run("player entry", func(t *testing.T) {
+		t.Parallel()
+		e := memory.TranscriptEntry{}
+		if e.IsNPC() {
+			t.Error("expected IsNPC()=false for entry without NPCID")
+		}
+	})
+}

--- a/proto/glyphoxa/v1/session.proto
+++ b/proto/glyphoxa/v1/session.proto
@@ -22,6 +22,8 @@ message NPCConfig {
   string voice_id = 4;
   repeated string knowledge_scope = 5;
   string budget_tier = 6;
+  bool gm_helper = 7;
+  bool address_only = 8;
 }
 
 // StartSessionRequest is sent by the gateway to a worker to start a new voice session.


### PR DESCRIPTION
## Summary

Implements the foundational GM helper NPC infrastructure from issue #37 plan phases 1-3:

- **BudgetTier zero-value fix**: Added `BudgetUnset = 0` to iota so `BudgetFast` (now 1) is distinguishable from unset. Added `Resolve()` method for safe defaulting.
- **Identity propagation**: `GMHelper` and `AddressOnly` fields flow through all three NPC definition sources — YAML config (`config.NPCConfig`), proto (`NPCConfig` message), and PostgreSQL (`npcstore.NPCDefinition` + schema migration).
- **`identityFromConfig()` factory**: Single conversion point replaces duplicated struct literals in `app.go` and `session_manager.go`.
- **`ApplyDefaults()`**: New config step ensures GM helper NPCs default to `AddressOnly: true`.
- **GM-assistant preamble**: `FormatSystemPrompt` gains a `gmHelper bool` parameter that prepends a meta-game framing preamble.
- **Address-only routing**: Orchestrator skips address-only agents in last-speaker and single-NPC fallback heuristics. Prevents `lastSpeaker` poisoning when addressing the GM helper by name.
- **`SpeakerRole` typed constant**: `RoleGM`, `RoleGMAssistant` with `DisplaySuffix()` method. Added to `TranscriptEntry` and rendered in formatted transcripts.
- **`config.Diff` tracking**: `GMHelperChanged` and `AddressOnlyChanged` fields for hot-reload detection.

## Test plan

- [x] `make check` passes (fmt + vet + all tests with `-race`)
- [x] `make lint` passes (0 issues)
- [x] New tests: BudgetTier Resolve/String/MaxLatencyMs/iota ordering
- [x] New tests: SpeakerRole DisplaySuffix, TranscriptEntry.IsNPC
- [x] New tests: ApplyDefaults (3 cases: GM helper sets AddressOnly, explicit preserved, non-GM preserved)
- [x] New tests: config.Diff GMHelper/AddressOnly change detection
- [x] New tests: FormatSystemPrompt GM preamble present/absent, SpeakerRole suffix rendering
- [x] New tests: 5 address-only routing tests (name reachable, last-speaker skip, single-NPC skip, no lastSpeaker poisoning, DM puppet)
- [x] Existing npcstore mock tests updated for new gm_helper/address_only columns

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)