### PR TITLE
fix: barge-in, mute interruption, and transcript truncation

### DIFF
--- a/docs/plans/2026-03-15-fix-barge-in-mute-transcript-truncation-plan.md
+++ b/docs/plans/2026-03-15-fix-barge-in-mute-transcript-truncation-plan.md
@@ -1,0 +1,304 @@
+---
+title: "fix: Barge-in, mute interruption, and transcript truncation"
+type: fix
+status: completed
+date: 2026-03-15
+---
+
+# fix: Barge-in, Mute Interruption, and Transcript Truncation
+
+## Overview
+
+Three related bugs share a root cause — the mixer has no feedback path to upstream components when playback is interrupted:
+
+1. **Barge-in doesn't stop NPCs reliably** — `audio_pipeline.go:208` calls `mixer.Interrupt(PlayerBargeIn)` but never `mixer.BargeIn(speakerID)`, so the `OnBargeIn` callback never fires.
+2. **Muting doesn't stop current speech** — `MuteAgent`/`MuteAll` only set a boolean flag; they don't interrupt the mixer.
+3. **Transcript records full text** — the cascade engine emits the complete LLM response regardless of whether audio was cut short. The agent also records `resp.Text` in `a.messages` before audio even starts playing.
+
+Brainstorm: `docs/brainstorms/2026-03-15-barge-in-fix-brainstorm.md`
+
+## Problem Statement
+
+When a player talks over an NPC or a GM mutes an NPC mid-sentence, the NPC should stop talking immediately and the transcript should reflect only what was actually heard. Currently none of this works — audio may continue playing, and transcripts always contain the full generated text.
+
+## Proposed Solution
+
+A coordinated fix across four layers: mixer interface, audio segment metadata, cascade engine feedback, and mute command wiring.
+
+### Key Architecture Decision: Engine-Side Text Tracking
+
+The SpecFlow analysis identified a critical mismatch: the cascade engine produces **one `AudioSegment` per NPC turn** — all sentences stream through a single `Audio <-chan []byte` channel. The mixer has no concept of sentence boundaries in the audio stream.
+
+**Chosen approach:** Track committed text in the cascade engine, not the mixer. The engine already knows sentence boundaries (it sends sentences to TTS one at a time via `textCh`). On interrupt, the engine snapshots its committed text and appends `...`.
+
+This avoids refactoring the TTS streaming pipeline (one stream per turn) into multiple streams per sentence, which would be a much larger change for marginal benefit.
+
+Data flow on interrupt:
+
+```
+Player speaks → VAD → mixer.BargeIn(speakerID)
+                         ├── stops audio (closes cancelPlaying)
+                         ├── clears queue (drains queued segments)
+                         └── fires OnBargeIn callback
+                              └── signals cascade engine via cancel channel
+                                   └── engine snapshots committedText
+                                   └── emits truncated transcript: committedText + "..."
+                                   └── agent updates a.messages with truncated text
+```
+
+### Scoping Decision: S2S Engine
+
+The S2S engine (`internal/engine/s2s/`) has a separate interrupt path via `SessionHandle.Interrupt()`. Fixing it requires different plumbing (the S2S provider handles barge-in natively). **Deferred to a follow-up issue** to keep this change focused on the cascade path, which is the primary engine used in production.
+
+## Technical Approach
+
+### Phase 1: Mixer Interface — Add `BargeIn` and NPC-Scoped Interrupt
+
+**Problem:** `BargeIn(speakerID)` exists on `PriorityMixer` but not on the `audio.Mixer` interface. Also, `Interrupt(DMOverride)` is NPC-agnostic — muting NPC-A while NPC-B is speaking would stop NPC-B.
+
+**Changes:**
+
+#### `pkg/audio/mixer.go`
+
+- Add `BargeIn(speakerID string)` to the `Mixer` interface. Semantics: interrupt current + clear queue + fire `OnBargeIn` callback.
+- Add `InterruptNPC(npcID string, reason InterruptReason)` to the `Mixer` interface. Semantics: only interrupt if the currently playing segment's `NPCID` matches; remove queued segments with matching `NPCID`. No-op if a different NPC is playing.
+
+```go
+type Mixer interface {
+    Enqueue(segment *AudioSegment, priority int)
+    Interrupt(reason InterruptReason)
+    BargeIn(speakerID string)                          // NEW
+    InterruptNPC(npcID string, reason InterruptReason)  // NEW
+    OnBargeIn(handler func(speakerID string))
+    SetGap(d time.Duration)
+}
+```
+
+#### `pkg/audio/mixer/mixer.go`
+
+- `InterruptNPC`: check `m.playing.NPCID == npcID` before interrupting. Remove matching entries from queue.
+
+#### `pkg/audio/mock/mock.go`
+
+- Add `BargeIn` and `InterruptNPC` to the mock with call recording.
+
+#### `internal/app/audio_pipeline.go`
+
+- Line 208: change `p.mixer.Interrupt(audio.PlayerBargeIn)` → `p.mixer.BargeIn(speakerID)`.
+
+**Tests:**
+
+- `pkg/audio/mixer/mixer_test.go`: test `InterruptNPC` only interrupts matching NPC; test `BargeIn` fires handler + clears queue.
+
+---
+
+### Phase 2: Playback Completion Callback on AudioSegment
+
+**Problem:** The mixer knows whether a segment finished naturally or was interrupted, but has no way to communicate this upstream.
+
+**Changes:**
+
+#### `pkg/audio/mixer.go` — `AudioSegment`
+
+Add a completion callback:
+
+```go
+type AudioSegment struct {
+    NPCID      string
+    Audio      <-chan []byte
+    SampleRate int
+    Channels   int
+    Priority   int
+    streamErr  atomic.Pointer[error]
+
+    // OnDone is called when the mixer finishes with this segment.
+    // interrupted is true if playback was cut short (barge-in or mute),
+    // false if the segment played to completion.
+    // Called on the mixer's dispatch goroutine; must not block.
+    // May be nil.
+    OnDone func(interrupted bool)  // NEW
+}
+```
+
+#### `pkg/audio/mixer/mixer.go`
+
+- In `play()`: call `seg.OnDone(false)` on natural completion (channel closed), call `seg.OnDone(true)` on cancel/done.
+- In `interruptLocked()`: for queued segments being drained, call `seg.OnDone(true)` before draining.
+- Guard all calls with nil check.
+
+**Tests:**
+
+- `mixer_test.go`: verify `OnDone(false)` on natural playback, `OnDone(true)` on interrupt, `OnDone(true)` on queued segment drain.
+
+---
+
+### Phase 3: Cascade Engine — Deferred Transcript with Truncation
+
+**Problem:** The cascade engine emits the full generated text to the transcript channel unconditionally, and the agent records `resp.Text` in `a.messages` before audio plays.
+
+**Changes:**
+
+#### `internal/engine/engine.go` — `Response`
+
+Add a field for the engine to communicate the final (possibly truncated) text:
+
+```go
+type Response struct {
+    Text       string
+    Audio      <-chan []byte
+    SampleRate int
+    Channels   int
+    ToolCalls  []llm.ToolCall
+    streamErr  atomic.Pointer[error]
+
+    // FinalText is closed when the definitive response text is available.
+    // Read FinalTextValue after <-FinalText returns.
+    // If playback completes naturally, FinalTextValue == Text.
+    // If interrupted, FinalTextValue is the truncated text with "..." suffix.
+    FinalText      chan struct{}  // NEW
+    FinalTextValue string        // NEW — read after FinalText closes
+}
+```
+
+#### `internal/engine/cascade/cascade.go`
+
+- Track committed text atomically. Each time a sentence is sent to `textCh` (TTS input), append it to a `committedText` accumulator.
+- Create a cancel channel per Process call. Set `seg.OnDone` to signal this channel.
+- **Single-model path:** Set `OnDone` on the AudioSegment. On natural completion, set `FinalTextValue = Text` and close `FinalText`. On interrupt, set `FinalTextValue = committedText + "..."` and close `FinalText`.
+- **Dual-model path:** Same pattern. The background goroutine tracks `committedText` as it sends sentences to `textCh`. The `OnDone` callback snapshots `committedText`.
+- **Transcript emission:** Move transcript emission to happen after `OnDone` fires (either path). Emit `FinalTextValue` instead of the full generated text.
+
+#### `internal/agent/npc.go`
+
+- **Defer message history recording.** Instead of appending `resp.Text` immediately at line 304, launch a goroutine that waits on `<-resp.FinalText` and then appends `resp.FinalTextValue`.
+- This goroutine must hold `a.mu` briefly to append — use a targeted lock acquisition, not holding the lock across the wait.
+- The goroutine must also respect context cancellation to avoid leaking.
+
+**Tests:**
+
+- `cascade_test.go`: test that transcript emits truncated text when `OnDone(true)` fires mid-generation. Test that transcript emits full text on natural completion. Test committed text tracking across sentence boundaries.
+- `npc_test.go`: test that `a.messages` contains truncated text after interrupt.
+
+---
+
+### Phase 4: Mute Commands Interrupt Audio
+
+**Problem:** `MuteAgent`/`MuteAll` only set flags; they don't stop current speech.
+
+**Changes:**
+
+#### `internal/agent/orchestrator/orchestrator.go`
+
+Add a mixer reference to the orchestrator:
+
+```go
+type Orchestrator struct {
+    // ... existing fields ...
+    mixer audio.Mixer  // NEW — may be nil (text-only mode)
+}
+```
+
+- New option: `WithMixer(m audio.Mixer) Option`.
+- `MuteAgent(id)`: after setting `entry.muted = true`, call `o.mixer.InterruptNPC(id, audio.DMOverride)` if mixer is non-nil.
+- `MuteAll()`: after setting all flags, call `o.mixer.Interrupt(audio.DMOverride)` if mixer is non-nil.
+
+#### Wiring — `internal/app/` or `internal/session/`
+
+- Pass the mixer when constructing the orchestrator (wherever `orchestrator.New()` is called).
+
+**Tests:**
+
+- `orchestrator_test.go`: test `MuteAgent` calls `InterruptNPC` on the mock mixer. Test `MuteAll` calls `Interrupt(DMOverride)`. Test nil mixer is safe.
+
+---
+
+### Phase 5: Barge-In Cancels In-Flight Generation
+
+**Problem:** When barge-in fires, the cascade engine's background goroutine (strong model + TTS) keeps running, wasting compute.
+
+**Changes:**
+
+#### `internal/agent/npc.go`
+
+- Store a `context.CancelFunc` for the in-flight Process call.
+- Register the mixer's `OnBargeIn` handler to cancel this context.
+- On barge-in: cancel the generation context → strong model stream closes → TTS stops → audio channel closes.
+
+```go
+type liveAgent struct {
+    // ... existing fields ...
+    genCancel context.CancelFunc  // NEW — cancels in-flight generation
+    genMu     sync.Mutex          // NEW — guards genCancel
+}
+```
+
+- In `HandleUtterance`: create a child context with cancel, store cancel in `a.genCancel`.
+- Register `mixer.OnBargeIn` in `NewAgent` to call `a.genCancel()`.
+- Clear `genCancel` after Process completes naturally.
+
+**Tests:**
+
+- `npc_test.go`: test that barge-in cancels in-flight context.
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [x]Talking over an NPC (VAD fires) stops the NPC's audio immediately
+- [x]`/npc mute <name>` stops that NPC's current speech immediately
+- [x]`/npc muteall` stops all NPC speech immediately
+- [x]Muting NPC-A while NPC-B is speaking does NOT interrupt NPC-B
+- [x]Interrupted NPC transcript shows truncated text with `...` suffix
+- [x]Naturally completed NPC speech transcript shows full text (no `...`)
+- [x]Agent message history (`a.messages`) reflects truncated text after interrupt
+- [x]Barge-in cancels in-flight LLM/TTS generation (no wasted compute)
+- [x]Queued NPC segments that were never played are drained and their `OnDone(true)` fires
+
+### Non-Functional Requirements
+
+- [x]All new code has `t.Parallel()` on tests and subtests
+- [x]Race detector passes: `go test -race -count=1 ./...`
+- [x]No locks held during blocking I/O (especially the `OnDone` callback)
+- [x]Compile-time interface assertions for updated `Mixer` interface
+- [x]Mock implementations updated for new interface methods
+
+### Quality Gates
+
+- [x]`make check` passes (fmt + vet + test)
+- [x]`make lint` passes
+- [x]Existing mixer tests still pass
+- [x]Existing cascade engine tests still pass
+- [x]Existing orchestrator tests still pass
+
+## Dependencies & Prerequisites
+
+- No external dependencies. All changes are internal to the codebase.
+- The `audio.Mixer` interface change affects: `pkg/audio/mixer/mixer.go`, `pkg/audio/mock/mock.go`, and any test doubles.
+
+## Risk Analysis & Mitigation
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| `OnDone` callback blocks mixer dispatch goroutine | Audio playback stalls | Document "must not block" contract; keep callback lightweight (signal a channel) |
+| Race between natural completion and interrupt | Double `OnDone` call | Use `sync.Once` wrapper in mixer's play loop |
+| Agent `a.messages` append races with HandleUtterance | Corrupted history | Use targeted mutex acquisition in the deferred goroutine |
+| Deferred transcript emission leaks goroutine | Resource leak | Respect context cancellation in the wait goroutine |
+| `InterruptNPC` iterates queue under lock | Latency spike on large queues | Queue is typically small (<16 segments); acceptable |
+
+## References & Research
+
+### Internal References
+
+- Brainstorm: `docs/brainstorms/2026-03-15-barge-in-fix-brainstorm.md`
+- Mixer interface: `pkg/audio/mixer.go:91-119`
+- PriorityMixer: `pkg/audio/mixer/mixer.go` (BargeIn at line 176, Interrupt at line 151)
+- Audio pipeline barge-in: `internal/app/audio_pipeline.go:208`
+- Cascade transcript emission: `internal/engine/cascade/cascade.go:287-291`
+- Agent message recording: `internal/agent/npc.go:302-312`
+- Mute commands: `internal/discord/commands/npc.go:136-258`
+- Orchestrator mute: `internal/agent/orchestrator/orchestrator.go:175-343`
+
+### Follow-Up Work
+
+- S2S engine barge-in: wire `SessionHandle.Interrupt()` on barge-in, implement transcript truncation for S2S providers
+- Queued-but-never-played NPC responses: decide whether to mark as "cancelled" in transcript or silently drop

--- a/internal/agent/npc.go
+++ b/internal/agent/npc.go
@@ -109,6 +109,10 @@ type liveAgent struct {
 	// mu is held by HandleUtterance.
 	toolCtxMu sync.Mutex
 	toolCtx   context.Context
+
+	// genMu guards genCancel, which cancels the in-flight generation context.
+	genMu     sync.Mutex
+	genCancel context.CancelFunc
 }
 
 // NewAgent creates a concrete [NPCAgent] from the given configuration.
@@ -153,6 +157,20 @@ func NewAgent(cfg AgentConfig) (NPCAgent, error) {
 		sessionID:     cfg.SessionID,
 		budgetTier:    cfg.BudgetTier,
 		onTranscript:  cfg.OnTranscript,
+	}
+
+	// Register barge-in handler to cancel in-flight generation when a player
+	// starts speaking. This prevents wasted LLM/TTS compute on responses
+	// that will never be heard.
+	if cfg.Mixer != nil {
+		cfg.Mixer.OnBargeIn(func(_ string) {
+			a.genMu.Lock()
+			cancel := a.genCancel
+			a.genMu.Unlock()
+			if cancel != nil {
+				cancel()
+			}
+		})
 	}
 
 	// Wire MCP tools into the engine when a host is provided.
@@ -270,14 +288,26 @@ func (a *liveAgent) HandleUtterance(ctx context.Context, speaker string, transcr
 		Timestamp:  0,
 	}
 
+	// Create a child context for this generation cycle. The barge-in handler
+	// cancels this context to abort in-flight LLM/TTS when a player speaks.
+	genCtx, genCancel := context.WithCancel(ctx)
+	a.genMu.Lock()
+	a.genCancel = genCancel
+	a.genMu.Unlock()
+
 	// Store the context for tool call handlers that may run in engine
 	// background goroutines (e.g., cascade strong-model stage).
 	a.toolCtxMu.Lock()
-	a.toolCtx = ctx
+	a.toolCtx = genCtx
 	a.toolCtxMu.Unlock()
 
-	resp, err := a.eng.Process(ctx, frame, promptCtx)
+	resp, err := a.eng.Process(genCtx, frame, promptCtx)
 	if err != nil {
+		genCancel()
+		// Clear genCancel to avoid holding a stale reference.
+		a.genMu.Lock()
+		a.genCancel = nil
+		a.genMu.Unlock()
 		return fmt.Errorf("agent: engine process: %w", err)
 	}
 

--- a/internal/agent/npc.go
+++ b/internal/agent/npc.go
@@ -290,8 +290,25 @@ func (a *liveAgent) HandleUtterance(ctx context.Context, speaker string, transcr
 			Channels:   resp.Channels,
 			Priority:   defaultAudioPriority,
 		}
+		// Wire the OnDone callback to signal the engine when playback
+		// finishes so it can determine the final (possibly truncated) text.
+		if resp.NotifyDone != nil {
+			seg.OnDone = func(interrupted bool) {
+				select {
+				case resp.NotifyDone <- interrupted:
+				default:
+				}
+			}
+		}
 		a.mixer.Enqueue(seg, defaultAudioPriority)
 	} else if resp.Audio != nil {
+		// No mixer — signal natural completion so the engine can resolve FinalText.
+		if resp.NotifyDone != nil {
+			select {
+			case resp.NotifyDone <- false:
+			default:
+			}
+		}
 		// Drain audio channel to avoid blocking the engine pipeline.
 		go func(ch <-chan []byte) {
 			for range ch {
@@ -300,8 +317,14 @@ func (a *liveAgent) HandleUtterance(ctx context.Context, speaker string, transcr
 	}
 
 	// 6. Record the exchange in conversation history.
+	//
+	// Optimistic recording: append the full text immediately so the next
+	// HandleUtterance always has context. A background goroutine corrects
+	// the last assistant message if FinalText reveals truncation.
 	a.messages = append(a.messages, userMsg)
+	assistantIdx := -1
 	if resp.Text != "" {
+		assistantIdx = len(a.messages)
 		a.messages = append(a.messages, llm.Message{
 			Role:    "assistant",
 			Content: resp.Text,
@@ -309,7 +332,37 @@ func (a *liveAgent) HandleUtterance(ctx context.Context, speaker string, transcr
 		})
 	}
 
+	// Launch correction goroutine if the engine supports FinalText.
+	if resp.FinalText != nil && assistantIdx >= 0 {
+		go a.correctMessageHistory(ctx, resp, assistantIdx)
+	}
+
 	return nil
+}
+
+// correctMessageHistory waits for the engine to resolve FinalText, then
+// replaces the assistant message at idx with the definitive (possibly
+// truncated) text. This runs in a background goroutine and acquires a.mu
+// briefly for the update.
+func (a *liveAgent) correctMessageHistory(ctx context.Context, resp *engine.Response, idx int) {
+	select {
+	case <-resp.FinalText:
+	case <-ctx.Done():
+		return
+	}
+
+	finalText := resp.FinalTextValue
+	if finalText == "" || finalText == resp.Text {
+		return // no correction needed
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Guard against out-of-bounds (defensive; should not happen in practice).
+	if idx < len(a.messages) && a.messages[idx].Role == "assistant" {
+		a.messages[idx].Content = finalText
+	}
 }
 
 // UpdateScene pushes a new scene context to the NPC. The scene is stored

--- a/internal/agent/npc_test.go
+++ b/internal/agent/npc_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/MrWong99/glyphoxa/internal/agent"
 	"github.com/MrWong99/glyphoxa/internal/engine"
@@ -27,16 +28,21 @@ import (
 func TestBargeIn_CancelsInFlightGeneration(t *testing.T) {
 	t.Parallel()
 
-	// Create a blocking engine that waits on its context.
-	processStarted := make(chan struct{})
-	processCtx := make(chan context.Context, 1)
+	// cancelled is closed by the ProcessFunc once its context is cancelled.
+	cancelled := make(chan struct{})
+	processReady := make(chan struct{})
 
 	eng := &enginemock.VoiceEngine{
 		ProcessFunc: func(ctx context.Context, _ audio.AudioFrame, _ engine.PromptContext) (*engine.Response, error) {
-			processCtx <- ctx
-			close(processStarted)
+			close(processReady)
 			// Block until context is cancelled.
-			<-ctx.Done()
+			select {
+			case <-ctx.Done():
+			case <-time.After(5 * time.Second):
+				// Safety net so the test doesn't hang forever in CI.
+				return nil, errors.New("timed out waiting for context cancellation")
+			}
+			close(cancelled)
 			return &engine.Response{
 				Text:  "Partial.",
 				Audio: closedAudioCh(),
@@ -63,23 +69,27 @@ func TestBargeIn_CancelsInFlightGeneration(t *testing.T) {
 	}()
 
 	// Wait for Process to be called.
-	<-processStarted
+	<-processReady
 
 	// Simulate barge-in via the mixer.
 	mixer.TriggerBargeIn("player-2")
 
-	// The generation context should have been cancelled.
-	ctx := <-processCtx
+	// The generation context should have been cancelled promptly.
 	select {
-	case <-ctx.Done():
-		// Good — context was cancelled by barge-in.
-	default:
-		t.Error("generation context was not cancelled by barge-in")
+	case <-cancelled:
+		// Good — ProcessFunc observed cancellation.
+	case <-time.After(5 * time.Second):
+		t.Fatal("generation context was not cancelled by barge-in within 5s")
 	}
 
 	// HandleUtterance should complete.
-	if err := <-done; err != nil {
-		t.Fatalf("HandleUtterance error: %v", err)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("HandleUtterance error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("HandleUtterance did not complete within 5s")
 	}
 }
 

--- a/internal/agent/npc_test.go
+++ b/internal/agent/npc_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/MrWong99/glyphoxa/internal/hotctx"
 	"github.com/MrWong99/glyphoxa/internal/mcp"
 	mcpmock "github.com/MrWong99/glyphoxa/internal/mcp/mock"
+	"github.com/MrWong99/glyphoxa/pkg/audio"
 	audiomock "github.com/MrWong99/glyphoxa/pkg/audio/mock"
 	"github.com/MrWong99/glyphoxa/pkg/memory"
 	memorymock "github.com/MrWong99/glyphoxa/pkg/memory/mock"
@@ -20,6 +21,67 @@ import (
 	"github.com/MrWong99/glyphoxa/pkg/provider/tts"
 	ttsmock "github.com/MrWong99/glyphoxa/pkg/provider/tts/mock"
 )
+
+// ─── Barge-In Cancellation ──────────────────────────────────────────────────
+
+func TestBargeIn_CancelsInFlightGeneration(t *testing.T) {
+	t.Parallel()
+
+	// Create a blocking engine that waits on its context.
+	processStarted := make(chan struct{})
+	processCtx := make(chan context.Context, 1)
+
+	eng := &enginemock.VoiceEngine{
+		ProcessFunc: func(ctx context.Context, _ audio.AudioFrame, _ engine.PromptContext) (*engine.Response, error) {
+			processCtx <- ctx
+			close(processStarted)
+			// Block until context is cancelled.
+			<-ctx.Done()
+			return &engine.Response{
+				Text:  "Partial.",
+				Audio: closedAudioCh(),
+			}, nil
+		},
+	}
+
+	mixer := &audiomock.Mixer{}
+	cfg := validConfig()
+	cfg.Engine = eng
+	cfg.Mixer = mixer
+
+	a, err := agent.NewAgent(cfg)
+	if err != nil {
+		t.Fatalf("NewAgent: %v", err)
+	}
+
+	// Start HandleUtterance in a goroutine.
+	done := make(chan error, 1)
+	go func() {
+		done <- a.HandleUtterance(context.Background(), "player-1", stt.Transcript{
+			Text: "Hello.", IsFinal: true,
+		})
+	}()
+
+	// Wait for Process to be called.
+	<-processStarted
+
+	// Simulate barge-in via the mixer.
+	mixer.TriggerBargeIn("player-2")
+
+	// The generation context should have been cancelled.
+	ctx := <-processCtx
+	select {
+	case <-ctx.Done():
+		// Good — context was cancelled by barge-in.
+	default:
+		t.Error("generation context was not cancelled by barge-in")
+	}
+
+	// HandleUtterance should complete.
+	if err := <-done; err != nil {
+		t.Fatalf("HandleUtterance error: %v", err)
+	}
+}
 
 // testIdentity returns a standard NPCIdentity for use in tests.
 func testIdentity() agent.NPCIdentity {

--- a/internal/agent/orchestrator/orchestrator.go
+++ b/internal/agent/orchestrator/orchestrator.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MrWong99/glyphoxa/internal/agent"
 	"github.com/MrWong99/glyphoxa/internal/engine"
+	"github.com/MrWong99/glyphoxa/pkg/audio"
 	"github.com/MrWong99/glyphoxa/pkg/memory"
 	"github.com/MrWong99/glyphoxa/pkg/provider/stt"
 )
@@ -34,6 +35,7 @@ type Orchestrator struct {
 
 	detector *AddressDetector
 	buffer   *UtteranceBuffer
+	mixer    audio.Mixer // may be nil (text-only mode)
 
 	dmOverrides map[string]string // speaker → forced NPC id (puppet mode)
 }
@@ -53,6 +55,15 @@ type Option func(*Orchestrator)
 func WithBufferSize(n int) Option {
 	return func(o *Orchestrator) {
 		o.buffer = NewUtteranceBuffer(n, o.buffer.maxAge)
+	}
+}
+
+// WithMixer sets the audio mixer used to interrupt NPC playback when
+// mute commands are issued. When nil, mute commands only set the muted
+// flag without stopping current audio.
+func WithMixer(m audio.Mixer) Option {
+	return func(o *Orchestrator) {
+		o.mixer = m
 	}
 }
 
@@ -170,7 +181,8 @@ func (o *Orchestrator) ActiveAgents() []agent.NPCAgent {
 	return result
 }
 
-// MuteAgent prevents the agent identified by id from receiving new utterances.
+// MuteAgent prevents the agent identified by id from receiving new utterances
+// and interrupts any current speech for that NPC via the mixer (if set).
 // Returns an error if id does not correspond to a registered agent.
 func (o *Orchestrator) MuteAgent(id string) error {
 	o.mu.Lock()
@@ -181,6 +193,10 @@ func (o *Orchestrator) MuteAgent(id string) error {
 		return fmt.Errorf("orchestrator: agent %q not found", id)
 	}
 	entry.muted = true
+
+	if o.mixer != nil {
+		o.mixer.InterruptNPC(id, audio.DMOverride)
+	}
 	return nil
 }
 
@@ -310,7 +326,8 @@ func (o *Orchestrator) IsMuted(id string) (bool, error) {
 	return entry.muted, nil
 }
 
-// MuteAll mutes all agents atomically and returns the number of agents
+// MuteAll mutes all agents atomically, interrupts all current and queued
+// NPC audio via the mixer (if set), and returns the number of agents
 // whose mute state was changed (agents already muted are not counted).
 func (o *Orchestrator) MuteAll() int {
 	o.mu.Lock()
@@ -322,6 +339,10 @@ func (o *Orchestrator) MuteAll() int {
 			e.muted = true
 			changed++
 		}
+	}
+
+	if changed > 0 && o.mixer != nil {
+		o.mixer.Interrupt(audio.DMOverride)
 	}
 	return changed
 }

--- a/internal/agent/orchestrator/orchestrator_test.go
+++ b/internal/agent/orchestrator/orchestrator_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/MrWong99/glyphoxa/internal/agent"
 	agentmock "github.com/MrWong99/glyphoxa/internal/agent/mock"
 	enginemock "github.com/MrWong99/glyphoxa/internal/engine/mock"
+	"github.com/MrWong99/glyphoxa/pkg/audio"
+	audiomock "github.com/MrWong99/glyphoxa/pkg/audio/mock"
 	"github.com/MrWong99/glyphoxa/pkg/provider/stt"
 )
 
@@ -753,4 +755,75 @@ func TestAddressOnlyRouting(t *testing.T) {
 			t.Fatalf("want h1 (puppet), got %s", got.ID())
 		}
 	})
+}
+
+// ── Mute + Mixer Integration ─────────────────────────────────────────────
+
+func TestMuteAgent_InterruptsNPC(t *testing.T) {
+	t.Parallel()
+
+	grimjaw, _ := newMockAgent("g1", "Grimjaw")
+	mixer := &audiomock.Mixer{}
+	o := New([]agent.NPCAgent{grimjaw}, WithMixer(mixer))
+
+	if err := o.MuteAgent("g1"); err != nil {
+		t.Fatalf("mute: %v", err)
+	}
+
+	if len(mixer.InterruptNPCCalls) != 1 {
+		t.Fatalf("want 1 InterruptNPC call, got %d", len(mixer.InterruptNPCCalls))
+	}
+	call := mixer.InterruptNPCCalls[0]
+	if call.NPCID != "g1" {
+		t.Errorf("InterruptNPC NPCID = %q, want %q", call.NPCID, "g1")
+	}
+	if call.Reason != audio.DMOverride {
+		t.Errorf("InterruptNPC Reason = %v, want DMOverride", call.Reason)
+	}
+}
+
+func TestMuteAll_InterruptsAll(t *testing.T) {
+	t.Parallel()
+
+	grimjaw, _ := newMockAgent("g1", "Grimjaw")
+	elara, _ := newMockAgent("e1", "Elara")
+	mixer := &audiomock.Mixer{}
+	o := New([]agent.NPCAgent{grimjaw, elara}, WithMixer(mixer))
+
+	changed := o.MuteAll()
+	if changed != 2 {
+		t.Fatalf("MuteAll changed = %d, want 2", changed)
+	}
+
+	if len(mixer.InterruptCalls) != 1 {
+		t.Fatalf("want 1 Interrupt call, got %d", len(mixer.InterruptCalls))
+	}
+	if mixer.InterruptCalls[0].Reason != audio.DMOverride {
+		t.Errorf("Interrupt Reason = %v, want DMOverride", mixer.InterruptCalls[0].Reason)
+	}
+}
+
+func TestMuteAll_NilMixer_NoOp(t *testing.T) {
+	t.Parallel()
+
+	grimjaw, _ := newMockAgent("g1", "Grimjaw")
+	o := New([]agent.NPCAgent{grimjaw}) // no mixer
+
+	// Should not panic.
+	changed := o.MuteAll()
+	if changed != 1 {
+		t.Fatalf("MuteAll changed = %d, want 1", changed)
+	}
+}
+
+func TestMuteAgent_NilMixer_NoOp(t *testing.T) {
+	t.Parallel()
+
+	grimjaw, _ := newMockAgent("g1", "Grimjaw")
+	o := New([]agent.NPCAgent{grimjaw}) // no mixer
+
+	// Should not panic.
+	if err := o.MuteAgent("g1"); err != nil {
+		t.Fatalf("mute: %v", err)
+	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -362,7 +362,7 @@ func (a *App) initAgents(ctx context.Context) error {
 	}
 
 	a.agents = agents
-	a.router = orchestrator.New(agents)
+	a.router = orchestrator.New(agents, orchestrator.WithMixer(a.mixer))
 
 	if a.graph != nil {
 		registerNPCEntities(ctx, a.graph, a.cfg.NPCs)

--- a/internal/app/audio_pipeline.go
+++ b/internal/app/audio_pipeline.go
@@ -204,8 +204,9 @@ func (p *audioPipeline) processParticipant(ctx context.Context, speakerID string
 					slog.Debug("audio pipeline: speech start",
 						"speaker", speakerID, "prob", event.Probability)
 
-					// Barge-in: interrupt current NPC playback and clear queue.
-					p.mixer.Interrupt(audio.PlayerBargeIn)
+					// Barge-in: interrupt current NPC playback, clear queue,
+					// and fire the OnBargeIn callback.
+					p.mixer.BargeIn(speakerID)
 
 					// Snapshot STT config under lock — UpdateKeywords may be
 					// writing p.sttCfg.Keywords concurrently.

--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -182,8 +182,8 @@ func (sm *SessionManager) Start(ctx context.Context, channelID string, dmUserID 
 	}
 	closers = append(closers, agentClosers...)
 
-	// Create orchestrator with loaded agents.
-	orch := orchestrator.New(agents)
+	// Create orchestrator with loaded agents and wire the mixer for mute interrupts.
+	orch := orchestrator.New(agents, orchestrator.WithMixer(mixer))
 
 	// Create a session-scoped context for background work, carrying
 	// the tenant identity for downstream subsystems.

--- a/internal/engine/cascade/cascade.go
+++ b/internal/engine/cascade/cascade.go
@@ -225,54 +225,123 @@ func (e *Engine) Process(ctx context.Context, _ audio.AudioFrame, prompt engine.
 			return nil, fmt.Errorf("cascade: TTS start failed: %w", err)
 		}
 
-		// Emit player input transcript entry.
-		if playerMsg, ok := lastUserMessage(prompt.Messages); ok {
-			e.emitTranscript(memory.TranscriptEntry{
-				SpeakerID:   playerMsg.Name,
-				SpeakerName: playerMsg.Name,
-				Text:        playerMsg.Content,
-				Timestamp:   time.Now(),
-			})
+		finalText := make(chan struct{})
+		notifyDone := make(chan bool, 1)
+		resp := &engine.Response{
+			Text:       opener,
+			Audio:      audioCh,
+			SampleRate: e.ttsSampleRate,
+			Channels:   e.ttsChannels,
+			FinalText:  finalText,
+			NotifyDone: notifyDone,
 		}
 
-		// Emit NPC response transcript entry.
-		e.emitTranscript(memory.TranscriptEntry{
-			Text:      opener,
-			Timestamp: time.Now(),
+		// Background goroutine: wait for playback outcome, then emit transcript.
+		e.wg.Go(func() {
+			interrupted := e.waitForDone(ctx, notifyDone)
+
+			if interrupted {
+				// Single sentence — if interrupted mid-playback, some audio
+				// was heard. Use the opener with truncation marker.
+				resp.FinalTextValue = opener + "..."
+			} else {
+				resp.FinalTextValue = opener
+			}
+			close(finalText)
+
+			// Emit player input transcript entry.
+			if playerMsg, ok := lastUserMessage(prompt.Messages); ok {
+				e.emitTranscript(memory.TranscriptEntry{
+					SpeakerID:   playerMsg.Name,
+					SpeakerName: playerMsg.Name,
+					Text:        playerMsg.Content,
+					Timestamp:   time.Now(),
+				})
+			}
+
+			// Emit NPC response transcript entry with the final text.
+			e.emitTranscript(memory.TranscriptEntry{
+				Text:      resp.FinalTextValue,
+				Timestamp: time.Now(),
+			})
 		})
 
-		return &engine.Response{Text: opener, Audio: audioCh, SampleRate: e.ttsSampleRate, Channels: e.ttsChannels}, nil
+		return resp, nil
 	}
 
 	// ── Stage 2b: Dual-model path ─────────────────────────────────────────────
 
 	// Create the shared text channel that feeds the TTS stream.
+	// We wrap it with a tracking channel that records committed text.
 	textCh := make(chan string, defaultTextBuf)
 	audioCh, err := e.ttsP.SynthesizeStream(ctx, textCh, e.voice)
 	if err != nil {
 		return nil, fmt.Errorf("cascade: TTS start failed: %w", err)
 	}
 
+	finalText := make(chan struct{})
+	notifyDone := make(chan bool, 1)
 	strongReq := e.buildStrongPrompt(prompt, tools, opener)
-	resp := &engine.Response{Text: opener, Audio: audioCh, SampleRate: e.ttsSampleRate, Channels: e.ttsChannels}
+	resp := &engine.Response{
+		Text:       opener,
+		Audio:      audioCh,
+		SampleRate: e.ttsSampleRate,
+		Channels:   e.ttsChannels,
+		FinalText:  finalText,
+		NotifyDone: notifyDone,
+	}
 
 	// Background goroutine: send opener → strong model (with tool loop) → close textCh.
 	e.wg.Go(func() {
 		defer close(textCh)
 
+		// committedText tracks sentences that have been sent to TTS.
+		// Protected by committedMu for concurrent access from the
+		// forwardStrongModel goroutine and the done-waiter below.
+		var committedMu sync.Mutex
+		var committedText strings.Builder
+
+		// commitSentence is called each time a sentence is delivered to TTS.
+		commitSentence := func(sentence string) {
+			committedMu.Lock()
+			if committedText.Len() > 0 {
+				committedText.WriteByte(' ')
+			}
+			committedText.WriteString(sentence)
+			committedMu.Unlock()
+		}
+
 		// Deliver the opener to TTS immediately so playback begins.
 		select {
 		case textCh <- opener:
+			commitSentence(opener)
 		case <-ctx.Done():
 			return
 		}
 
-		// Run the strong model with tool-call loop support.
-		continuation := e.forwardStrongModel(ctx, strongReq, textCh, resp)
+		// Run the strong model with tool-call loop support, tracking
+		// committed sentences.
+		continuation := e.forwardStrongModelTracked(ctx, strongReq, textCh, resp, commitSentence)
 		fullText := opener
 		if continuation != "" {
 			fullText = opener + " " + continuation
 		}
+		// Wait for playback outcome.
+		interrupted := e.waitForDone(ctx, notifyDone)
+
+		if interrupted {
+			committedMu.Lock()
+			committed := strings.TrimSpace(committedText.String())
+			committedMu.Unlock()
+			if committed == "" {
+				resp.FinalTextValue = "..."
+			} else {
+				resp.FinalTextValue = committed + "..."
+			}
+		} else {
+			resp.FinalTextValue = strings.TrimSpace(fullText)
+		}
+		close(finalText)
 
 		// Emit player input transcript entry.
 		if playerMsg, ok := lastUserMessage(prompt.Messages); ok {
@@ -284,9 +353,9 @@ func (e *Engine) Process(ctx context.Context, _ audio.AudioFrame, prompt engine.
 			})
 		}
 
-		// Emit NPC response transcript entry.
+		// Emit NPC response transcript entry with the final text.
 		e.emitTranscript(memory.TranscriptEntry{
-			Text:      strings.TrimSpace(fullText),
+			Text:      resp.FinalTextValue,
 			Timestamp: time.Now(),
 		})
 	})
@@ -363,6 +432,58 @@ func (e *Engine) Close() error {
 // mock call records.
 func (e *Engine) Wait() {
 	e.wg.Wait()
+}
+
+// waitForDone blocks until the playback outcome is signalled via notifyDone
+// or ctx is cancelled. Returns true if the segment was interrupted, false if
+// it played to completion.
+func (e *Engine) waitForDone(ctx context.Context, notifyDone <-chan bool) bool {
+	select {
+	case interrupted, ok := <-notifyDone:
+		if !ok {
+			// Channel closed without a value — treat as natural completion.
+			return false
+		}
+		return interrupted
+	case <-ctx.Done():
+		// Context cancelled — generation was aborted, treat as interrupted.
+		return true
+	case <-e.done:
+		// Engine closing — treat as interrupted.
+		return true
+	}
+}
+
+// forwardStrongModelTracked wraps [Engine.forwardStrongModel] and calls
+// commitSentence for each sentence delivered to textCh. This allows the
+// caller to track which text has actually been committed to TTS.
+func (e *Engine) forwardStrongModelTracked(
+	ctx context.Context,
+	strongReq llm.CompletionRequest,
+	textCh chan<- string,
+	resp *engine.Response,
+	commitSentence func(string),
+) string {
+	// Wrap textCh with a tracking channel.
+	trackCh := make(chan string, defaultTextBuf)
+	var trackWg sync.WaitGroup
+	trackWg.Add(1)
+	go func() {
+		defer trackWg.Done()
+		for sentence := range trackCh {
+			commitSentence(sentence)
+			select {
+			case textCh <- sentence:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	result := e.forwardStrongModel(ctx, strongReq, trackCh, resp)
+	close(trackCh)
+	trackWg.Wait()
+	return result
 }
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────

--- a/internal/engine/cascade/cascade_test.go
+++ b/internal/engine/cascade/cascade_test.go
@@ -27,6 +27,14 @@ func drainAudio(ch <-chan []byte) {
 	}
 }
 
+// signalDone notifies the engine that playback completed naturally.
+// Must be called after drainAudio for tests that check transcript emission.
+func signalDone(resp *enginepkg.Response) {
+	if resp.NotifyDone != nil {
+		resp.NotifyDone <- false
+	}
+}
+
 // newTTS returns a TTS mock that emits a single "audio" chunk per call.
 func newTTS() *ttsmock.Provider {
 	return &ttsmock.Provider{
@@ -128,6 +136,7 @@ func TestProcess_FastModelOnly(t *testing.T) {
 		t.Fatalf("Process: unexpected error: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	// Fast model must have been called exactly once.
@@ -184,6 +193,7 @@ func TestProcess_DualModel(t *testing.T) {
 		t.Fatalf("Process: unexpected error: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	if len(fastLLM.StreamCalls) != 1 {
@@ -281,6 +291,7 @@ func TestProcess_OpenerSentenceDetection(t *testing.T) {
 				t.Fatalf("Process: %v", err)
 			}
 			drainAudio(resp.Audio)
+			signalDone(resp)
 			e.Wait()
 
 			// Verify opener text.
@@ -354,6 +365,7 @@ func TestProcess_ForcedPrefix(t *testing.T) {
 		t.Fatalf("Process: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	if len(strongLLM.StreamCalls) != 1 {
@@ -413,12 +425,14 @@ func TestProcess_FastModelInstructionAppended(t *testing.T) {
 	)
 	t.Cleanup(func() { _ = e.Close() })
 
-	_, err := e.Process(context.Background(), emptyAudioFrame, enginepkg.PromptContext{
+	resp, err := e.Process(context.Background(), emptyAudioFrame, enginepkg.PromptContext{
 		SystemPrompt: "You are an NPC.",
 	})
 	if err != nil {
 		t.Fatalf("Process: %v", err)
 	}
+	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	if len(fastLLM.StreamCalls) == 0 {
@@ -477,6 +491,7 @@ func TestInjectContext_StoresUpdate(t *testing.T) {
 		t.Fatalf("Process: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	if len(fastLLM.StreamCalls) == 0 {
@@ -496,6 +511,7 @@ func TestInjectContext_StoresUpdate(t *testing.T) {
 		t.Fatalf("second Process: %v", err)
 	}
 	drainAudio(resp2.Audio)
+	signalDone(resp2)
 	e.Wait()
 
 	if len(fastLLM.StreamCalls) == 0 {
@@ -545,6 +561,7 @@ func TestSetTools_OnlyStrongModel(t *testing.T) {
 		t.Fatalf("Process: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	if len(fastLLM.StreamCalls) == 0 {
@@ -610,6 +627,7 @@ func TestOnToolCall_RegistersHandler(t *testing.T) {
 		t.Fatalf("Process after OnToolCall: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	// No tool calls were issued by the LLM in this test, so callCount stays 0.
@@ -693,6 +711,7 @@ func TestConcurrentProcess(t *testing.T) {
 				return
 			}
 			drainAudio(resp.Audio)
+			signalDone(resp)
 		}(i)
 	}
 
@@ -762,6 +781,7 @@ func TestWithTranscriptBuffer(t *testing.T) {
 		t.Fatalf("Process: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 }
 
@@ -793,6 +813,7 @@ func TestProcess_EmitsTranscriptEntries_SingleModel(t *testing.T) {
 		t.Fatalf("Process: unexpected error: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 	_ = e.Close()
 
@@ -857,6 +878,7 @@ func TestProcess_EmitsTranscriptEntries_DualModel(t *testing.T) {
 		t.Fatalf("Process: unexpected error: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 	_ = e.Close()
 
@@ -914,6 +936,7 @@ func TestProcess_EmitsTranscriptEntries_NoPlayerMessage(t *testing.T) {
 		t.Fatalf("Process: unexpected error: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 	_ = e.Close()
 
@@ -989,6 +1012,7 @@ func TestProcess_ToolCallSingleIteration(t *testing.T) {
 		t.Fatalf("Process: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	// Handler must have been called exactly once.
@@ -1068,6 +1092,7 @@ func TestProcess_ToolCallMultiIteration(t *testing.T) {
 		t.Fatalf("Process: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	callMu.Lock()
@@ -1128,6 +1153,7 @@ func TestProcess_ToolCallNilHandler(t *testing.T) {
 		t.Fatalf("Process: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	// Must not panic. Strong model should have been called only once (no retry).
@@ -1178,6 +1204,7 @@ func TestProcess_ToolCallHandlerError(t *testing.T) {
 		t.Fatalf("Process: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	// Strong model must have been called twice (tool request + after error result).
@@ -1245,6 +1272,7 @@ func TestProcess_ToolCallIterationCap(t *testing.T) {
 		t.Fatalf("Process: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	// Strong model should have been called exactly maxIters times.
@@ -1333,6 +1361,7 @@ func TestWithSTT_OptionStored(t *testing.T) {
 		t.Fatalf("Process: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 }
 
@@ -1371,6 +1400,7 @@ func TestInjectContext_SceneAndUtterances(t *testing.T) {
 		t.Fatalf("Process: %v", err)
 	}
 	drainAudio(resp.Audio)
+	signalDone(resp)
 	e.Wait()
 
 	if len(fastLLM.StreamCalls) == 0 {
@@ -1394,5 +1424,183 @@ func TestInjectContext_SceneAndUtterances(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("recent utterance not found in messages: %+v", req.Messages)
+	}
+}
+
+// ─── FinalText / Transcript Truncation ────────────────────────────────────────
+
+func TestFinalText_NaturalCompletion_SingleModel(t *testing.T) {
+	t.Parallel()
+
+	fastLLM := &llmmock.Provider{
+		StreamChunks: []llm.Chunk{
+			{Text: "Hello there.", FinishReason: "stop"},
+		},
+	}
+	e := cascade.New(fastLLM, &llmmock.Provider{}, newTTS(), tts.VoiceProfile{})
+	defer e.Close()
+
+	resp, err := e.Process(context.Background(), emptyAudioFrame, enginepkg.PromptContext{
+		SystemPrompt: "NPC.",
+		Messages:     []llm.Message{{Role: "user", Content: "Hi", Name: "p1"}},
+	})
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	drainAudio(resp.Audio)
+
+	// Signal natural completion.
+	resp.NotifyDone <- false
+	<-resp.FinalText
+
+	if resp.FinalTextValue != "Hello there." {
+		t.Errorf("FinalTextValue = %q, want %q", resp.FinalTextValue, "Hello there.")
+	}
+}
+
+func TestFinalText_Interrupted_SingleModel(t *testing.T) {
+	t.Parallel()
+
+	fastLLM := &llmmock.Provider{
+		StreamChunks: []llm.Chunk{
+			{Text: "Hello there.", FinishReason: "stop"},
+		},
+	}
+	e := cascade.New(fastLLM, &llmmock.Provider{}, newTTS(), tts.VoiceProfile{})
+	defer e.Close()
+
+	resp, err := e.Process(context.Background(), emptyAudioFrame, enginepkg.PromptContext{
+		SystemPrompt: "NPC.",
+		Messages:     []llm.Message{{Role: "user", Content: "Hi", Name: "p1"}},
+	})
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	drainAudio(resp.Audio)
+
+	// Signal interruption.
+	resp.NotifyDone <- true
+	<-resp.FinalText
+
+	if resp.FinalTextValue != "Hello there...." {
+		t.Errorf("FinalTextValue = %q, want %q", resp.FinalTextValue, "Hello there....")
+	}
+}
+
+func TestFinalText_NaturalCompletion_DualModel(t *testing.T) {
+	t.Parallel()
+
+	fastLLM := &llmmock.Provider{
+		StreamChunks: []llm.Chunk{
+			{Text: "Greetings! I have much to share.", FinishReason: "stop"},
+		},
+	}
+	strongLLM := &llmmock.Provider{
+		StreamChunks: []llm.Chunk{
+			{Text: "The ancient lore speaks of dragons.", FinishReason: "stop"},
+		},
+	}
+	e := cascade.New(fastLLM, strongLLM, newTTS(), tts.VoiceProfile{})
+	defer e.Close()
+
+	resp, err := e.Process(context.Background(), emptyAudioFrame, enginepkg.PromptContext{
+		SystemPrompt: "NPC.",
+		Messages:     []llm.Message{{Role: "user", Content: "Tell me.", Name: "p1"}},
+	})
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	drainAudio(resp.Audio)
+
+	// Signal natural completion.
+	resp.NotifyDone <- false
+	<-resp.FinalText
+
+	// Should contain the full text.
+	if !strings.Contains(resp.FinalTextValue, "Greetings!") {
+		t.Errorf("FinalTextValue missing opener: %q", resp.FinalTextValue)
+	}
+	if strings.HasSuffix(resp.FinalTextValue, "...") {
+		t.Errorf("FinalTextValue should not have truncation marker: %q", resp.FinalTextValue)
+	}
+}
+
+func TestFinalText_Interrupted_DualModel(t *testing.T) {
+	t.Parallel()
+
+	fastLLM := &llmmock.Provider{
+		StreamChunks: []llm.Chunk{
+			{Text: "Greetings! I have much to share.", FinishReason: "stop"},
+		},
+	}
+	strongLLM := &llmmock.Provider{
+		StreamChunks: []llm.Chunk{
+			{Text: "The ancient lore speaks of dragons. And also of fire.", FinishReason: "stop"},
+		},
+	}
+	e := cascade.New(fastLLM, strongLLM, newTTS(), tts.VoiceProfile{})
+	defer e.Close()
+
+	resp, err := e.Process(context.Background(), emptyAudioFrame, enginepkg.PromptContext{
+		SystemPrompt: "NPC.",
+		Messages:     []llm.Message{{Role: "user", Content: "Tell me.", Name: "p1"}},
+	})
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	drainAudio(resp.Audio)
+
+	// Signal interruption.
+	resp.NotifyDone <- true
+	<-resp.FinalText
+
+	// Should have truncation marker.
+	if !strings.HasSuffix(resp.FinalTextValue, "...") {
+		t.Errorf("FinalTextValue should end with '...': %q", resp.FinalTextValue)
+	}
+}
+
+func TestFinalText_TranscriptEmitsTruncatedText(t *testing.T) {
+	t.Parallel()
+
+	fastLLM := &llmmock.Provider{
+		StreamChunks: []llm.Chunk{
+			{Text: "Well met.", FinishReason: "stop"},
+		},
+	}
+	e := cascade.New(fastLLM, &llmmock.Provider{}, newTTS(), tts.VoiceProfile{})
+	ch := e.Transcripts()
+
+	resp, err := e.Process(context.Background(), emptyAudioFrame, enginepkg.PromptContext{
+		SystemPrompt: "NPC.",
+		Messages:     []llm.Message{{Role: "user", Content: "Hi", Name: "p1"}},
+	})
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	drainAudio(resp.Audio)
+
+	// Signal interruption.
+	resp.NotifyDone <- true
+	e.Wait()
+	_ = e.Close()
+
+	var entries []memory.TranscriptEntry
+	for entry := range ch {
+		entries = append(entries, entry)
+	}
+
+	// Find the NPC transcript entry.
+	found := false
+	for _, entry := range entries {
+		if entry.SpeakerID == "" && strings.HasSuffix(entry.Text, "...") {
+			found = true
+			if entry.Text != "Well met...." {
+				t.Errorf("NPC transcript text = %q, want %q", entry.Text, "Well met....")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected truncated NPC transcript entry, got: %+v", entries)
 	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -100,6 +100,27 @@ type Response struct {
 	// streamErr stores the error that caused the Audio channel to close early.
 	// Access via Err and SetStreamErr.
 	streamErr atomic.Pointer[error]
+
+	// FinalText is closed when the definitive response text is available.
+	// Read FinalTextValue after <-FinalText returns.
+	//
+	// If playback completes naturally, FinalTextValue == Text.
+	// If interrupted (barge-in or mute), FinalTextValue is the truncated
+	// text with a "..." suffix reflecting only what was actually heard.
+	//
+	// May be nil for engines that do not support transcript truncation —
+	// callers must check before waiting.
+	FinalText chan struct{}
+
+	// FinalTextValue holds the definitive (possibly truncated) response text.
+	// Only valid after FinalText is closed.
+	FinalTextValue string
+
+	// NotifyDone is written to by the caller (agent) when the mixer
+	// finishes with the audio segment. interrupted=true means playback
+	// was cut short. The engine reads this to decide whether to truncate.
+	// May be nil if the engine does not support truncation.
+	NotifyDone chan bool
 }
 
 // Err returns the error that caused the Audio channel to close prematurely,

--- a/internal/engine/mock/mock.go
+++ b/internal/engine/mock/mock.go
@@ -56,6 +56,10 @@ type SetToolsCall struct {
 type VoiceEngine struct {
 	mu sync.Mutex
 
+	// ProcessFunc, when non-nil, is called instead of returning ProcessResult/ProcessError.
+	// Use this for tests that need to block or inspect the context.
+	ProcessFunc func(ctx context.Context, input audio.AudioFrame, prompt engine.PromptContext) (*engine.Response, error)
+
 	// ProcessResult is returned by [VoiceEngine.Process] (may be nil).
 	ProcessResult *engine.Response
 
@@ -95,10 +99,15 @@ type VoiceEngine struct {
 }
 
 // Process implements [engine.VoiceEngine].
-func (v *VoiceEngine) Process(_ context.Context, input audio.AudioFrame, prompt engine.PromptContext) (*engine.Response, error) {
+// If ProcessFunc is set, it is called instead of returning ProcessResult/ProcessError.
+func (v *VoiceEngine) Process(ctx context.Context, input audio.AudioFrame, prompt engine.PromptContext) (*engine.Response, error) {
 	v.mu.Lock()
-	defer v.mu.Unlock()
 	v.ProcessCalls = append(v.ProcessCalls, ProcessCall{Input: input, Prompt: prompt})
+	fn := v.ProcessFunc
+	v.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, input, prompt)
+	}
 	return v.ProcessResult, v.ProcessError
 }
 

--- a/pkg/audio/mixer.go
+++ b/pkg/audio/mixer.go
@@ -1,6 +1,7 @@
 package audio
 
 import (
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -62,6 +63,29 @@ type AudioSegment struct {
 	// streamErr stores the error that caused the Audio channel to close early.
 	// Access via Err and SetStreamErr.
 	streamErr atomic.Pointer[error]
+
+	// OnDone is called exactly once when the mixer finishes with this segment.
+	// interrupted is true if playback was cut short (barge-in, mute, or queue
+	// drain), false if the segment played to completion.
+	//
+	// Called on the mixer's dispatch goroutine; must not block.
+	// May be nil.
+	OnDone func(interrupted bool)
+
+	// doneOnce ensures OnDone fires at most once even if both natural
+	// completion and interrupt race.
+	doneOnce sync.Once
+}
+
+// FireDone invokes OnDone exactly once with the given interrupted flag.
+// It is safe to call multiple times; only the first call has any effect.
+// Callers (typically a [Mixer] implementation) should call FireDone(false)
+// on natural completion and FireDone(true) on interrupt or queue drain.
+func (s *AudioSegment) FireDone(interrupted bool) {
+	if s.OnDone == nil {
+		return
+	}
+	s.doneOnce.Do(func() { s.OnDone(interrupted) })
 }
 
 // Err returns the error that caused the Audio channel to close prematurely,
@@ -102,6 +126,20 @@ type Mixer interface {
 	// reason and advances to the next queued segment (if any). If nothing is
 	// playing, Interrupt is a no-op.
 	Interrupt(reason InterruptReason)
+
+	// BargeIn signals that a player started speaking while an NPC segment is
+	// playing. It interrupts the current segment with [PlayerBargeIn]
+	// semantics, clears the queue, and invokes the registered barge-in handler
+	// (if any) on a new goroutine. speakerID is the platform participant ID
+	// of the interrupting player.
+	BargeIn(speakerID string)
+
+	// InterruptNPC interrupts the currently playing segment only if it belongs
+	// to the NPC identified by npcID. Queued segments with matching npcID are
+	// also removed. If the currently playing segment belongs to a different NPC,
+	// InterruptNPC is a no-op. This enables NPC-scoped muting without
+	// disturbing other NPCs.
+	InterruptNPC(npcID string, reason InterruptReason)
 
 	// OnBargeIn registers handler as the callback to invoke when voice-activity
 	// detection determines that a player has started speaking while an NPC is

--- a/pkg/audio/mixer/mixer.go
+++ b/pkg/audio/mixer/mixer.go
@@ -184,6 +184,34 @@ func (m *PriorityMixer) BargeIn(speakerID string) {
 	}
 }
 
+// InterruptNPC interrupts the currently playing segment only if its NPCID
+// matches npcID. Queued segments with matching NPCID are also removed and
+// their audio channels drained. If the currently playing segment belongs to
+// a different NPC, InterruptNPC is a no-op.
+func (m *PriorityMixer) InterruptNPC(npcID string, reason audio.InterruptReason) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Interrupt current playback only if it belongs to the target NPC.
+	if m.playing != nil && m.playing.NPCID == npcID {
+		m.interruptLocked(reason, false)
+	}
+
+	// Remove queued segments belonging to the target NPC.
+	kept := m.queue[:0]
+	for _, e := range m.queue {
+		if e.segment.NPCID == npcID {
+			e.segment.FireDone(true)
+			go audio.Drain(e.segment.Audio)
+		} else {
+			kept = append(kept, e)
+		}
+	}
+	m.queue = kept
+	// Re-establish heap invariant after filtering.
+	heap.Init(&m.queue)
+}
+
 // SetGap configures the base silence duration inserted between consecutive
 // segments. Jitter of ±1/6 of the gap is applied automatically. A gap of
 // zero disables inter-segment silence entirely. Changes take effect before
@@ -214,6 +242,7 @@ func (m *PriorityMixer) Close() error {
 	// Drain the queue.
 	for m.queue.Len() > 0 {
 		e := heap.Pop(&m.queue).(entry)
+		e.segment.FireDone(true)
 		go audio.Drain(e.segment.Audio)
 	}
 	m.mu.Unlock()
@@ -236,6 +265,7 @@ func (m *PriorityMixer) interruptLocked(reason audio.InterruptReason, clearQueue
 	if clearQueue {
 		for m.queue.Len() > 0 {
 			e := heap.Pop(&m.queue).(entry)
+			e.segment.FireDone(true)
 			go audio.Drain(e.segment.Audio)
 		}
 	}
@@ -280,6 +310,7 @@ func (m *PriorityMixer) dispatch() {
 							<-gapTimer.C
 						}
 						// Drain the segment we just dequeued.
+						seg.FireDone(true)
 						go audio.Drain(seg.Audio)
 						return
 					case <-cancel:
@@ -287,6 +318,7 @@ func (m *PriorityMixer) dispatch() {
 							<-gapTimer.C
 						}
 						// Interrupted during gap — segment was preempted.
+						seg.FireDone(true)
 						go audio.Drain(seg.Audio)
 						continue
 					case <-gapTimer.C:
@@ -336,15 +368,18 @@ func (m *PriorityMixer) play(seg *audio.AudioSegment, cancel chan struct{}) {
 		select {
 		case <-m.done:
 			slog.Debug("mixer: play interrupted by close", "npcID", seg.NPCID, "chunks", chunks, "totalBytes", totalBytes)
+			seg.FireDone(true)
 			go audio.Drain(seg.Audio)
 			return
 		case <-cancel:
 			slog.Debug("mixer: play interrupted by cancel", "npcID", seg.NPCID, "chunks", chunks, "totalBytes", totalBytes)
+			seg.FireDone(true)
 			go audio.Drain(seg.Audio)
 			return
 		case chunk, ok := <-seg.Audio:
 			if !ok {
 				slog.Debug("mixer: play finished", "npcID", seg.NPCID, "chunks", chunks, "totalBytes", totalBytes)
+				seg.FireDone(false)
 				return // segment finished naturally
 			}
 			chunks++

--- a/pkg/audio/mixer/mixer_test.go
+++ b/pkg/audio/mixer/mixer_test.go
@@ -535,6 +535,244 @@ func TestMixer_OutputEmitsAudioFrame(t *testing.T) {
 	}
 }
 
+func TestInterruptNPC_MatchingNPC(t *testing.T) {
+	t.Parallel()
+
+	output, get := collectOutput()
+	m := mixer.New(output, mixer.WithGap(0))
+	defer m.Close()
+
+	// Start playing an open segment from npc-A.
+	segA, sendChA := makeOpenSegment("npc-A", 1)
+	m.Enqueue(segA, 1)
+	sendChA <- []byte("a-audio")
+	time.Sleep(30 * time.Millisecond)
+
+	// Queue a segment from npc-A and one from npc-B.
+	segA2 := makeSegment("npc-A", 1, []byte("a-queued"))
+	segB := makeSegment("npc-B", 1, []byte("b-queued"))
+	m.Enqueue(segA2, 1)
+	m.Enqueue(segB, 1)
+
+	// InterruptNPC for npc-A — should stop current and remove npc-A from queue.
+	m.InterruptNPC("npc-A", audio.DMOverride)
+	close(sendChA)
+
+	time.Sleep(100 * time.Millisecond)
+
+	chunks := get()
+	// npc-B's queued segment should still play.
+	foundB := false
+	for _, c := range chunks {
+		if string(c) == "b-queued" {
+			foundB = true
+		}
+		if string(c) == "a-queued" {
+			t.Error("npc-A queued segment should have been removed")
+		}
+	}
+	if !foundB {
+		t.Error("npc-B queued segment should still play after InterruptNPC(npc-A)")
+	}
+}
+
+func TestInterruptNPC_DifferentNPC_NoOp(t *testing.T) {
+	t.Parallel()
+
+	output, get := collectOutput()
+	m := mixer.New(output, mixer.WithGap(0))
+	defer m.Close()
+
+	// Start playing npc-A.
+	segA, sendChA := makeOpenSegment("npc-A", 1)
+	m.Enqueue(segA, 1)
+	sendChA <- []byte("a-audio")
+	time.Sleep(30 * time.Millisecond)
+
+	// InterruptNPC for npc-B — should be a no-op (npc-A keeps playing).
+	m.InterruptNPC("npc-B", audio.DMOverride)
+
+	sendChA <- []byte("a-continues")
+	time.Sleep(30 * time.Millisecond)
+	close(sendChA)
+
+	time.Sleep(50 * time.Millisecond)
+
+	chunks := get()
+	found := false
+	for _, c := range chunks {
+		if string(c) == "a-continues" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("npc-A should continue playing when InterruptNPC targets npc-B")
+	}
+}
+
+func TestBargeIn_FiresHandlerAndClearsQueue(t *testing.T) {
+	t.Parallel()
+
+	output, get := collectOutput()
+	m := mixer.New(output, mixer.WithGap(0))
+	defer m.Close()
+
+	var handlerCalled atomic.Bool
+	var handlerSpeaker atomic.Value
+	m.OnBargeIn(func(speakerID string) {
+		handlerCalled.Store(true)
+		handlerSpeaker.Store(speakerID)
+	})
+
+	// Start playing.
+	seg, sendCh := makeOpenSegment("npc-1", 1)
+	m.Enqueue(seg, 1)
+	sendCh <- []byte("playing")
+	time.Sleep(30 * time.Millisecond)
+
+	// Queue another segment.
+	seg2 := makeSegment("npc-2", 1, []byte("queued"))
+	m.Enqueue(seg2, 1)
+
+	// BargeIn should stop current, clear queue, fire handler.
+	m.BargeIn("player-7")
+	close(sendCh)
+
+	time.Sleep(50 * time.Millisecond)
+
+	if !handlerCalled.Load() {
+		t.Error("barge-in handler was not called")
+	}
+	if v, ok := handlerSpeaker.Load().(string); !ok || v != "player-7" {
+		t.Errorf("handler called with %q, want %q", v, "player-7")
+	}
+
+	// Queue should be cleared.
+	chunks := get()
+	for _, c := range chunks {
+		if string(c) == "queued" {
+			t.Error("queued segment should not play after BargeIn")
+		}
+	}
+}
+
+func TestOnDone_NaturalCompletion(t *testing.T) {
+	t.Parallel()
+
+	output, _ := collectOutput()
+	m := mixer.New(output, mixer.WithGap(0))
+	defer m.Close()
+
+	var interrupted atomic.Bool
+	interrupted.Store(true) // default to true so we can detect false
+	done := make(chan struct{})
+
+	seg := makeSegment("npc-1", 1, []byte("hello"))
+	seg.OnDone = func(i bool) {
+		interrupted.Store(i)
+		close(done)
+	}
+	m.Enqueue(seg, 1)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("OnDone not called within timeout")
+	}
+
+	if interrupted.Load() {
+		t.Error("OnDone should be called with false on natural completion")
+	}
+}
+
+func TestOnDone_Interrupted(t *testing.T) {
+	t.Parallel()
+
+	output, _ := collectOutput()
+	m := mixer.New(output, mixer.WithGap(0))
+	defer m.Close()
+
+	var interrupted atomic.Bool
+	done := make(chan struct{})
+
+	seg, sendCh := makeOpenSegment("npc-1", 1)
+	seg.OnDone = func(i bool) {
+		interrupted.Store(i)
+		close(done)
+	}
+	m.Enqueue(seg, 1)
+	sendCh <- []byte("audio")
+	time.Sleep(30 * time.Millisecond)
+
+	m.Interrupt(audio.PlayerBargeIn)
+	close(sendCh)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("OnDone not called within timeout")
+	}
+
+	if !interrupted.Load() {
+		t.Error("OnDone should be called with true on interrupt")
+	}
+}
+
+func TestOnDone_QueuedSegmentDrained(t *testing.T) {
+	t.Parallel()
+
+	output, _ := collectOutput()
+	m := mixer.New(output, mixer.WithGap(0))
+	defer m.Close()
+
+	var queuedInterrupted atomic.Bool
+	queuedDone := make(chan struct{})
+
+	// Start a playing segment.
+	seg1, sendCh := makeOpenSegment("npc-1", 1)
+	m.Enqueue(seg1, 1)
+	sendCh <- []byte("playing")
+	time.Sleep(30 * time.Millisecond)
+
+	// Queue a segment with OnDone.
+	seg2 := makeSegment("npc-2", 1, []byte("queued"))
+	seg2.OnDone = func(i bool) {
+		queuedInterrupted.Store(i)
+		close(queuedDone)
+	}
+	m.Enqueue(seg2, 1)
+
+	// Barge-in clears queue — queued segment should get OnDone(true).
+	m.BargeIn("player-1")
+	close(sendCh)
+
+	select {
+	case <-queuedDone:
+	case <-time.After(time.Second):
+		t.Fatal("OnDone not called on queued segment within timeout")
+	}
+
+	if !queuedInterrupted.Load() {
+		t.Error("queued segment OnDone should be called with true")
+	}
+}
+
+func TestOnDone_NilIsNoop(t *testing.T) {
+	t.Parallel()
+
+	output, _ := collectOutput()
+	m := mixer.New(output, mixer.WithGap(0))
+	defer m.Close()
+
+	// Segment with nil OnDone should not panic.
+	seg := makeSegment("npc-1", 1, []byte("hello"))
+	seg.OnDone = nil
+	m.Enqueue(seg, 1)
+
+	time.Sleep(50 * time.Millisecond)
+	// No panic = success.
+}
+
 func TestMixer_RejectsInvalidFormat(t *testing.T) {
 	output, _ := collectOutput()
 	m := mixer.New(output, mixer.WithGap(0))

--- a/pkg/audio/mock/mock.go
+++ b/pkg/audio/mock/mock.go
@@ -169,6 +169,20 @@ type SetGapCall struct {
 	Duration time.Duration
 }
 
+// BargeInCall records the arguments of a single [Mixer.BargeIn] invocation.
+type BargeInCall struct {
+	// SpeakerID is the speaker ID passed to BargeIn.
+	SpeakerID string
+}
+
+// InterruptNPCCall records the arguments of a single [Mixer.InterruptNPC] invocation.
+type InterruptNPCCall struct {
+	// NPCID is the NPC ID passed to InterruptNPC.
+	NPCID string
+	// Reason is the interrupt reason passed to InterruptNPC.
+	Reason audio.InterruptReason
+}
+
 // Mixer is a mock implementation of [audio.Mixer].
 type Mixer struct {
 	mu sync.Mutex
@@ -178,6 +192,12 @@ type Mixer struct {
 
 	// InterruptCalls records all Interrupt invocations.
 	InterruptCalls []InterruptCall
+
+	// BargeInCalls records all BargeIn invocations.
+	BargeInCalls []BargeInCall
+
+	// InterruptNPCCalls records all InterruptNPC invocations.
+	InterruptNPCCalls []InterruptNPCCall
 
 	// SetGapCalls records all SetGap invocations.
 	SetGapCalls []SetGapCall
@@ -201,6 +221,25 @@ func (m *Mixer) Interrupt(reason audio.InterruptReason) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.InterruptCalls = append(m.InterruptCalls, InterruptCall{Reason: reason})
+}
+
+// BargeIn implements [audio.Mixer]. Records the call and invokes registered handlers.
+func (m *Mixer) BargeIn(speakerID string) {
+	m.mu.Lock()
+	m.BargeInCalls = append(m.BargeInCalls, BargeInCall{SpeakerID: speakerID})
+	handlers := make([]func(string), len(m.BargeInHandlers))
+	copy(handlers, m.BargeInHandlers)
+	m.mu.Unlock()
+	for _, h := range handlers {
+		h(speakerID)
+	}
+}
+
+// InterruptNPC implements [audio.Mixer]. Records the call arguments.
+func (m *Mixer) InterruptNPC(npcID string, reason audio.InterruptReason) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.InterruptNPCCalls = append(m.InterruptNPCCalls, InterruptNPCCall{NPCID: npcID, Reason: reason})
 }
 
 // OnBargeIn implements [audio.Mixer]. Appends handler to BargeInHandlers.


### PR DESCRIPTION
Closes #45

## Summary

- **Barge-in now works end-to-end**: `audio_pipeline.go` calls `mixer.BargeIn(speakerID)` instead of `mixer.Interrupt(PlayerBargeIn)`, firing the `OnBargeIn` callback that cancels in-flight LLM/TTS generation
- **Mute commands interrupt audio immediately**: `MuteAgent` calls `InterruptNPC` (NPC-scoped) and `MuteAll` calls `Interrupt(DMOverride)` — muting NPC-A while NPC-B speaks no longer interrupts NPC-B
- **Transcript reflects what was actually heard**: cascade engine tracks committed text per-sentence and emits truncated text with `...` suffix on interrupt; agent message history is corrected asynchronously via `FinalText` channel

## Changes by phase

### Phase 1: Mixer interface
- Added `BargeIn(speakerID)` and `InterruptNPC(npcID, reason)` to `audio.Mixer` interface
- Implemented `InterruptNPC` on `PriorityMixer` with NPC-scoped queue filtering

### Phase 2: OnDone callback
- Added `OnDone func(interrupted bool)` + `FireDone()` with `sync.Once` to `AudioSegment`
- Mixer calls `FireDone` on natural completion, interrupt, and queue drain

### Phase 3: Cascade transcript truncation
- Added `FinalText`, `FinalTextValue`, `NotifyDone` to `engine.Response`
- Cascade engine tracks `committedText` per sentence, defers transcript emission until playback outcome known
- Single-model and dual-model paths both support truncation

### Phase 4: Mute → Mixer wiring
- Added `WithMixer` option to orchestrator
- `MuteAgent`/`MuteAll` now interrupt audio after setting flags

### Phase 5: Barge-in cancels generation
- `liveAgent` stores `genCancel` for in-flight Process context
- `OnBargeIn` handler cancels generation → LLM/TTS streams close immediately
- Added `ProcessFunc` to engine mock for context-aware test blocking

## Testing

- 15 new tests across mixer, cascade, orchestrator, and agent packages
- All tests use `t.Parallel()` and race detector
- `make check` (fmt + vet + test) passes
- `make lint` (golangci-lint) passes — 0 issues

## Post-Deploy Monitoring & Validation

- **What to monitor**: Watch for `agent: engine process:` error logs that might indicate premature context cancellation
- **Expected healthy behavior**: Barge-in should produce truncated transcripts (`...` suffix); mute should immediately silence targeted NPC
- **Failure signal**: Full transcripts appearing despite barge-in, or `context canceled` errors in non-barge-in flows
- **Validation window**: First session after deploy, check transcript logs for truncation markers

## Follow-up

- S2S engine barge-in (separate interrupt path via `SessionHandle.Interrupt()`)
- Decide policy for queued-but-never-played NPC responses in transcript

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)