### PR TITLE
ci: add version tag support to Docker workflow and consolidate image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Docker
 on:
   push:
     branches: [main]
+    tags: ["v*"]
 
 permissions:
   contents: read
@@ -36,6 +37,11 @@ jobs:
           images: ghcr.io/mrwong99/glyphoxa
           tags: |
             type=ref,event=branch
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push
         uses: docker/build-push-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: write
-  packages: write
 
 jobs:
   release:
@@ -80,22 +79,6 @@ jobs:
           cmake --build build-arm64 --config Release -j$(nproc)
           cmake --install build-arm64
 
-      - name: Download ONNX Runtime (amd64)
-        run: |
-          curl -fsL "https://github.com/microsoft/onnxruntime/releases/download/v1.24.3/onnxruntime-linux-x64-1.24.3.tgz" \
-            -o /tmp/onnxruntime-amd64.tgz
-          mkdir -p /tmp/onnx/amd64
-          tar xzf /tmp/onnxruntime-amd64.tgz -C /tmp/onnx/amd64 --strip-components=1
-          rm -f /tmp/onnxruntime-amd64.tgz
-
-      - name: Download ONNX Runtime (arm64)
-        run: |
-          curl -fsL "https://github.com/microsoft/onnxruntime/releases/download/v1.24.3/onnxruntime-linux-aarch64-1.24.3.tgz" \
-            -o /tmp/onnxruntime-arm64.tgz
-          mkdir -p /tmp/onnx/arm64
-          tar xzf /tmp/onnxruntime-arm64.tgz -C /tmp/onnx/arm64 --strip-components=1
-          rm -f /tmp/onnxruntime-arm64.tgz
-
       - name: Download libdave (amd64)
         run: |
           DAVE_VERSION="v1.1.1/cpp"
@@ -147,47 +130,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # --- Docker image (reuses the statically-linked binaries from GoReleaser) ---
-
-      - name: Prepare Docker context
-        run: |
-          mkdir -p docker-ctx/linux/amd64 docker-ctx/linux/arm64
-          cp dist/glyphoxa_linux_amd64*/glyphoxa docker-ctx/linux/amd64/
-          cp /tmp/dave/amd64/lib/libdave.so docker-ctx/linux/amd64/
-          cp /tmp/onnx/amd64/lib/libonnxruntime.so.1.24.3 docker-ctx/linux/amd64/libonnxruntime.so
-          cp dist/glyphoxa_linux_arm64*/glyphoxa docker-ctx/linux/arm64/
-          cp /tmp/dave/arm64/lib/libdave.so docker-ctx/linux/arm64/
-          cp /tmp/onnx/arm64/lib/libonnxruntime.so.1.24.3 docker-ctx/linux/arm64/libonnxruntime.so
-          cp Dockerfile.release docker-ctx/Dockerfile
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/mrwong99/glyphoxa
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: docker-ctx
-          file: docker-ctx/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      # Docker images are built and pushed by .github/workflows/docker.yml,
+      # which triggers on both main-branch pushes and v* tags.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -237,11 +237,14 @@ Tagged releases (`v*`) are built automatically by GitHub Actions using [GoReleas
 Each release produces the following tags:
 
 ```
-ghcr.io/mrwong99/glyphoxa:<version>       # e.g. 0.3.0
-ghcr.io/mrwong99/glyphoxa:<major>.<minor>  # e.g. 0.3
+ghcr.io/mrwong99/glyphoxa:v<version>       # e.g. v0.3.0
+ghcr.io/mrwong99/glyphoxa:v<major>.<minor>  # e.g. v0.3
+ghcr.io/mrwong99/glyphoxa:<version>         # e.g. 0.3.0
+ghcr.io/mrwong99/glyphoxa:<major>.<minor>   # e.g. 0.3
+ghcr.io/mrwong99/glyphoxa:latest            # latest release
 ```
 
-The `main` branch builds a separate image via the multi-stage `Dockerfile` (used in the Compose stack by default).
+The `main` branch builds a separate image tagged `main` via the multi-stage `Dockerfile`.
 
 ### Supported architectures
 


### PR DESCRIPTION
## Summary

- **Docker workflow** (`docker.yml`): Added `tags: ["v*"]` trigger and semver-based image tagging (`v1.2.3`, `v1.2`, `1.2.3`, `1.2`, `latest`) so tagged releases produce properly versioned Docker images
- **Release workflow** (`release.yml`): Removed the duplicated Docker build steps (ONNX download, libdave cross-compile, multi-platform image build/push) that are now handled by `docker.yml` — eliminates ~60 lines of redundant CI config and the extra `packages: write` permission
- **Deployment docs**: Updated image tag examples to reflect the new `v`-prefixed and `latest` tags

## Test plan

- [ ] Push a test tag (`v0.0.0-test`) and verify `docker.yml` triggers with correct image tags
- [ ] Verify `release.yml` still produces binaries without Docker steps
- [ ] Confirm `docker.yml` produces `latest` tag only for `v*` tags (not branch pushes)