### PR TITLE
feat(gateway): Postgres backends for gateway (Wave 1, Lane C)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"sync/atomic"
 	"syscall"
 	"time"
 

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/disgoorg/disgo/voice"
 	"github.com/disgoorg/godave/golibdave"
 	"github.com/disgoorg/godave/libdave"
+	"github.com/jackc/pgx/v5/pgxpool"
 	anyllmlib "github.com/mozilla-ai/any-llm-go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -281,6 +283,19 @@ func runGateway(cfg *config.Config) int {
 
 	printStartupSummary(cfg, "gateway")
 
+	// ── Database ──────────────────────────────────────────────────────────────
+	dsn := os.Getenv("GLYPHOXA_DATABASE_DSN")
+	if dsn == "" {
+		slog.Error("GLYPHOXA_DATABASE_DSN not set — database is required for gateway mode")
+		return 1
+	}
+	pool, err := openGatewayPool(ctx, dsn)
+	if err != nil {
+		slog.Error("failed to connect to database", "err", err)
+		return 1
+	}
+	defer pool.Close()
+
 	// ── Admin API ─────────────────────────────────────────────────────────────
 	adminKey := os.Getenv("GLYPHOXA_ADMIN_KEY")
 	if adminKey == "" {
@@ -292,7 +307,11 @@ func runGateway(cfg *config.Config) int {
 	botMgr := gw.NewBotManager()
 	botConnector := gw.NewDiscordBotConnector(botMgr)
 
-	adminStore := gw.NewMemAdminStore()
+	adminStore, err := gw.NewPostgresAdminStore(ctx, pool)
+	if err != nil {
+		slog.Error("failed to create postgres admin store", "err", err)
+		return 1
+	}
 	adminAPI := gw.NewAdminAPI(adminStore, adminKey, botConnector)
 
 	adminAddr := cfg.Server.ListenAddr
@@ -319,7 +338,11 @@ func runGateway(cfg *config.Config) int {
 	observeSrv := startObserveServer(cfg)
 
 	// ── Session Orchestrator ─────────────────────────────────────────────────
-	orch := sessionorch.NewMemoryOrchestrator()
+	orch, err := sessionorch.NewPostgresOrchestrator(ctx, pool)
+	if err != nil {
+		slog.Error("failed to create postgres orchestrator", "err", err)
+		return 1
+	}
 	callbackBridge := sessionorch.NewCallbackBridge(orch)
 
 	// ── gRPC server (receives worker callbacks) ──────────────────────────────
@@ -386,6 +409,27 @@ func runGateway(cfg *config.Config) int {
 
 	slog.Info("goodbye")
 	return 0
+}
+
+// openGatewayPool creates a shared pgxpool.Pool for the gateway database.
+func openGatewayPool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
+	poolCfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: parse database DSN: %w", err)
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: create connection pool: %w", err)
+	}
+
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("gateway: ping database: %w", err)
+	}
+
+	slog.Info("database connection established")
+	return pool, nil
 }
 
 // runWorker runs the worker mode: voice pipeline execution, receiving

--- a/internal/gateway/adminstore_postgres.go
+++ b/internal/gateway/adminstore_postgres.go
@@ -1,0 +1,164 @@
+package gateway
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/MrWong99/glyphoxa/internal/config"
+)
+
+//go:embed migrations/*.sql
+var adminMigrationsFS embed.FS
+
+// Compile-time interface assertion.
+var _ AdminStore = (*PostgresAdminStore)(nil)
+
+// PostgresAdminStore is a PostgreSQL-backed implementation of AdminStore.
+// It manages tenant records in the tenants table.
+//
+// All methods are safe for concurrent use (backed by pgxpool).
+type PostgresAdminStore struct {
+	pool *pgxpool.Pool
+}
+
+// adminMigrationFiles lists the up-migration files in order.
+var adminMigrationFiles = []string{
+	"migrations/000001_tenants.up.sql",
+}
+
+// NewPostgresAdminStore creates a PostgreSQL-backed admin store.
+// It runs migrations to ensure the tenants table exists.
+func NewPostgresAdminStore(ctx context.Context, pool *pgxpool.Pool) (*PostgresAdminStore, error) {
+	if err := runAdminMigrations(ctx, pool); err != nil {
+		return nil, fmt.Errorf("gateway: run admin migrations: %w", err)
+	}
+	return &PostgresAdminStore{pool: pool}, nil
+}
+
+// runAdminMigrations applies the embedded SQL migration files in order.
+func runAdminMigrations(ctx context.Context, pool *pgxpool.Pool) error {
+	for _, f := range adminMigrationFiles {
+		upSQL, err := adminMigrationsFS.ReadFile(f)
+		if err != nil {
+			return fmt.Errorf("read migration %s: %w", f, err)
+		}
+
+		_, err = pool.Exec(ctx, string(upSQL))
+		if err != nil {
+			return fmt.Errorf("exec migration %s: %w", f, err)
+		}
+	}
+
+	slog.Info("gateway: admin migrations applied")
+	return nil
+}
+
+// CreateTenant inserts a new tenant. Returns an error if the ID already exists.
+func (s *PostgresAdminStore) CreateTenant(ctx context.Context, t Tenant) error {
+	tag, err := s.pool.Exec(ctx, `
+		INSERT INTO tenants (id, license_tier, bot_token, guild_ids, monthly_session_hours, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, t.ID, t.LicenseTier.String(), t.BotToken, t.GuildIDs, t.MonthlySessionHours, t.CreatedAt, t.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("gateway: create tenant %q: %w", t.ID, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("gateway: tenant %q already exists", t.ID)
+	}
+	return nil
+}
+
+// GetTenant returns a tenant by ID. Returns an error if not found.
+func (s *PostgresAdminStore) GetTenant(ctx context.Context, id string) (Tenant, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT id, license_tier, bot_token, guild_ids, monthly_session_hours, created_at, updated_at
+		FROM tenants
+		WHERE id = $1
+	`, id)
+
+	return scanTenant(row)
+}
+
+// UpdateTenant updates an existing tenant record. Returns an error if not found.
+func (s *PostgresAdminStore) UpdateTenant(ctx context.Context, t Tenant) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE tenants
+		SET license_tier = $2, bot_token = $3, guild_ids = $4,
+		    monthly_session_hours = $5, updated_at = now()
+		WHERE id = $1
+	`, t.ID, t.LicenseTier.String(), t.BotToken, t.GuildIDs, t.MonthlySessionHours)
+	if err != nil {
+		return fmt.Errorf("gateway: update tenant %q: %w", t.ID, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("gateway: tenant %q not found", t.ID)
+	}
+	return nil
+}
+
+// DeleteTenant removes a tenant by ID. Returns an error if not found.
+func (s *PostgresAdminStore) DeleteTenant(ctx context.Context, id string) error {
+	tag, err := s.pool.Exec(ctx, `
+		DELETE FROM tenants WHERE id = $1
+	`, id)
+	if err != nil {
+		return fmt.Errorf("gateway: delete tenant %q: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("gateway: tenant %q not found", id)
+	}
+	return nil
+}
+
+// ListTenants returns all tenants ordered by ID.
+func (s *PostgresAdminStore) ListTenants(ctx context.Context) ([]Tenant, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, license_tier, bot_token, guild_ids, monthly_session_hours, created_at, updated_at
+		FROM tenants
+		ORDER BY id
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: list tenants: %w", err)
+	}
+	defer rows.Close()
+
+	var tenants []Tenant
+	for rows.Next() {
+		t, err := scanTenant(rows)
+		if err != nil {
+			return nil, err
+		}
+		tenants = append(tenants, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("gateway: list tenants: %w", err)
+	}
+	return tenants, nil
+}
+
+// scanTenant reads a single tenant row into a Tenant struct.
+func scanTenant(row pgx.Row) (Tenant, error) {
+	var t Tenant
+	var tierStr string
+
+	err := row.Scan(&t.ID, &tierStr, &t.BotToken, &t.GuildIDs, &t.MonthlySessionHours, &t.CreatedAt, &t.UpdatedAt)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return Tenant{}, fmt.Errorf("gateway: tenant not found")
+		}
+		return Tenant{}, fmt.Errorf("gateway: scan tenant: %w", err)
+	}
+
+	tier, err := config.ParseLicenseTier(tierStr)
+	if err != nil {
+		return Tenant{}, fmt.Errorf("gateway: parse license tier %q: %w", tierStr, err)
+	}
+	t.LicenseTier = tier
+
+	return t, nil
+}

--- a/internal/gateway/migrations/000001_tenants.up.sql
+++ b/internal/gateway/migrations/000001_tenants.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS tenants (
+    id                    TEXT        PRIMARY KEY,
+    license_tier          TEXT        NOT NULL DEFAULT 'shared',
+    bot_token             TEXT        NOT NULL DEFAULT '',
+    guild_ids             TEXT[]      DEFAULT '{}',
+    monthly_session_hours NUMERIC(10,2) NOT NULL DEFAULT 0,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenants_tier ON tenants (license_tier);


### PR DESCRIPTION
## Summary

- **Phase 1 — DB pool setup:** `runGateway()` reads `GLYPHOXA_DATABASE_DSN` env var, creates a shared `*pgxpool.Pool` via `openGatewayPool()`. Errors immediately if DSN is empty (DB is required, no in-memory fallback).
- **Phase 2 — Wire PostgresOrchestrator:** Replaces `sessionorch.NewMemoryOrchestrator()` with `sessionorch.NewPostgresOrchestrator(ctx, pool)` so session state persists across gateway restarts.
- **Phase 3 — PostgresAdminStore:** New `internal/gateway/adminstore_postgres.go` implementing the `AdminStore` interface with PostgreSQL. Includes `migrations/000001_tenants.up.sql` with idempotent DDL, full CRUD operations, compile-time interface assertion `var _ AdminStore = (*PostgresAdminStore)(nil)`, and error wrapping following project conventions.

### Schema
```sql
tenants(id TEXT PK, license_tier TEXT, bot_token TEXT, guild_ids TEXT[],
        monthly_session_hours NUMERIC(10,2), created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ)
```

### Files changed
- `cmd/glyphoxa/main.go` — DB pool setup, wire PostgresAdminStore + PostgresOrchestrator, `openGatewayPool()` helper
- `internal/gateway/adminstore_postgres.go` — new PostgresAdminStore implementation
- `internal/gateway/migrations/000001_tenants.up.sql` — tenants table migration

## Test plan
- [x] `go build ./internal/gateway/` compiles cleanly
- [x] `go test -race -count=1 ./internal/gateway/` passes (existing admin API tests still work)
- [ ] Integration test with real PostgreSQL (requires DB — deferred to CI or manual)
- [ ] Verify tenant CRUD operations persist across gateway restart