### PR TITLE
feat(audio): voice-only Discord platform + export shared app helpers

### DIFF
--- a/internal/app/exports.go
+++ b/internal/app/exports.go
@@ -1,0 +1,99 @@
+// This file exports package-level helpers so they can be reused by the worker
+// RuntimeFactory (cmd/glyphoxa runWorker) without duplicating logic. The
+// unexported originals remain for backward compatibility within the package.
+
+package app
+
+import (
+	"context"
+
+	"github.com/MrWong99/glyphoxa/internal/agent"
+	"github.com/MrWong99/glyphoxa/internal/agent/orchestrator"
+	"github.com/MrWong99/glyphoxa/internal/config"
+	"github.com/MrWong99/glyphoxa/internal/engine"
+	"github.com/MrWong99/glyphoxa/internal/mcp"
+	"github.com/MrWong99/glyphoxa/internal/transcript"
+	"github.com/MrWong99/glyphoxa/pkg/audio"
+	"github.com/MrWong99/glyphoxa/pkg/memory"
+	"github.com/MrWong99/glyphoxa/pkg/provider/stt"
+	"github.com/MrWong99/glyphoxa/pkg/provider/vad"
+)
+
+// BuildEngine constructs the appropriate VoiceEngine for an NPC config.
+// Exported wrapper around buildEngine for use by the worker RuntimeFactory.
+func BuildEngine(providers *Providers, npc config.NPCConfig, ttsEntry config.ProviderEntry) (engine.VoiceEngine, error) {
+	return buildEngine(providers, npc, ttsEntry)
+}
+
+// IdentityFromConfig converts a config.NPCConfig to an agent.NPCIdentity.
+// Exported wrapper around identityFromConfig.
+func IdentityFromConfig(npc config.NPCConfig) agent.NPCIdentity {
+	return identityFromConfig(npc)
+}
+
+// ConfigBudgetTier converts a config.BudgetTier string to mcp.BudgetTier.
+// Exported wrapper around configBudgetTier.
+func ConfigBudgetTier(tier config.BudgetTier) mcp.BudgetTier {
+	return configBudgetTier(tier)
+}
+
+// TTSFormatFromConfig returns the TTS output sample rate and channel count
+// from a TTS provider config entry.
+// Exported wrapper around ttsFormatFromConfig.
+func TTSFormatFromConfig(entry config.ProviderEntry) (sampleRate, channels int) {
+	return ttsFormatFromConfig(entry)
+}
+
+// RegisterNPCEntities upserts NPC entities in the knowledge graph.
+// Exported wrapper around registerNPCEntities.
+func RegisterNPCEntities(ctx context.Context, graph memory.KnowledgeGraph, npcs []config.NPCConfig) {
+	registerNPCEntities(ctx, graph, npcs)
+}
+
+// VADConfigFromProvider extracts VAD session parameters from a provider config.
+// Exported wrapper around vadConfigFromProvider.
+func VADConfigFromProvider(entry config.ProviderEntry) vad.Config {
+	return vadConfigFromProvider(entry)
+}
+
+// STTConfigFromProvider extracts STT stream parameters from a provider config.
+// Exported wrapper around sttConfigFromProvider.
+func STTConfigFromProvider(entry config.ProviderEntry) stt.StreamConfig {
+	return sttConfigFromProvider(entry)
+}
+
+// AudioPipelineConfig holds all dependencies for an [AudioPipeline].
+// Exported version of audioPipelineConfig for use by the worker RuntimeFactory.
+type AudioPipelineConfig struct {
+	Conn        audio.Connection
+	VADEngine   vad.Engine
+	STTProvider stt.Provider
+	Orch        *orchestrator.Orchestrator
+	Mixer       audio.Mixer
+	VADCfg      vad.Config
+	STTCfg      stt.StreamConfig
+	Ctx         context.Context
+	Pipeline    transcript.Pipeline // may be nil — correction is skipped when nil
+	Entities    func() []string     // returns current entity names; may be nil
+}
+
+// AudioPipeline is the exported type alias for the audio pipeline.
+// Use [NewAudioPipeline] to create one.
+type AudioPipeline = audioPipeline
+
+// NewAudioPipeline creates an AudioPipeline from the given exported config.
+// Call Start to begin processing and Stop to tear down.
+func NewAudioPipeline(cfg AudioPipelineConfig) *AudioPipeline {
+	return newAudioPipeline(audioPipelineConfig{
+		conn:        cfg.Conn,
+		vadEngine:   cfg.VADEngine,
+		sttProvider: cfg.STTProvider,
+		orch:        cfg.Orch,
+		mixer:       cfg.Mixer,
+		vadCfg:      cfg.VADCfg,
+		sttCfg:      cfg.STTCfg,
+		ctx:         cfg.Ctx,
+		pipeline:    cfg.Pipeline,
+		entities:    cfg.Entities,
+	})
+}

--- a/pkg/audio/discord/voice_only.go
+++ b/pkg/audio/discord/voice_only.go
@@ -1,0 +1,128 @@
+package discord
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MrWong99/glyphoxa/pkg/audio"
+	"github.com/disgoorg/disgo"
+	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/disgo/cache"
+	"github.com/disgoorg/disgo/gateway"
+	"github.com/disgoorg/disgo/voice"
+	"github.com/disgoorg/snowflake/v2"
+)
+
+// Compile-time interface assertion.
+var _ audio.Platform = (*VoiceOnlyPlatform)(nil)
+
+// VoiceOnlyOption configures a [VoiceOnlyPlatform].
+type VoiceOnlyOption func(*voiceOnlyConfig)
+
+type voiceOnlyConfig struct {
+	voiceOpts []voice.ManagerConfigOpt
+}
+
+// WithVoiceManagerOpts passes additional [voice.ManagerConfigOpt] to the
+// underlying disgo client (e.g., for DAVE E2EE encryption).
+func WithVoiceManagerOpts(opts ...voice.ManagerConfigOpt) VoiceOnlyOption {
+	return func(c *voiceOnlyConfig) {
+		c.voiceOpts = append(c.voiceOpts, opts...)
+	}
+}
+
+// VoiceOnlyPlatform is a minimal Discord client that provides only voice
+// channel connectivity. Unlike a full discord.Bot, it does not register slash
+// commands, handle interaction events, or manage guild state beyond what is
+// required for voice connections.
+//
+// It is designed for distributed-mode workers that receive session parameters
+// via gRPC and only need to join a voice channel with a tenant's bot token.
+//
+// VoiceOnlyPlatform implements [audio.Platform].
+// All exported methods are safe for concurrent use.
+type VoiceOnlyPlatform struct {
+	client    *bot.Client
+	inner     *Platform
+	guildID   snowflake.ID
+	closeOnce sync.Once
+}
+
+// NewVoiceOnlyPlatform creates a minimal disgo client with only voice
+// capabilities and opens the Discord gateway. The client has no slash command
+// handlers, no interaction event listeners, and minimal cache (voice states
+// only).
+//
+// The guildID parameter scopes the platform to a single guild. Call Connect
+// to join a voice channel within that guild.
+//
+// Close must be called when the platform is no longer needed.
+func NewVoiceOnlyPlatform(ctx context.Context, token, guildID string, opts ...VoiceOnlyOption) (*VoiceOnlyPlatform, error) {
+	gID, err := snowflake.Parse(guildID)
+	if err != nil {
+		return nil, fmt.Errorf("discord: parse guild ID %q: %w", guildID, err)
+	}
+
+	var cfg voiceOnlyConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	botOpts := []bot.ConfigOpt{
+		bot.WithDefaultGateway(),
+		bot.WithCacheConfigOpts(
+			cache.WithCaches(cache.FlagVoiceStates),
+		),
+		bot.WithGatewayConfigOpts(
+			gateway.WithIntents(
+				gateway.IntentGuildVoiceStates,
+			),
+		),
+	}
+	if len(cfg.voiceOpts) > 0 {
+		botOpts = append(botOpts, bot.WithVoiceManagerConfigOpts(cfg.voiceOpts...))
+	}
+
+	client, err := disgo.New(token, botOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("discord: create voice-only client: %w", err)
+	}
+
+	if err := client.OpenGateway(ctx); err != nil {
+		client.Close(ctx)
+		return nil, fmt.Errorf("discord: open voice-only gateway: %w", err)
+	}
+
+	platform := New(client.VoiceManager, gID)
+
+	slog.Info("discord: voice-only platform ready", "guild_id", guildID)
+
+	return &VoiceOnlyPlatform{
+		client:  client,
+		inner:   platform,
+		guildID: gID,
+	}, nil
+}
+
+// Connect joins the voice channel identified by channelID and returns an
+// active [audio.Connection].
+func (p *VoiceOnlyPlatform) Connect(ctx context.Context, channelID string) (audio.Connection, error) {
+	return p.inner.Connect(ctx, channelID)
+}
+
+// Close disconnects from Discord and releases all resources. It is safe to
+// call more than once; subsequent calls are no-ops.
+func (p *VoiceOnlyPlatform) Close() error {
+	p.closeOnce.Do(func() {
+		if p.client != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			p.client.Close(ctx)
+			slog.Info("discord: voice-only platform closed", "guild_id", p.guildID)
+		}
+	})
+	return nil
+}

--- a/pkg/audio/discord/voice_only_test.go
+++ b/pkg/audio/discord/voice_only_test.go
@@ -1,0 +1,39 @@
+package discord
+
+import (
+	"testing"
+
+	"github.com/MrWong99/glyphoxa/pkg/audio"
+)
+
+// ─── compile-time interface assertions ───────────────────────────────────────
+
+var _ audio.Platform = (*VoiceOnlyPlatform)(nil)
+
+// ─── VoiceOnlyPlatform tests ─────────────────────────────────────────────────
+
+// TestNewVoiceOnlyPlatform_InvalidGuildID verifies that an unparseable guild ID
+// returns an error without attempting a Discord connection.
+func TestNewVoiceOnlyPlatform_InvalidGuildID(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewVoiceOnlyPlatform(t.Context(), "fake-token", "not-a-snowflake")
+	if err == nil {
+		t.Fatal("expected error for invalid guild ID, got nil")
+	}
+}
+
+// TestVoiceOnlyPlatform_CloseNil verifies that Close on a zero-value
+// VoiceOnlyPlatform does not panic.
+func TestVoiceOnlyPlatform_CloseNil(t *testing.T) {
+	t.Parallel()
+
+	p := &VoiceOnlyPlatform{}
+	// Close should not panic even with nil client.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Close panicked: %v", r)
+		}
+	}()
+	_ = p.Close()
+}


### PR DESCRIPTION
## Summary

**Wave 1 Lane D** of distributed mode production readiness.

- **Voice-only platform** (`pkg/audio/discord/voice_only.go`): `NewVoiceOnlyPlatform(ctx, token, guildID)` creates a minimal disgo client with ONLY voice capabilities — no slash commands, no event routing, minimal cache (voice states only). Implements `audio.Platform`. Includes `WithVoiceManagerOpts` for DAVE E2EE support. Designed for distributed-mode workers that connect directly to Discord voice via tenant bot tokens received over gRPC.

- **Exported shared helpers** (`internal/app/exports.go`): Exports `BuildEngine`, `IdentityFromConfig`, `ConfigBudgetTier`, `TTSFormatFromConfig`, `RegisterNPCEntities`, `VADConfigFromProvider`, `STTConfigFromProvider`, `NewAudioPipeline`, and `AudioPipelineConfig` — all as additive wrappers around existing unexported functions. No behavior changes. These are needed by the Wave 2 worker `RuntimeFactory` (Lane G).

## Test plan

- [x] `go build ./pkg/audio/discord/...` passes
- [x] `go build ./internal/app/...` passes
- [x] `go test -race -count=1 ./pkg/audio/discord/...` passes (interface assertion, invalid guild ID, nil-safe Close)
- [x] `go test -race -count=1 ./internal/app/...` passes (all existing tests unaffected)
- [x] `go vet` clean on both packages
- [x] `gofmt` compliant
- [ ] Full voice integration requires a real Discord bot token (manual test)