### PR TITLE
feat(gateway): readiness checks, guild filtering, faster zombie cleanup (Wave 1 Lane E)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -303,20 +304,21 @@ func runGateway(cfg *config.Config) int {
 		Addr:    adminAddr,
 		Handler: adminAPI.Handler(),
 	}
+	// Track server readiness with atomic flags for health checks.
+	var grpcReady, adminReady atomic.Bool
+
 	go func() {
 		ln, err := net.Listen("tcp", adminAddr)
 		if err != nil {
 			slog.Error("admin API listen failed", "addr", adminAddr, "err", err)
 			return
 		}
+		adminReady.Store(true)
 		slog.Info("admin API started", "addr", ln.Addr().String())
 		if err := adminSrv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			slog.Error("admin API error", "err", err)
 		}
 	}()
-
-	// ── Observability ─────────────────────────────────────────────────────────
-	observeSrv := startObserveServer(cfg)
 
 	// ── Session Orchestrator ─────────────────────────────────────────────────
 	orch := sessionorch.NewMemoryOrchestrator()
@@ -336,22 +338,45 @@ func runGateway(cfg *config.Config) int {
 			slog.Error("gateway gRPC listen failed", "addr", grpcAddr, "err", err)
 			return
 		}
+		grpcReady.Store(true)
 		slog.Info("gateway gRPC server started", "addr", ln.Addr().String())
 		if err := gwGRPCServer.Serve(ln); err != nil {
 			slog.Error("gateway gRPC server error", "err", err)
 		}
 	}()
 
+	// ── Observability ─────────────────────────────────────────────────────────
+	observeSrv := startObserveServer(cfg,
+		health.Checker{
+			Name: "grpc",
+			Check: func(_ context.Context) error {
+				if !grpcReady.Load() {
+					return fmt.Errorf("gRPC server not listening")
+				}
+				return nil
+			},
+		},
+		health.Checker{
+			Name: "admin_api",
+			Check: func(_ context.Context) error {
+				if !adminReady.Load() {
+					return fmt.Errorf("admin API not listening")
+				}
+				return nil
+			},
+		},
+	)
+
 	// ── Zombie session cleanup ───────────────────────────────────────────────
 	go func() {
-		ticker := time.NewTicker(30 * time.Second)
+		ticker := time.NewTicker(15 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if n, err := orch.CleanupZombies(ctx, 90*time.Second); err != nil {
+				if n, err := orch.CleanupZombies(ctx, 45*time.Second); err != nil {
 					slog.Warn("zombie cleanup error", "err", err)
 				} else if n > 0 {
 					slog.Info("cleaned up zombie sessions", "count", n)
@@ -442,6 +467,9 @@ func runWorker(cfg *config.Config) int {
 	if grpcAddr == "" {
 		grpcAddr = ":50051"
 	}
+	// Track server readiness with an atomic flag for health checks.
+	var workerGRPCReady atomic.Bool
+
 	wkGRPCServer := grpc.NewServer()
 	grpctransport.NewWorkerServer(handler).Register(wkGRPCServer)
 
@@ -451,6 +479,7 @@ func runWorker(cfg *config.Config) int {
 			slog.Error("worker gRPC listen failed", "addr", grpcAddr, "err", err)
 			return
 		}
+		workerGRPCReady.Store(true)
 		slog.Info("worker gRPC server started", "addr", ln.Addr().String())
 		if err := wkGRPCServer.Serve(ln); err != nil {
 			slog.Error("worker gRPC server error", "err", err)
@@ -478,7 +507,17 @@ func runWorker(cfg *config.Config) int {
 	}
 
 	// ── Observability ─────────────────────────────────────────────────────────
-	observeSrv := startObserveServer(cfg)
+	observeSrv := startObserveServer(cfg,
+		health.Checker{
+			Name: "grpc",
+			Check: func(_ context.Context) error {
+				if !workerGRPCReady.Load() {
+					return fmt.Errorf("gRPC server not listening")
+				}
+				return nil
+			},
+		},
+	)
 
 	slog.Info("worker ready — waiting for gRPC commands",
 		"mode", "worker",

--- a/internal/gateway/botconnector.go
+++ b/internal/gateway/botconnector.go
@@ -50,7 +50,7 @@ func (c *DiscordBotConnector) ConnectBot(ctx context.Context, tenantID, botToken
 		return fmt.Errorf("gateway: open discord gateway for tenant %q: %w", tenantID, err)
 	}
 
-	if err := c.mgr.AddBot(tenantID, client); err != nil {
+	if err := c.mgr.AddBot(tenantID, client, guildIDs); err != nil {
 		client.Close(ctx)
 		return fmt.Errorf("gateway: register bot for tenant %q: %w", tenantID, err)
 	}

--- a/internal/gateway/botmanager.go
+++ b/internal/gateway/botmanager.go
@@ -7,16 +7,18 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"maps"
 	"sync"
 
 	"github.com/disgoorg/disgo/bot"
 )
 
-// botEntry wraps a disgo client with inflight tracking.
+// botEntry wraps a disgo client with inflight tracking and guild filtering.
 // Follows the serverConn pattern from internal/mcp/mcphost/host.go.
 type botEntry struct {
 	client   *bot.Client
+	guildIDs map[string]struct{} // allowed guilds (empty = all)
 	inflight sync.WaitGroup
 }
 
@@ -36,9 +38,12 @@ func NewBotManager() *BotManager {
 	}
 }
 
-// AddBot registers a bot client for the given tenant. It returns an error if
-// a bot is already registered for tenantID.
-func (bm *BotManager) AddBot(tenantID string, client *bot.Client) error {
+// AddBot registers a bot client for the given tenant with an optional guild
+// allowlist. If guildIDs is non-empty, only events from those guilds will be
+// dispatched via [RouteEventForGuild]. An empty allowlist means all guilds are
+// allowed (backward compatible). It returns an error if a bot is already
+// registered for tenantID.
+func (bm *BotManager) AddBot(tenantID string, client *bot.Client, guildIDs []string) error {
 	bm.mu.Lock()
 	defer bm.mu.Unlock()
 
@@ -46,7 +51,11 @@ func (bm *BotManager) AddBot(tenantID string, client *bot.Client) error {
 		return fmt.Errorf("gateway: bot already registered for tenant %q", tenantID)
 	}
 
-	bm.bots[tenantID] = &botEntry{client: client}
+	allowed := make(map[string]struct{}, len(guildIDs))
+	for _, id := range guildIDs {
+		allowed[id] = struct{}{}
+	}
+	bm.bots[tenantID] = &botEntry{client: client, guildIDs: allowed}
 	return nil
 }
 
@@ -94,6 +103,33 @@ func (bm *BotManager) RouteEvent(tenantID string, handler func(*bot.Client)) {
 	if !ok {
 		bm.mu.RUnlock()
 		return
+	}
+	entry.inflight.Add(1)
+	client := entry.client
+	bm.mu.RUnlock()
+
+	defer entry.inflight.Done()
+	handler(client)
+}
+
+// RouteEventForGuild dispatches handler only if guildID is in the tenant's
+// allowlist. An empty allowlist means all guilds are permitted (backward
+// compatible). If no bot is registered for tenantID, handler is not called.
+func (bm *BotManager) RouteEventForGuild(tenantID, guildID string, handler func(*bot.Client)) {
+	bm.mu.RLock()
+	entry, ok := bm.bots[tenantID]
+	if !ok {
+		bm.mu.RUnlock()
+		return
+	}
+	// If guild filtering is configured, check allowlist.
+	if len(entry.guildIDs) > 0 {
+		if _, allowed := entry.guildIDs[guildID]; !allowed {
+			bm.mu.RUnlock()
+			slog.Debug("gateway: filtered event for non-allowed guild",
+				"tenant_id", tenantID, "guild_id", guildID)
+			return
+		}
 	}
 	entry.inflight.Add(1)
 	client := entry.client

--- a/internal/gateway/botmanager_test.go
+++ b/internal/gateway/botmanager_test.go
@@ -27,7 +27,7 @@ func TestAddBot(t *testing.T) {
 		{
 			name: "duplicate error",
 			setup: func(bm *BotManager) {
-				_ = bm.AddBot("tenant-1", nil)
+				_ = bm.AddBot("tenant-1", nil, nil)
 			},
 			tenantID:  "tenant-1",
 			wantErr:   true,
@@ -42,7 +42,7 @@ func TestAddBot(t *testing.T) {
 			bm := NewBotManager()
 			tt.setup(bm)
 
-			err := bm.AddBot(tt.tenantID, nil)
+			err := bm.AddBot(tt.tenantID, nil, nil)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -72,7 +72,7 @@ func TestRemoveBot(t *testing.T) {
 		{
 			name: "success",
 			setup: func(bm *BotManager) {
-				_ = bm.AddBot("tenant-1", nil)
+				_ = bm.AddBot("tenant-1", nil, nil)
 			},
 			tenantID: "tenant-1",
 			wantErr:  false,
@@ -119,7 +119,7 @@ func TestGet(t *testing.T) {
 	t.Parallel()
 
 	bm := NewBotManager()
-	_ = bm.AddBot("tenant-1", nil)
+	_ = bm.AddBot("tenant-1", nil, nil)
 
 	t.Run("found", func(t *testing.T) {
 		t.Parallel()
@@ -149,7 +149,7 @@ func TestRouteEvent(t *testing.T) {
 		t.Parallel()
 
 		bm := NewBotManager()
-		_ = bm.AddBot("tenant-1", nil)
+		_ = bm.AddBot("tenant-1", nil, nil)
 
 		called := false
 		bm.RouteEvent("tenant-1", func(c *bot.Client) {
@@ -181,12 +181,79 @@ func TestRouteEvent(t *testing.T) {
 	})
 }
 
+func TestRouteEventForGuild(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allowed guild", func(t *testing.T) {
+		t.Parallel()
+
+		bm := NewBotManager()
+		_ = bm.AddBot("tenant-1", nil, []string{"guild-a", "guild-b"})
+
+		called := false
+		bm.RouteEventForGuild("tenant-1", "guild-a", func(_ *bot.Client) {
+			called = true
+		})
+
+		if !called {
+			t.Error("handler was not called for allowed guild")
+		}
+	})
+
+	t.Run("blocked guild", func(t *testing.T) {
+		t.Parallel()
+
+		bm := NewBotManager()
+		_ = bm.AddBot("tenant-1", nil, []string{"guild-a", "guild-b"})
+
+		called := false
+		bm.RouteEventForGuild("tenant-1", "guild-c", func(_ *bot.Client) {
+			called = true
+		})
+
+		if called {
+			t.Error("handler should not have been called for blocked guild")
+		}
+	})
+
+	t.Run("empty allowlist allows all", func(t *testing.T) {
+		t.Parallel()
+
+		bm := NewBotManager()
+		_ = bm.AddBot("tenant-1", nil, nil)
+
+		called := false
+		bm.RouteEventForGuild("tenant-1", "any-guild", func(_ *bot.Client) {
+			called = true
+		})
+
+		if !called {
+			t.Error("handler was not called — empty allowlist should allow all guilds")
+		}
+	})
+
+	t.Run("not found tenant", func(t *testing.T) {
+		t.Parallel()
+
+		bm := NewBotManager()
+
+		called := false
+		bm.RouteEventForGuild("nonexistent", "guild-a", func(_ *bot.Client) {
+			called = true
+		})
+
+		if called {
+			t.Error("handler should not have been called for missing tenant")
+		}
+	})
+}
+
 func TestClose(t *testing.T) {
 	t.Parallel()
 
 	bm := NewBotManager()
-	_ = bm.AddBot("tenant-1", nil)
-	_ = bm.AddBot("tenant-2", nil)
+	_ = bm.AddBot("tenant-1", nil, nil)
+	_ = bm.AddBot("tenant-2", nil, nil)
 
 	bm.Close()
 
@@ -210,7 +277,7 @@ func TestConcurrentAccess(t *testing.T) {
 	// Pre-add half the tenants so RouteEvent and RemoveBot have targets.
 	for i := range numTenants / 2 {
 		tid := tenantID(i)
-		_ = bm.AddBot(tid, nil)
+		_ = bm.AddBot(tid, nil, nil)
 	}
 
 	var wg sync.WaitGroup
@@ -221,7 +288,7 @@ func TestConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			_ = bm.AddBot(tenantID(id), nil)
+			_ = bm.AddBot(tenantID(id), nil, nil)
 		}(i)
 	}
 


### PR DESCRIPTION
## Summary

Wave 1 Lane E — standalone gaps I4, I7, I2 from the distributed mode plan.

- **I4 — Gateway readiness checks:** Added `atomic.Bool` flags (`grpcReady`, `adminReady`) set when TCP listeners start in `runGateway()`. Passed as `health.Checker` instances to `startObserveServer()` so `/readyz` returns 503 until both gRPC and admin API are listening. Added equivalent `workerGRPCReady` check for `runWorker()`.
- **I7 — Faster zombie cleanup:** Reduced heartbeat timeout from 90s to 45s and cleanup interval from 30s to 15s in `runGateway()`. Worst-case crash detection drops from 120s to 60s.
- **I2 — Guild ID filtering:** Changed `BotManager.AddBot()` signature to accept `guildIDs []string`. Stores allowed guilds in `botEntry`. Added `RouteEventForGuild()` that checks the allowlist before dispatching events (empty allowlist = all guilds allowed, backward compatible). Updated `DiscordBotConnector.ConnectBot()` to pass `guildIDs` through.

## Test plan

- [x] `go test -race -count=1 ./internal/gateway/` — all tests pass including new `TestRouteEventForGuild` (allowed/blocked/empty allowlist/missing tenant)
- [x] `go test -race -count=1 ./internal/health/` — all existing health tests pass
- [ ] Integration: verify `/readyz` returns 503 on gateway startup, then 200 after listeners bind