### PR TITLE
feat(gateway): gRPC TLS, OTel interceptors, and usage/quota wiring (Wave 2, Lane I)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -38,6 +37,7 @@ import (
 	gw "github.com/MrWong99/glyphoxa/internal/gateway"
 	"github.com/MrWong99/glyphoxa/internal/gateway/grpctransport"
 	"github.com/MrWong99/glyphoxa/internal/gateway/sessionorch"
+	"github.com/MrWong99/glyphoxa/internal/gateway/usage"
 	"github.com/MrWong99/glyphoxa/internal/health"
 	"github.com/MrWong99/glyphoxa/internal/mcp"
 	"github.com/MrWong99/glyphoxa/internal/mcp/mcphost"
@@ -344,15 +344,37 @@ func runGateway(cfg *config.Config) int {
 		slog.Error("failed to create postgres orchestrator", "err", err)
 		return 1
 	}
-	callbackBridge := sessionorch.NewCallbackBridge(orch)
+
+	// ── Usage tracking + quota enforcement ────────────────────────────────────
+	usageStore := usage.NewPostgresStore(pool)
+	quotaLookup := func(ctx context.Context, tenantID string) (float64, error) {
+		t, err := adminStore.GetTenant(ctx, tenantID)
+		if err != nil {
+			return 0, err
+		}
+		return t.MonthlySessionHours, nil
+	}
+	guardedOrch := usage.NewQuotaGuard(orch, usageStore, quotaLookup)
+
+	callbackBridge := sessionorch.NewCallbackBridge(guardedOrch)
+	recordingBridge := usage.NewRecordingBridge(callbackBridge, guardedOrch, usageStore)
 
 	// ── gRPC server (receives worker callbacks) ──────────────────────────────
 	grpcAddr := os.Getenv("GLYPHOXA_GRPC_ADDR")
 	if grpcAddr == "" {
 		grpcAddr = ":50051"
 	}
-	gwGRPCServer := grpc.NewServer()
-	grpctransport.NewGatewayServer(callbackBridge).Register(gwGRPCServer)
+
+	grpcOpts := observe.GRPCServerOptions()
+	if tlsCred, err := observe.GRPCServerCredentials(); err != nil {
+		slog.Error("failed to load gRPC TLS credentials", "err", err)
+		return 1
+	} else if tlsCred != nil {
+		grpcOpts = append(grpcOpts, tlsCred)
+	}
+
+	gwGRPCServer := grpc.NewServer(grpcOpts...)
+	grpctransport.NewGatewayServer(recordingBridge).Register(gwGRPCServer)
 
 	go func() {
 		ln, err := net.Listen("tcp", grpcAddr)
@@ -479,7 +501,13 @@ func runWorker(cfg *config.Config) int {
 	gwAddr := os.Getenv("GLYPHOXA_GATEWAY_ADDR")
 	var callback gw.GatewayCallback
 	if gwAddr != "" {
-		gwConn, err := grpc.NewClient(gwAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		clientCred, err := observe.GRPCClientCredentials()
+		if err != nil {
+			slog.Error("failed to load gRPC client TLS credentials", "err", err)
+			return 1
+		}
+		dialOpts := append(observe.GRPCDialOptions(), clientCred)
+		gwConn, err := grpc.NewClient(gwAddr, dialOpts...)
 		if err != nil {
 			slog.Error("failed to connect to gateway", "addr", gwAddr, "err", err)
 			return 1
@@ -513,7 +541,15 @@ func runWorker(cfg *config.Config) int {
 	// Track server readiness with an atomic flag for health checks.
 	var workerGRPCReady atomic.Bool
 
-	wkGRPCServer := grpc.NewServer()
+	wkGRPCOpts := observe.GRPCServerOptions()
+	if tlsCred, err := observe.GRPCServerCredentials(); err != nil {
+		slog.Error("failed to load gRPC TLS credentials", "err", err)
+		return 1
+	} else if tlsCred != nil {
+		wkGRPCOpts = append(wkGRPCOpts, tlsCred)
+	}
+
+	wkGRPCServer := grpc.NewServer(wkGRPCOpts...)
 	grpctransport.NewWorkerServer(handler).Register(wkGRPCServer)
 
 	go func() {

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/tiktoken-go/tokenizer v0.7.0
 	github.com/yalue/onnxruntime_go v1.27.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.64.0
 	go.opentelemetry.io/otel/metric v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 h1:yI1/OhfEPy7J9eoa6Sj051C7n5dvpj0QX8g4sRchg04=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0/go.mod h1:NoUCKYWK+3ecatC4HjkRktREheMeEtrXoQxrqYFeHSc=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.66.0 h1:PnV4kVnw0zOmwwFkAzCN5O07fw1YOIQor120zrh0AVo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.66.0/go.mod h1:ofAwF4uinaf8SXdVzzbL4OsxJ3VfeEg3f/F6CeF49/Y=
 go.opentelemetry.io/otel v1.42.0 h1:lSQGzTgVR3+sgJDAU/7/ZMjN9Z+vUip7leaqBKy4sho=

--- a/internal/gateway/usage/recording_bridge.go
+++ b/internal/gateway/usage/recording_bridge.go
@@ -1,0 +1,88 @@
+package usage
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/MrWong99/glyphoxa/internal/gateway"
+	"github.com/MrWong99/glyphoxa/internal/gateway/sessionorch"
+)
+
+// Compile-time interface assertion.
+var _ gateway.GatewayCallback = (*RecordingBridge)(nil)
+
+// RecordingBridge wraps a [gateway.GatewayCallback] and records session
+// hours in the usage [Store] when a session transitions to ended.
+// It looks up session start times from the orchestrator to compute duration.
+type RecordingBridge struct {
+	inner gateway.GatewayCallback
+	orch  sessionorch.Orchestrator
+	usage Store
+}
+
+// NewRecordingBridge creates a GatewayCallback that records session hours
+// on session end, then delegates to the inner callback.
+func NewRecordingBridge(inner gateway.GatewayCallback, orch sessionorch.Orchestrator, usage Store) *RecordingBridge {
+	return &RecordingBridge{inner: inner, orch: orch, usage: usage}
+}
+
+// ReportState delegates to the inner callback. When the state is
+// [gateway.SessionEnded], it records the session duration in the usage store.
+func (b *RecordingBridge) ReportState(ctx context.Context, sessionID string, state gateway.SessionState, errMsg string) error {
+	// Record usage before transitioning (session is still accessible).
+	if state == gateway.SessionEnded {
+		b.recordSessionHours(ctx, sessionID)
+	}
+
+	return b.inner.ReportState(ctx, sessionID, state, errMsg)
+}
+
+// Heartbeat delegates directly to the inner callback.
+func (b *RecordingBridge) Heartbeat(ctx context.Context, sessionID string) error {
+	return b.inner.Heartbeat(ctx, sessionID)
+}
+
+// recordSessionHours looks up the session, computes its duration, and
+// records it in the usage store. Errors are logged but not propagated
+// — session lifecycle must not fail due to metering errors.
+func (b *RecordingBridge) recordSessionHours(ctx context.Context, sessionID string) {
+	sess, err := b.orch.GetSession(ctx, sessionID)
+	if err != nil {
+		slog.Warn("usage: failed to look up session for recording", "session_id", sessionID, "err", err)
+		return
+	}
+
+	if sess.StartedAt.IsZero() {
+		slog.Warn("usage: session has no start time, skipping usage recording", "session_id", sessionID)
+		return
+	}
+
+	duration := time.Since(sess.StartedAt)
+	hours := duration.Hours()
+	if hours <= 0 {
+		return
+	}
+
+	delta := Record{
+		TenantID:     sess.TenantID,
+		Period:       CurrentPeriod(),
+		SessionHours: hours,
+	}
+
+	if err := b.usage.RecordUsage(ctx, sess.TenantID, delta); err != nil {
+		slog.Warn("usage: failed to record session hours",
+			"session_id", sessionID,
+			"tenant_id", sess.TenantID,
+			"hours", hours,
+			"err", err,
+		)
+		return
+	}
+
+	slog.Info("usage: recorded session hours",
+		"session_id", sessionID,
+		"tenant_id", sess.TenantID,
+		"hours", hours,
+	)
+}

--- a/internal/observe/grpc.go
+++ b/internal/observe/grpc.go
@@ -1,0 +1,103 @@
+package observe
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/MrWong99/glyphoxa/internal/config"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// GRPCServerOptions returns gRPC server options that add OTel stats handlers
+// for automatic trace propagation and RPC duration metrics. Append these to
+// any other server options (e.g. TLS credentials) when creating a
+// [grpc.Server].
+func GRPCServerOptions() []grpc.ServerOption {
+	return []grpc.ServerOption{
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.ChainUnaryInterceptor(TenantUnaryServerInterceptor()),
+		grpc.ChainStreamInterceptor(TenantStreamServerInterceptor()),
+	}
+}
+
+// GRPCDialOptions returns gRPC dial options that add OTel stats handlers
+// for automatic trace propagation and RPC duration metrics on the client
+// side. Append these to any other dial options (e.g. TLS credentials)
+// when creating a [grpc.ClientConn].
+func GRPCDialOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+	}
+}
+
+// tenantMDKey is the gRPC metadata key used to propagate tenant_id.
+const tenantMDKey = "x-tenant-id"
+
+// TenantUnaryServerInterceptor returns a [grpc.UnaryServerInterceptor] that
+// extracts tenant_id from incoming gRPC metadata and injects a
+// [config.TenantContext] into the request context. If no tenant_id metadata
+// is present the request proceeds without tenant context.
+func TenantUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		ctx = enrichWithTenant(ctx)
+		return handler(ctx, req)
+	}
+}
+
+// TenantStreamServerInterceptor returns a [grpc.StreamServerInterceptor]
+// that extracts tenant_id from incoming gRPC metadata and injects a
+// [config.TenantContext] into the stream context.
+func TenantStreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv any,
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		ctx := enrichWithTenant(ss.Context())
+		wrapped := &tenantServerStream{ServerStream: ss, ctx: ctx}
+		return handler(srv, wrapped)
+	}
+}
+
+// enrichWithTenant extracts tenant_id from gRPC metadata and returns a
+// context enriched with [config.TenantContext]. Returns ctx unchanged if
+// no tenant metadata is present.
+func enrichWithTenant(ctx context.Context) context.Context {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
+	}
+
+	vals := md.Get(tenantMDKey)
+	if len(vals) == 0 || vals[0] == "" {
+		return ctx
+	}
+
+	tenantID := vals[0]
+	slog.Debug("gRPC: tenant context extracted", "tenant_id", tenantID)
+
+	tc := config.TenantContext{
+		TenantID: tenantID,
+	}
+	return config.WithTenant(ctx, tc)
+}
+
+// tenantServerStream wraps a [grpc.ServerStream] to override Context()
+// with a tenant-enriched context.
+type tenantServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+// Context returns the tenant-enriched context.
+func (s *tenantServerStream) Context() context.Context {
+	return s.ctx
+}

--- a/internal/observe/grpctls.go
+++ b/internal/observe/grpctls.go
@@ -1,0 +1,114 @@
+package observe
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// TLS env var names read by [GRPCServerCredentials] and [GRPCClientCredentials].
+const (
+	envTLSCert = "GLYPHOXA_GRPC_TLS_CERT"
+	envTLSKey  = "GLYPHOXA_GRPC_TLS_KEY"
+	envTLSCA   = "GLYPHOXA_GRPC_TLS_CA"
+)
+
+// GRPCServerCredentials returns a [grpc.ServerOption] for TLS if the
+// GLYPHOXA_GRPC_TLS_CERT and GLYPHOXA_GRPC_TLS_KEY env vars are set.
+// When GLYPHOXA_GRPC_TLS_CA is also set, mutual TLS (mTLS) is enabled
+// and client certificates are verified against the CA bundle.
+//
+// Returns nil when TLS env vars are not set (caller should use insecure).
+func GRPCServerCredentials() (grpc.ServerOption, error) {
+	certFile := os.Getenv(envTLSCert)
+	keyFile := os.Getenv(envTLSKey)
+
+	if certFile == "" || keyFile == "" {
+		slog.Warn("gRPC TLS not configured — running insecure (set GLYPHOXA_GRPC_TLS_CERT and GLYPHOXA_GRPC_TLS_KEY to enable)")
+		return nil, nil
+	}
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("observe: load gRPC TLS cert/key: %w", err)
+	}
+
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	// Optional mTLS: require client certs verified against CA.
+	caFile := os.Getenv(envTLSCA)
+	if caFile != "" {
+		caBytes, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("observe: read gRPC TLS CA: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caBytes) {
+			return nil, fmt.Errorf("observe: no valid certs found in %s", caFile)
+		}
+		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+		tlsCfg.ClientCAs = pool
+		slog.Info("gRPC mTLS enabled", "cert", certFile, "key", keyFile, "ca", caFile)
+	} else {
+		slog.Info("gRPC TLS enabled (server-only)", "cert", certFile, "key", keyFile)
+	}
+
+	return grpc.Creds(credentials.NewTLS(tlsCfg)), nil
+}
+
+// GRPCClientCredentials returns a [grpc.DialOption] for TLS if the
+// GLYPHOXA_GRPC_TLS_CA env var is set (server certificate verification).
+// When GLYPHOXA_GRPC_TLS_CERT and GLYPHOXA_GRPC_TLS_KEY are also set,
+// the client presents a certificate for mTLS.
+//
+// Falls back to insecure credentials when no TLS env vars are set.
+func GRPCClientCredentials() (grpc.DialOption, error) {
+	caFile := os.Getenv(envTLSCA)
+	certFile := os.Getenv(envTLSCert)
+	keyFile := os.Getenv(envTLSKey)
+
+	if caFile == "" && certFile == "" {
+		slog.Warn("gRPC client TLS not configured — connecting insecure")
+		return grpc.WithTransportCredentials(insecure.NewCredentials()), nil
+	}
+
+	tlsCfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	// Server CA verification.
+	if caFile != "" {
+		caBytes, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("observe: read gRPC client CA: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caBytes) {
+			return nil, fmt.Errorf("observe: no valid certs found in %s", caFile)
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	// Optional client certificate for mTLS.
+	if certFile != "" && keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("observe: load gRPC client cert/key: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+		slog.Info("gRPC client mTLS enabled", "cert", certFile, "ca", caFile)
+	} else {
+		slog.Info("gRPC client TLS enabled (server verification only)", "ca", caFile)
+	}
+
+	return grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)), nil
+}


### PR DESCRIPTION
## Summary

Wave 2, Lane I: gRPC hardening, observability, and quota wiring for distributed mode.

- **I5 — gRPC TLS support**: `observe.GRPCServerCredentials()` and `observe.GRPCClientCredentials()` read TLS cert/key/CA from env vars (`GLYPHOXA_GRPC_TLS_CERT`, `GLYPHOXA_GRPC_TLS_KEY`, `GLYPHOXA_GRPC_TLS_CA`). Defaults to insecure with warning. Supports mTLS when CA is set. Applied to gateway server, worker server, and worker→gateway client.
- **I6 — gRPC observability interceptors**: `observe.GRPCServerOptions()` and `observe.GRPCDialOptions()` add OTel stats handlers (via `otelgrpc`) for automatic trace propagation and RPC duration metrics. `TenantUnaryServerInterceptor` / `TenantStreamServerInterceptor` extract `x-tenant-id` from gRPC metadata into `config.TenantContext`. Wired into both gateway and worker.
- **I3 — Usage/quota wiring**: `usage.QuotaGuard` wraps the orchestrator in `runGateway()` with a quota lookup against `AdminStore.GetTenant().MonthlySessionHours`. `usage.RecordingBridge` wraps `CallbackBridge` to record session hours on `SessionEnded` transitions. Metering errors are logged but don't block session lifecycle.

### New files
- `internal/observe/grpctls.go` — TLS credential helpers
- `internal/observe/grpc.go` — OTel interceptors + tenant extraction
- `internal/gateway/usage/recording_bridge.go` — Usage recording bridge

### Modified files
- `cmd/glyphoxa/main.go` — Wire TLS, OTel, and quota into gateway + worker
- `go.mod` / `go.sum` — Upgrade `otelgrpc` v0.61→v0.67

## Test plan
- [x] `go build ./internal/observe/...` passes
- [x] `go build ./internal/gateway/usage/...` passes
- [x] `go vet ./cmd/glyphoxa/...` passes
- [x] `go test -race -count=1 ./internal/observe/...` passes
- [x] `go test -race -count=1 ./internal/gateway/usage/...` passes
- [x] `go test -race -count=1 ./internal/gateway/sessionorch/...` passes
- [ ] Full binary link requires whisper.cpp libs (pre-existing env constraint)
- [ ] TLS: set env vars → verify encrypted gRPC connection
- [ ] Quota: create tenant with MonthlySessionHours > 0 → verify enforcement