### PR TITLE
feat(gateway): NPC gRPC extensions, gateway NPC commands, and recap (Wave 3, Lane J)

### DIFF
--- a/gen/glyphoxa/v1/session.pb.go
+++ b/gen/glyphoxa/v1/session.pb.go
@@ -768,6 +768,615 @@ func (*HeartbeatResponse) Descriptor() ([]byte, []int) {
 	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{11}
 }
 
+// NPCInfo describes an NPC within a running session.
+type NPCInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Muted         bool                   `protobuf:"varint,3,opt,name=muted,proto3" json:"muted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NPCInfo) Reset() {
+	*x = NPCInfo{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NPCInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NPCInfo) ProtoMessage() {}
+
+func (x *NPCInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NPCInfo.ProtoReflect.Descriptor instead.
+func (*NPCInfo) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *NPCInfo) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *NPCInfo) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *NPCInfo) GetMuted() bool {
+	if x != nil {
+		return x.Muted
+	}
+	return false
+}
+
+// ListNPCsRequest asks a worker for the NPCs in a session.
+type ListNPCsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListNPCsRequest) Reset() {
+	*x = ListNPCsRequest{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListNPCsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListNPCsRequest) ProtoMessage() {}
+
+func (x *ListNPCsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListNPCsRequest.ProtoReflect.Descriptor instead.
+func (*ListNPCsRequest) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *ListNPCsRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+// ListNPCsResponse returns the NPCs in a session.
+type ListNPCsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Npcs          []*NPCInfo             `protobuf:"bytes,1,rep,name=npcs,proto3" json:"npcs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListNPCsResponse) Reset() {
+	*x = ListNPCsResponse{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListNPCsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListNPCsResponse) ProtoMessage() {}
+
+func (x *ListNPCsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListNPCsResponse.ProtoReflect.Descriptor instead.
+func (*ListNPCsResponse) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *ListNPCsResponse) GetNpcs() []*NPCInfo {
+	if x != nil {
+		return x.Npcs
+	}
+	return nil
+}
+
+// MuteNPCRequest asks a worker to mute a specific NPC.
+type MuteNPCRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	NpcName       string                 `protobuf:"bytes,2,opt,name=npc_name,json=npcName,proto3" json:"npc_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MuteNPCRequest) Reset() {
+	*x = MuteNPCRequest{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuteNPCRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuteNPCRequest) ProtoMessage() {}
+
+func (x *MuteNPCRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuteNPCRequest.ProtoReflect.Descriptor instead.
+func (*MuteNPCRequest) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *MuteNPCRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *MuteNPCRequest) GetNpcName() string {
+	if x != nil {
+		return x.NpcName
+	}
+	return ""
+}
+
+// MuteNPCResponse is the worker's reply after muting an NPC.
+type MuteNPCResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MuteNPCResponse) Reset() {
+	*x = MuteNPCResponse{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuteNPCResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuteNPCResponse) ProtoMessage() {}
+
+func (x *MuteNPCResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuteNPCResponse.ProtoReflect.Descriptor instead.
+func (*MuteNPCResponse) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{16}
+}
+
+// UnmuteNPCRequest asks a worker to unmute a specific NPC.
+type UnmuteNPCRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	NpcName       string                 `protobuf:"bytes,2,opt,name=npc_name,json=npcName,proto3" json:"npc_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnmuteNPCRequest) Reset() {
+	*x = UnmuteNPCRequest{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnmuteNPCRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnmuteNPCRequest) ProtoMessage() {}
+
+func (x *UnmuteNPCRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnmuteNPCRequest.ProtoReflect.Descriptor instead.
+func (*UnmuteNPCRequest) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *UnmuteNPCRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *UnmuteNPCRequest) GetNpcName() string {
+	if x != nil {
+		return x.NpcName
+	}
+	return ""
+}
+
+// UnmuteNPCResponse is the worker's reply after unmuting an NPC.
+type UnmuteNPCResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnmuteNPCResponse) Reset() {
+	*x = UnmuteNPCResponse{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnmuteNPCResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnmuteNPCResponse) ProtoMessage() {}
+
+func (x *UnmuteNPCResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnmuteNPCResponse.ProtoReflect.Descriptor instead.
+func (*UnmuteNPCResponse) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{18}
+}
+
+// MuteAllNPCsRequest asks a worker to mute all NPCs in a session.
+type MuteAllNPCsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MuteAllNPCsRequest) Reset() {
+	*x = MuteAllNPCsRequest{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuteAllNPCsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuteAllNPCsRequest) ProtoMessage() {}
+
+func (x *MuteAllNPCsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuteAllNPCsRequest.ProtoReflect.Descriptor instead.
+func (*MuteAllNPCsRequest) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *MuteAllNPCsRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+// MuteAllNPCsResponse returns how many NPCs were muted.
+type MuteAllNPCsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Count         int32                  `protobuf:"varint,1,opt,name=count,proto3" json:"count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MuteAllNPCsResponse) Reset() {
+	*x = MuteAllNPCsResponse{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuteAllNPCsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuteAllNPCsResponse) ProtoMessage() {}
+
+func (x *MuteAllNPCsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuteAllNPCsResponse.ProtoReflect.Descriptor instead.
+func (*MuteAllNPCsResponse) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *MuteAllNPCsResponse) GetCount() int32 {
+	if x != nil {
+		return x.Count
+	}
+	return 0
+}
+
+// UnmuteAllNPCsRequest asks a worker to unmute all NPCs in a session.
+type UnmuteAllNPCsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnmuteAllNPCsRequest) Reset() {
+	*x = UnmuteAllNPCsRequest{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnmuteAllNPCsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnmuteAllNPCsRequest) ProtoMessage() {}
+
+func (x *UnmuteAllNPCsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnmuteAllNPCsRequest.ProtoReflect.Descriptor instead.
+func (*UnmuteAllNPCsRequest) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *UnmuteAllNPCsRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+// UnmuteAllNPCsResponse returns how many NPCs were unmuted.
+type UnmuteAllNPCsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Count         int32                  `protobuf:"varint,1,opt,name=count,proto3" json:"count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnmuteAllNPCsResponse) Reset() {
+	*x = UnmuteAllNPCsResponse{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnmuteAllNPCsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnmuteAllNPCsResponse) ProtoMessage() {}
+
+func (x *UnmuteAllNPCsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnmuteAllNPCsResponse.ProtoReflect.Descriptor instead.
+func (*UnmuteAllNPCsResponse) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *UnmuteAllNPCsResponse) GetCount() int32 {
+	if x != nil {
+		return x.Count
+	}
+	return 0
+}
+
+// SpeakNPCRequest asks a worker to make an NPC speak pre-written text.
+type SpeakNPCRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	NpcName       string                 `protobuf:"bytes,2,opt,name=npc_name,json=npcName,proto3" json:"npc_name,omitempty"`
+	Text          string                 `protobuf:"bytes,3,opt,name=text,proto3" json:"text,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SpeakNPCRequest) Reset() {
+	*x = SpeakNPCRequest{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SpeakNPCRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SpeakNPCRequest) ProtoMessage() {}
+
+func (x *SpeakNPCRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SpeakNPCRequest.ProtoReflect.Descriptor instead.
+func (*SpeakNPCRequest) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *SpeakNPCRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *SpeakNPCRequest) GetNpcName() string {
+	if x != nil {
+		return x.NpcName
+	}
+	return ""
+}
+
+func (x *SpeakNPCRequest) GetText() string {
+	if x != nil {
+		return x.Text
+	}
+	return ""
+}
+
+// SpeakNPCResponse is the worker's reply after triggering NPC speech.
+type SpeakNPCResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SpeakNPCResponse) Reset() {
+	*x = SpeakNPCResponse{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SpeakNPCResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SpeakNPCResponse) ProtoMessage() {}
+
+func (x *SpeakNPCResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SpeakNPCResponse.ProtoReflect.Descriptor instead.
+func (*SpeakNPCResponse) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{24}
+}
+
 var File_glyphoxa_v1_session_proto protoreflect.FileDescriptor
 
 const file_glyphoxa_v1_session_proto_rawDesc = "" +
@@ -828,16 +1437,57 @@ const file_glyphoxa_v1_session_proto_rawDesc = "" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x1d\n" +
 	"\n" +
 	"worker_pod\x18\x02 \x01(\tR\tworkerPod\"\x13\n" +
-	"\x11HeartbeatResponse*{\n" +
+	"\x11HeartbeatResponse\"C\n" +
+	"\aNPCInfo\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
+	"\x05muted\x18\x03 \x01(\bR\x05muted\"0\n" +
+	"\x0fListNPCsRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"<\n" +
+	"\x10ListNPCsResponse\x12(\n" +
+	"\x04npcs\x18\x01 \x03(\v2\x14.glyphoxa.v1.NPCInfoR\x04npcs\"J\n" +
+	"\x0eMuteNPCRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x19\n" +
+	"\bnpc_name\x18\x02 \x01(\tR\anpcName\"\x11\n" +
+	"\x0fMuteNPCResponse\"L\n" +
+	"\x10UnmuteNPCRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x19\n" +
+	"\bnpc_name\x18\x02 \x01(\tR\anpcName\"\x13\n" +
+	"\x11UnmuteNPCResponse\"3\n" +
+	"\x12MuteAllNPCsRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"+\n" +
+	"\x13MuteAllNPCsResponse\x12\x14\n" +
+	"\x05count\x18\x01 \x01(\x05R\x05count\"5\n" +
+	"\x14UnmuteAllNPCsRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"-\n" +
+	"\x15UnmuteAllNPCsResponse\x12\x14\n" +
+	"\x05count\x18\x01 \x01(\x05R\x05count\"_\n" +
+	"\x0fSpeakNPCRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x19\n" +
+	"\bnpc_name\x18\x02 \x01(\tR\anpcName\x12\x12\n" +
+	"\x04text\x18\x03 \x01(\tR\x04text\"\x12\n" +
+	"\x10SpeakNPCResponse*{\n" +
 	"\fSessionState\x12\x1d\n" +
 	"\x19SESSION_STATE_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15SESSION_STATE_PENDING\x10\x01\x12\x18\n" +
 	"\x14SESSION_STATE_ACTIVE\x10\x02\x12\x17\n" +
-	"\x13SESSION_STATE_ENDED\x10\x032\x89\x02\n" +
+	"\x13SESSION_STATE_ENDED\x10\x032\xd7\x05\n" +
 	"\x14SessionWorkerService\x12S\n" +
 	"\fStartSession\x12 .glyphoxa.v1.StartSessionRequest\x1a!.glyphoxa.v1.StartSessionResponse\x12P\n" +
 	"\vStopSession\x12\x1f.glyphoxa.v1.StopSessionRequest\x1a .glyphoxa.v1.StopSessionResponse\x12J\n" +
-	"\tGetStatus\x12\x1d.glyphoxa.v1.GetStatusRequest\x1a\x1e.glyphoxa.v1.GetStatusResponse2\xb5\x01\n" +
+	"\tGetStatus\x12\x1d.glyphoxa.v1.GetStatusRequest\x1a\x1e.glyphoxa.v1.GetStatusResponse\x12G\n" +
+	"\bListNPCs\x12\x1c.glyphoxa.v1.ListNPCsRequest\x1a\x1d.glyphoxa.v1.ListNPCsResponse\x12D\n" +
+	"\aMuteNPC\x12\x1b.glyphoxa.v1.MuteNPCRequest\x1a\x1c.glyphoxa.v1.MuteNPCResponse\x12J\n" +
+	"\tUnmuteNPC\x12\x1d.glyphoxa.v1.UnmuteNPCRequest\x1a\x1e.glyphoxa.v1.UnmuteNPCResponse\x12P\n" +
+	"\vMuteAllNPCs\x12\x1f.glyphoxa.v1.MuteAllNPCsRequest\x1a .glyphoxa.v1.MuteAllNPCsResponse\x12V\n" +
+	"\rUnmuteAllNPCs\x12!.glyphoxa.v1.UnmuteAllNPCsRequest\x1a\".glyphoxa.v1.UnmuteAllNPCsResponse\x12G\n" +
+	"\bSpeakNPC\x12\x1c.glyphoxa.v1.SpeakNPCRequest\x1a\x1d.glyphoxa.v1.SpeakNPCResponse2\xb5\x01\n" +
 	"\x15SessionGatewayService\x12P\n" +
 	"\vReportState\x12\x1f.glyphoxa.v1.ReportStateRequest\x1a .glyphoxa.v1.ReportStateResponse\x12J\n" +
 	"\tHeartbeat\x12\x1d.glyphoxa.v1.HeartbeatRequest\x1a\x1e.glyphoxa.v1.HeartbeatResponseB9Z7github.com/MrWong99/glyphoxa/gen/glyphoxa/v1;glyphoxav1b\x06proto3"
@@ -855,7 +1505,7 @@ func file_glyphoxa_v1_session_proto_rawDescGZIP() []byte {
 }
 
 var file_glyphoxa_v1_session_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_glyphoxa_v1_session_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_glyphoxa_v1_session_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_glyphoxa_v1_session_proto_goTypes = []any{
 	(SessionState)(0),             // 0: glyphoxa.v1.SessionState
 	(*NPCConfig)(nil),             // 1: glyphoxa.v1.NPCConfig
@@ -870,29 +1520,55 @@ var file_glyphoxa_v1_session_proto_goTypes = []any{
 	(*ReportStateResponse)(nil),   // 10: glyphoxa.v1.ReportStateResponse
 	(*HeartbeatRequest)(nil),      // 11: glyphoxa.v1.HeartbeatRequest
 	(*HeartbeatResponse)(nil),     // 12: glyphoxa.v1.HeartbeatResponse
-	(*timestamppb.Timestamp)(nil), // 13: google.protobuf.Timestamp
+	(*NPCInfo)(nil),               // 13: glyphoxa.v1.NPCInfo
+	(*ListNPCsRequest)(nil),       // 14: glyphoxa.v1.ListNPCsRequest
+	(*ListNPCsResponse)(nil),      // 15: glyphoxa.v1.ListNPCsResponse
+	(*MuteNPCRequest)(nil),        // 16: glyphoxa.v1.MuteNPCRequest
+	(*MuteNPCResponse)(nil),       // 17: glyphoxa.v1.MuteNPCResponse
+	(*UnmuteNPCRequest)(nil),      // 18: glyphoxa.v1.UnmuteNPCRequest
+	(*UnmuteNPCResponse)(nil),     // 19: glyphoxa.v1.UnmuteNPCResponse
+	(*MuteAllNPCsRequest)(nil),    // 20: glyphoxa.v1.MuteAllNPCsRequest
+	(*MuteAllNPCsResponse)(nil),   // 21: glyphoxa.v1.MuteAllNPCsResponse
+	(*UnmuteAllNPCsRequest)(nil),  // 22: glyphoxa.v1.UnmuteAllNPCsRequest
+	(*UnmuteAllNPCsResponse)(nil), // 23: glyphoxa.v1.UnmuteAllNPCsResponse
+	(*SpeakNPCRequest)(nil),       // 24: glyphoxa.v1.SpeakNPCRequest
+	(*SpeakNPCResponse)(nil),      // 25: glyphoxa.v1.SpeakNPCResponse
+	(*timestamppb.Timestamp)(nil), // 26: google.protobuf.Timestamp
 }
 var file_glyphoxa_v1_session_proto_depIdxs = []int32{
 	1,  // 0: glyphoxa.v1.StartSessionRequest.npc_configs:type_name -> glyphoxa.v1.NPCConfig
 	0,  // 1: glyphoxa.v1.SessionStatus.state:type_name -> glyphoxa.v1.SessionState
-	13, // 2: glyphoxa.v1.SessionStatus.started_at:type_name -> google.protobuf.Timestamp
+	26, // 2: glyphoxa.v1.SessionStatus.started_at:type_name -> google.protobuf.Timestamp
 	7,  // 3: glyphoxa.v1.GetStatusResponse.sessions:type_name -> glyphoxa.v1.SessionStatus
 	0,  // 4: glyphoxa.v1.ReportStateRequest.state:type_name -> glyphoxa.v1.SessionState
-	2,  // 5: glyphoxa.v1.SessionWorkerService.StartSession:input_type -> glyphoxa.v1.StartSessionRequest
-	4,  // 6: glyphoxa.v1.SessionWorkerService.StopSession:input_type -> glyphoxa.v1.StopSessionRequest
-	6,  // 7: glyphoxa.v1.SessionWorkerService.GetStatus:input_type -> glyphoxa.v1.GetStatusRequest
-	9,  // 8: glyphoxa.v1.SessionGatewayService.ReportState:input_type -> glyphoxa.v1.ReportStateRequest
-	11, // 9: glyphoxa.v1.SessionGatewayService.Heartbeat:input_type -> glyphoxa.v1.HeartbeatRequest
-	3,  // 10: glyphoxa.v1.SessionWorkerService.StartSession:output_type -> glyphoxa.v1.StartSessionResponse
-	5,  // 11: glyphoxa.v1.SessionWorkerService.StopSession:output_type -> glyphoxa.v1.StopSessionResponse
-	8,  // 12: glyphoxa.v1.SessionWorkerService.GetStatus:output_type -> glyphoxa.v1.GetStatusResponse
-	10, // 13: glyphoxa.v1.SessionGatewayService.ReportState:output_type -> glyphoxa.v1.ReportStateResponse
-	12, // 14: glyphoxa.v1.SessionGatewayService.Heartbeat:output_type -> glyphoxa.v1.HeartbeatResponse
-	10, // [10:15] is the sub-list for method output_type
-	5,  // [5:10] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	13, // 5: glyphoxa.v1.ListNPCsResponse.npcs:type_name -> glyphoxa.v1.NPCInfo
+	2,  // 6: glyphoxa.v1.SessionWorkerService.StartSession:input_type -> glyphoxa.v1.StartSessionRequest
+	4,  // 7: glyphoxa.v1.SessionWorkerService.StopSession:input_type -> glyphoxa.v1.StopSessionRequest
+	6,  // 8: glyphoxa.v1.SessionWorkerService.GetStatus:input_type -> glyphoxa.v1.GetStatusRequest
+	14, // 9: glyphoxa.v1.SessionWorkerService.ListNPCs:input_type -> glyphoxa.v1.ListNPCsRequest
+	16, // 10: glyphoxa.v1.SessionWorkerService.MuteNPC:input_type -> glyphoxa.v1.MuteNPCRequest
+	18, // 11: glyphoxa.v1.SessionWorkerService.UnmuteNPC:input_type -> glyphoxa.v1.UnmuteNPCRequest
+	20, // 12: glyphoxa.v1.SessionWorkerService.MuteAllNPCs:input_type -> glyphoxa.v1.MuteAllNPCsRequest
+	22, // 13: glyphoxa.v1.SessionWorkerService.UnmuteAllNPCs:input_type -> glyphoxa.v1.UnmuteAllNPCsRequest
+	24, // 14: glyphoxa.v1.SessionWorkerService.SpeakNPC:input_type -> glyphoxa.v1.SpeakNPCRequest
+	9,  // 15: glyphoxa.v1.SessionGatewayService.ReportState:input_type -> glyphoxa.v1.ReportStateRequest
+	11, // 16: glyphoxa.v1.SessionGatewayService.Heartbeat:input_type -> glyphoxa.v1.HeartbeatRequest
+	3,  // 17: glyphoxa.v1.SessionWorkerService.StartSession:output_type -> glyphoxa.v1.StartSessionResponse
+	5,  // 18: glyphoxa.v1.SessionWorkerService.StopSession:output_type -> glyphoxa.v1.StopSessionResponse
+	8,  // 19: glyphoxa.v1.SessionWorkerService.GetStatus:output_type -> glyphoxa.v1.GetStatusResponse
+	15, // 20: glyphoxa.v1.SessionWorkerService.ListNPCs:output_type -> glyphoxa.v1.ListNPCsResponse
+	17, // 21: glyphoxa.v1.SessionWorkerService.MuteNPC:output_type -> glyphoxa.v1.MuteNPCResponse
+	19, // 22: glyphoxa.v1.SessionWorkerService.UnmuteNPC:output_type -> glyphoxa.v1.UnmuteNPCResponse
+	21, // 23: glyphoxa.v1.SessionWorkerService.MuteAllNPCs:output_type -> glyphoxa.v1.MuteAllNPCsResponse
+	23, // 24: glyphoxa.v1.SessionWorkerService.UnmuteAllNPCs:output_type -> glyphoxa.v1.UnmuteAllNPCsResponse
+	25, // 25: glyphoxa.v1.SessionWorkerService.SpeakNPC:output_type -> glyphoxa.v1.SpeakNPCResponse
+	10, // 26: glyphoxa.v1.SessionGatewayService.ReportState:output_type -> glyphoxa.v1.ReportStateResponse
+	12, // 27: glyphoxa.v1.SessionGatewayService.Heartbeat:output_type -> glyphoxa.v1.HeartbeatResponse
+	17, // [17:28] is the sub-list for method output_type
+	6,  // [6:17] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_glyphoxa_v1_session_proto_init() }
@@ -906,7 +1582,7 @@ func file_glyphoxa_v1_session_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_glyphoxa_v1_session_proto_rawDesc), len(file_glyphoxa_v1_session_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   12,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/gen/glyphoxa/v1/session_grpc.pb.go
+++ b/gen/glyphoxa/v1/session_grpc.pb.go
@@ -19,9 +19,15 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	SessionWorkerService_StartSession_FullMethodName = "/glyphoxa.v1.SessionWorkerService/StartSession"
-	SessionWorkerService_StopSession_FullMethodName  = "/glyphoxa.v1.SessionWorkerService/StopSession"
-	SessionWorkerService_GetStatus_FullMethodName    = "/glyphoxa.v1.SessionWorkerService/GetStatus"
+	SessionWorkerService_StartSession_FullMethodName  = "/glyphoxa.v1.SessionWorkerService/StartSession"
+	SessionWorkerService_StopSession_FullMethodName   = "/glyphoxa.v1.SessionWorkerService/StopSession"
+	SessionWorkerService_GetStatus_FullMethodName     = "/glyphoxa.v1.SessionWorkerService/GetStatus"
+	SessionWorkerService_ListNPCs_FullMethodName      = "/glyphoxa.v1.SessionWorkerService/ListNPCs"
+	SessionWorkerService_MuteNPC_FullMethodName       = "/glyphoxa.v1.SessionWorkerService/MuteNPC"
+	SessionWorkerService_UnmuteNPC_FullMethodName     = "/glyphoxa.v1.SessionWorkerService/UnmuteNPC"
+	SessionWorkerService_MuteAllNPCs_FullMethodName   = "/glyphoxa.v1.SessionWorkerService/MuteAllNPCs"
+	SessionWorkerService_UnmuteAllNPCs_FullMethodName = "/glyphoxa.v1.SessionWorkerService/UnmuteAllNPCs"
+	SessionWorkerService_SpeakNPC_FullMethodName      = "/glyphoxa.v1.SessionWorkerService/SpeakNPC"
 )
 
 // SessionWorkerServiceClient is the client API for SessionWorkerService service.
@@ -36,6 +42,18 @@ type SessionWorkerServiceClient interface {
 	StopSession(ctx context.Context, in *StopSessionRequest, opts ...grpc.CallOption) (*StopSessionResponse, error)
 	// GetStatus returns the status of one or all sessions on this worker.
 	GetStatus(ctx context.Context, in *GetStatusRequest, opts ...grpc.CallOption) (*GetStatusResponse, error)
+	// ListNPCs returns the NPCs in a running session.
+	ListNPCs(ctx context.Context, in *ListNPCsRequest, opts ...grpc.CallOption) (*ListNPCsResponse, error)
+	// MuteNPC mutes a specific NPC in a session.
+	MuteNPC(ctx context.Context, in *MuteNPCRequest, opts ...grpc.CallOption) (*MuteNPCResponse, error)
+	// UnmuteNPC unmutes a specific NPC in a session.
+	UnmuteNPC(ctx context.Context, in *UnmuteNPCRequest, opts ...grpc.CallOption) (*UnmuteNPCResponse, error)
+	// MuteAllNPCs mutes all NPCs in a session.
+	MuteAllNPCs(ctx context.Context, in *MuteAllNPCsRequest, opts ...grpc.CallOption) (*MuteAllNPCsResponse, error)
+	// UnmuteAllNPCs unmutes all NPCs in a session.
+	UnmuteAllNPCs(ctx context.Context, in *UnmuteAllNPCsRequest, opts ...grpc.CallOption) (*UnmuteAllNPCsResponse, error)
+	// SpeakNPC forces an NPC to speak pre-written text.
+	SpeakNPC(ctx context.Context, in *SpeakNPCRequest, opts ...grpc.CallOption) (*SpeakNPCResponse, error)
 }
 
 type sessionWorkerServiceClient struct {
@@ -76,6 +94,66 @@ func (c *sessionWorkerServiceClient) GetStatus(ctx context.Context, in *GetStatu
 	return out, nil
 }
 
+func (c *sessionWorkerServiceClient) ListNPCs(ctx context.Context, in *ListNPCsRequest, opts ...grpc.CallOption) (*ListNPCsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListNPCsResponse)
+	err := c.cc.Invoke(ctx, SessionWorkerService_ListNPCs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sessionWorkerServiceClient) MuteNPC(ctx context.Context, in *MuteNPCRequest, opts ...grpc.CallOption) (*MuteNPCResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(MuteNPCResponse)
+	err := c.cc.Invoke(ctx, SessionWorkerService_MuteNPC_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sessionWorkerServiceClient) UnmuteNPC(ctx context.Context, in *UnmuteNPCRequest, opts ...grpc.CallOption) (*UnmuteNPCResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UnmuteNPCResponse)
+	err := c.cc.Invoke(ctx, SessionWorkerService_UnmuteNPC_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sessionWorkerServiceClient) MuteAllNPCs(ctx context.Context, in *MuteAllNPCsRequest, opts ...grpc.CallOption) (*MuteAllNPCsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(MuteAllNPCsResponse)
+	err := c.cc.Invoke(ctx, SessionWorkerService_MuteAllNPCs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sessionWorkerServiceClient) UnmuteAllNPCs(ctx context.Context, in *UnmuteAllNPCsRequest, opts ...grpc.CallOption) (*UnmuteAllNPCsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UnmuteAllNPCsResponse)
+	err := c.cc.Invoke(ctx, SessionWorkerService_UnmuteAllNPCs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sessionWorkerServiceClient) SpeakNPC(ctx context.Context, in *SpeakNPCRequest, opts ...grpc.CallOption) (*SpeakNPCResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SpeakNPCResponse)
+	err := c.cc.Invoke(ctx, SessionWorkerService_SpeakNPC_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SessionWorkerServiceServer is the server API for SessionWorkerService service.
 // All implementations must embed UnimplementedSessionWorkerServiceServer
 // for forward compatibility.
@@ -88,6 +166,18 @@ type SessionWorkerServiceServer interface {
 	StopSession(context.Context, *StopSessionRequest) (*StopSessionResponse, error)
 	// GetStatus returns the status of one or all sessions on this worker.
 	GetStatus(context.Context, *GetStatusRequest) (*GetStatusResponse, error)
+	// ListNPCs returns the NPCs in a running session.
+	ListNPCs(context.Context, *ListNPCsRequest) (*ListNPCsResponse, error)
+	// MuteNPC mutes a specific NPC in a session.
+	MuteNPC(context.Context, *MuteNPCRequest) (*MuteNPCResponse, error)
+	// UnmuteNPC unmutes a specific NPC in a session.
+	UnmuteNPC(context.Context, *UnmuteNPCRequest) (*UnmuteNPCResponse, error)
+	// MuteAllNPCs mutes all NPCs in a session.
+	MuteAllNPCs(context.Context, *MuteAllNPCsRequest) (*MuteAllNPCsResponse, error)
+	// UnmuteAllNPCs unmutes all NPCs in a session.
+	UnmuteAllNPCs(context.Context, *UnmuteAllNPCsRequest) (*UnmuteAllNPCsResponse, error)
+	// SpeakNPC forces an NPC to speak pre-written text.
+	SpeakNPC(context.Context, *SpeakNPCRequest) (*SpeakNPCResponse, error)
 	mustEmbedUnimplementedSessionWorkerServiceServer()
 }
 
@@ -106,6 +196,24 @@ func (UnimplementedSessionWorkerServiceServer) StopSession(context.Context, *Sto
 }
 func (UnimplementedSessionWorkerServiceServer) GetStatus(context.Context, *GetStatusRequest) (*GetStatusResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetStatus not implemented")
+}
+func (UnimplementedSessionWorkerServiceServer) ListNPCs(context.Context, *ListNPCsRequest) (*ListNPCsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListNPCs not implemented")
+}
+func (UnimplementedSessionWorkerServiceServer) MuteNPC(context.Context, *MuteNPCRequest) (*MuteNPCResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method MuteNPC not implemented")
+}
+func (UnimplementedSessionWorkerServiceServer) UnmuteNPC(context.Context, *UnmuteNPCRequest) (*UnmuteNPCResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method UnmuteNPC not implemented")
+}
+func (UnimplementedSessionWorkerServiceServer) MuteAllNPCs(context.Context, *MuteAllNPCsRequest) (*MuteAllNPCsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method MuteAllNPCs not implemented")
+}
+func (UnimplementedSessionWorkerServiceServer) UnmuteAllNPCs(context.Context, *UnmuteAllNPCsRequest) (*UnmuteAllNPCsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method UnmuteAllNPCs not implemented")
+}
+func (UnimplementedSessionWorkerServiceServer) SpeakNPC(context.Context, *SpeakNPCRequest) (*SpeakNPCResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SpeakNPC not implemented")
 }
 func (UnimplementedSessionWorkerServiceServer) mustEmbedUnimplementedSessionWorkerServiceServer() {}
 func (UnimplementedSessionWorkerServiceServer) testEmbeddedByValue()                              {}
@@ -182,6 +290,114 @@ func _SessionWorkerService_GetStatus_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SessionWorkerService_ListNPCs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListNPCsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SessionWorkerServiceServer).ListNPCs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SessionWorkerService_ListNPCs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SessionWorkerServiceServer).ListNPCs(ctx, req.(*ListNPCsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SessionWorkerService_MuteNPC_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MuteNPCRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SessionWorkerServiceServer).MuteNPC(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SessionWorkerService_MuteNPC_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SessionWorkerServiceServer).MuteNPC(ctx, req.(*MuteNPCRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SessionWorkerService_UnmuteNPC_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UnmuteNPCRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SessionWorkerServiceServer).UnmuteNPC(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SessionWorkerService_UnmuteNPC_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SessionWorkerServiceServer).UnmuteNPC(ctx, req.(*UnmuteNPCRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SessionWorkerService_MuteAllNPCs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MuteAllNPCsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SessionWorkerServiceServer).MuteAllNPCs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SessionWorkerService_MuteAllNPCs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SessionWorkerServiceServer).MuteAllNPCs(ctx, req.(*MuteAllNPCsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SessionWorkerService_UnmuteAllNPCs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UnmuteAllNPCsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SessionWorkerServiceServer).UnmuteAllNPCs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SessionWorkerService_UnmuteAllNPCs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SessionWorkerServiceServer).UnmuteAllNPCs(ctx, req.(*UnmuteAllNPCsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SessionWorkerService_SpeakNPC_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SpeakNPCRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SessionWorkerServiceServer).SpeakNPC(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SessionWorkerService_SpeakNPC_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SessionWorkerServiceServer).SpeakNPC(ctx, req.(*SpeakNPCRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SessionWorkerService_ServiceDesc is the grpc.ServiceDesc for SessionWorkerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -200,6 +416,30 @@ var SessionWorkerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetStatus",
 			Handler:    _SessionWorkerService_GetStatus_Handler,
+		},
+		{
+			MethodName: "ListNPCs",
+			Handler:    _SessionWorkerService_ListNPCs_Handler,
+		},
+		{
+			MethodName: "MuteNPC",
+			Handler:    _SessionWorkerService_MuteNPC_Handler,
+		},
+		{
+			MethodName: "UnmuteNPC",
+			Handler:    _SessionWorkerService_UnmuteNPC_Handler,
+		},
+		{
+			MethodName: "MuteAllNPCs",
+			Handler:    _SessionWorkerService_MuteAllNPCs_Handler,
+		},
+		{
+			MethodName: "UnmuteAllNPCs",
+			Handler:    _SessionWorkerService_UnmuteAllNPCs_Handler,
+		},
+		{
+			MethodName: "SpeakNPC",
+			Handler:    _SessionWorkerService_SpeakNPC_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/discord/commands/npc_gateway.go
+++ b/internal/discord/commands/npc_gateway.go
@@ -1,0 +1,275 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/events"
+
+	discordbot "github.com/MrWong99/glyphoxa/internal/discord"
+	gw "github.com/MrWong99/glyphoxa/internal/gateway"
+)
+
+// GatewayNPCCommands handles /npc slash commands in gateway mode by proxying
+// NPC management operations through gRPC to the worker.
+type GatewayNPCCommands struct {
+	ctrl    gw.SessionController
+	npcCtrl gw.NPCController
+	perms   *discordbot.PermissionChecker
+}
+
+// NewGatewayNPCCommands creates and registers gateway NPC commands.
+func NewGatewayNPCCommands(
+	gwBot *gw.GatewayBot,
+	ctrl gw.SessionController,
+	npcCtrl gw.NPCController,
+	perms *discordbot.PermissionChecker,
+) *GatewayNPCCommands {
+	nc := &GatewayNPCCommands{ctrl: ctrl, npcCtrl: npcCtrl, perms: perms}
+	nc.Register(gwBot.Router())
+	return nc
+}
+
+// Register registers all /npc subcommands with the router.
+func (nc *GatewayNPCCommands) Register(router *discordbot.CommandRouter) {
+	def := nc.Definition()
+	router.RegisterCommand("npc", def, func(e *events.ApplicationCommandInteractionCreate) {
+		discordbot.RespondEphemeral(e, "Please use a subcommand: `/npc list`, `/npc mute`, `/npc unmute`, `/npc speak`, `/npc muteall`, `/npc unmuteall`.")
+	})
+	router.RegisterHandler("npc/list", nc.handleList)
+	router.RegisterHandler("npc/mute", nc.handleMute)
+	router.RegisterHandler("npc/unmute", nc.handleUnmute)
+	router.RegisterHandler("npc/speak", nc.handleSpeak)
+	router.RegisterHandler("npc/muteall", nc.handleMuteAll)
+	router.RegisterHandler("npc/unmuteall", nc.handleUnmuteAll)
+}
+
+// Definition returns the /npc SlashCommandCreate for Discord registration.
+func (nc *GatewayNPCCommands) Definition() discord.SlashCommandCreate {
+	npcNameOption := discord.ApplicationCommandOptionString{
+		Name:        "name",
+		Description: "NPC name",
+		Required:    true,
+	}
+	return discord.SlashCommandCreate{
+		Name:        "npc",
+		Description: "Manage NPC agents",
+		Options: []discord.ApplicationCommandOption{
+			discord.ApplicationCommandOptionSubCommand{
+				Name:        "list",
+				Description: "List all NPCs with their status",
+			},
+			discord.ApplicationCommandOptionSubCommand{
+				Name:        "mute",
+				Description: "Mute an NPC",
+				Options:     []discord.ApplicationCommandOption{npcNameOption},
+			},
+			discord.ApplicationCommandOptionSubCommand{
+				Name:        "unmute",
+				Description: "Unmute an NPC",
+				Options:     []discord.ApplicationCommandOption{npcNameOption},
+			},
+			discord.ApplicationCommandOptionSubCommand{
+				Name:        "speak",
+				Description: "Make an NPC speak pre-written text",
+				Options: []discord.ApplicationCommandOption{
+					npcNameOption,
+					discord.ApplicationCommandOptionString{
+						Name:        "text",
+						Description: "Text for the NPC to speak",
+						Required:    true,
+					},
+				},
+			},
+			discord.ApplicationCommandOptionSubCommand{
+				Name:        "muteall",
+				Description: "Mute all NPCs",
+			},
+			discord.ApplicationCommandOptionSubCommand{
+				Name:        "unmuteall",
+				Description: "Unmute all NPCs",
+			},
+		},
+	}
+}
+
+// sessionID returns the active session ID for the guild, or responds with
+// an error and returns empty string if no session is active.
+func (nc *GatewayNPCCommands) sessionID(e *events.ApplicationCommandInteractionCreate) string {
+	guildStr := e.GuildID().String()
+	if !nc.ctrl.IsActive(guildStr) {
+		discordbot.RespondEphemeral(e, "No active session.")
+		return ""
+	}
+	info, _ := nc.ctrl.Info(guildStr)
+	return info.SessionID
+}
+
+// handleList handles /npc list.
+func (nc *GatewayNPCCommands) handleList(e *events.ApplicationCommandInteractionCreate) {
+	if !nc.perms.IsDM(e) {
+		discordbot.RespondEphemeral(e, "You need the DM role to manage NPCs.")
+		return
+	}
+
+	sid := nc.sessionID(e)
+	if sid == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	npcs, err := nc.npcCtrl.ListNPCs(ctx, sid)
+	if err != nil {
+		discordbot.RespondError(e, err)
+		return
+	}
+
+	if len(npcs) == 0 {
+		discordbot.RespondEphemeral(e, "No NPCs in this session.")
+		return
+	}
+
+	var lines []string
+	for _, n := range npcs {
+		icon := "🔊"
+		if n.Muted {
+			icon = "🔇"
+		}
+		lines = append(lines, fmt.Sprintf("%s **%s** (ID: `%s`)", icon, n.Name, n.ID))
+	}
+
+	discordbot.RespondEmbed(e, discord.Embed{
+		Title:       "NPC Agents",
+		Description: strings.Join(lines, "\n"),
+		Color:       0x5865F2,
+	})
+}
+
+// handleMute handles /npc mute <name>.
+func (nc *GatewayNPCCommands) handleMute(e *events.ApplicationCommandInteractionCreate) {
+	if !nc.perms.IsDM(e) {
+		discordbot.RespondEphemeral(e, "You need the DM role to manage NPCs.")
+		return
+	}
+
+	sid := nc.sessionID(e)
+	if sid == "" {
+		return
+	}
+
+	name := e.SlashCommandInteractionData().String("name")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := nc.npcCtrl.MuteNPC(ctx, sid, name); err != nil {
+		discordbot.RespondError(e, err)
+		return
+	}
+	discordbot.RespondEphemeral(e, fmt.Sprintf("Muted **%s**.", name))
+}
+
+// handleUnmute handles /npc unmute <name>.
+func (nc *GatewayNPCCommands) handleUnmute(e *events.ApplicationCommandInteractionCreate) {
+	if !nc.perms.IsDM(e) {
+		discordbot.RespondEphemeral(e, "You need the DM role to manage NPCs.")
+		return
+	}
+
+	sid := nc.sessionID(e)
+	if sid == "" {
+		return
+	}
+
+	name := e.SlashCommandInteractionData().String("name")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := nc.npcCtrl.UnmuteNPC(ctx, sid, name); err != nil {
+		discordbot.RespondError(e, err)
+		return
+	}
+	discordbot.RespondEphemeral(e, fmt.Sprintf("Unmuted **%s**.", name))
+}
+
+// handleSpeak handles /npc speak <name> <text>.
+func (nc *GatewayNPCCommands) handleSpeak(e *events.ApplicationCommandInteractionCreate) {
+	if !nc.perms.IsDM(e) {
+		discordbot.RespondEphemeral(e, "You need the DM role to manage NPCs.")
+		return
+	}
+
+	sid := nc.sessionID(e)
+	if sid == "" {
+		return
+	}
+
+	data := e.SlashCommandInteractionData()
+	name := data.String("name")
+	text := data.String("text")
+
+	discordbot.DeferReply(e)
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		if err := nc.npcCtrl.SpeakNPC(ctx, sid, name, text); err != nil {
+			discordbot.FollowUp(e, fmt.Sprintf("Failed to make %s speak: %v", name, err))
+			return
+		}
+		discordbot.FollowUp(e, fmt.Sprintf("**%s** is speaking: %q", name, text))
+	}()
+}
+
+// handleMuteAll handles /npc muteall.
+func (nc *GatewayNPCCommands) handleMuteAll(e *events.ApplicationCommandInteractionCreate) {
+	if !nc.perms.IsDM(e) {
+		discordbot.RespondEphemeral(e, "You need the DM role to manage NPCs.")
+		return
+	}
+
+	sid := nc.sessionID(e)
+	if sid == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	count, err := nc.npcCtrl.MuteAllNPCs(ctx, sid)
+	if err != nil {
+		discordbot.RespondError(e, err)
+		return
+	}
+	discordbot.RespondEphemeral(e, fmt.Sprintf("Muted %d NPC(s).", count))
+}
+
+// handleUnmuteAll handles /npc unmuteall.
+func (nc *GatewayNPCCommands) handleUnmuteAll(e *events.ApplicationCommandInteractionCreate) {
+	if !nc.perms.IsDM(e) {
+		discordbot.RespondEphemeral(e, "You need the DM role to manage NPCs.")
+		return
+	}
+
+	sid := nc.sessionID(e)
+	if sid == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	count, err := nc.npcCtrl.UnmuteAllNPCs(ctx, sid)
+	if err != nil {
+		discordbot.RespondError(e, err)
+		return
+	}
+	discordbot.RespondEphemeral(e, fmt.Sprintf("Unmuted %d NPC(s).", count))
+}

--- a/internal/discord/commands/recap_gateway.go
+++ b/internal/discord/commands/recap_gateway.go
@@ -1,0 +1,299 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/events"
+
+	discordbot "github.com/MrWong99/glyphoxa/internal/discord"
+	gw "github.com/MrWong99/glyphoxa/internal/gateway"
+	"github.com/MrWong99/glyphoxa/internal/session"
+	"github.com/MrWong99/glyphoxa/pkg/memory"
+	"github.com/MrWong99/glyphoxa/pkg/provider/llm"
+)
+
+// GatewayRecapCommands handles the /session recap slash command in gateway mode.
+// It reads transcripts from the shared PostgreSQL session store and optionally
+// summarises them via the Summariser. Voice recap is text-only for MVP.
+type GatewayRecapCommands struct {
+	ctrl         gw.SessionController
+	npcCtrl      gw.NPCController
+	perms        *discordbot.PermissionChecker
+	sessionStore memory.SessionStore
+	summariser   session.Summariser
+}
+
+// GatewayRecapConfig holds dependencies for creating GatewayRecapCommands.
+type GatewayRecapConfig struct {
+	GatewayBot   *gw.GatewayBot
+	Ctrl         gw.SessionController
+	NPCCtrl      gw.NPCController
+	Perms        *discordbot.PermissionChecker
+	SessionStore memory.SessionStore
+	Summariser   session.Summariser // optional; if nil, raw transcript is shown
+}
+
+// NewGatewayRecapCommands creates a GatewayRecapCommands and registers the
+// recap handler with the gateway bot's router.
+func NewGatewayRecapCommands(cfg GatewayRecapConfig) *GatewayRecapCommands {
+	rc := &GatewayRecapCommands{
+		ctrl:         cfg.Ctrl,
+		npcCtrl:      cfg.NPCCtrl,
+		perms:        cfg.Perms,
+		sessionStore: cfg.SessionStore,
+		summariser:   cfg.Summariser,
+	}
+	rc.Register(cfg.GatewayBot.Router())
+	return rc
+}
+
+// Register registers the /session recap subcommand handler with the router.
+// The parent /session command definition is expected to be already registered
+// by GatewaySessionCommands; this only adds the handler for the recap subcommand.
+func (rc *GatewayRecapCommands) Register(router *discordbot.CommandRouter) {
+	router.RegisterHandler("session/recap", rc.handleRecap)
+}
+
+// handleRecap handles /session recap.
+func (rc *GatewayRecapCommands) handleRecap(e *events.ApplicationCommandInteractionCreate) {
+	if !rc.perms.IsDM(e) {
+		discordbot.RespondEphemeral(e, "You need the DM role to view session recaps.")
+		return
+	}
+
+	// Resolve session ID: explicit param > active session > most recent from store.
+	data := e.SlashCommandInteractionData()
+	sessionID, _ := data.OptString("session_id")
+
+	guildStr := e.GuildID().String()
+	var info gw.SessionInfo
+	var hasInfo bool
+
+	if sessionID == "" {
+		if rc.ctrl.IsActive(guildStr) {
+			info, hasInfo = rc.ctrl.Info(guildStr)
+			sessionID = info.SessionID
+		}
+	} else {
+		// Even with explicit session_id, try to get info for display.
+		if rc.ctrl.IsActive(guildStr) {
+			info, hasInfo = rc.ctrl.Info(guildStr)
+		}
+	}
+
+	if sessionID == "" && rc.sessionStore != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		sessions, err := rc.sessionStore.ListSessions(ctx, 1)
+		if err == nil && len(sessions) > 0 {
+			sessionID = sessions[0].SessionID
+		}
+	}
+
+	if sessionID == "" {
+		discordbot.RespondEphemeral(e, "No session data available. Start a session first with `/session start`.")
+		return
+	}
+
+	discordbot.DeferReply(e)
+
+	status := "Ended"
+	if hasInfo && rc.ctrl.IsActive(guildStr) {
+		status = "Active"
+	}
+
+	npcList := rc.buildNPCList(info.SessionID)
+	summary := rc.buildSummary(sessionID)
+
+	fields := []discord.EmbedField{
+		{Name: "Status", Value: status, Inline: new(true)},
+		{Name: "Session ID", Value: fmt.Sprintf("`%s`", sessionID), Inline: new(true)},
+	}
+
+	if hasInfo {
+		fields = append(fields,
+			discord.EmbedField{Name: "Campaign", Value: info.CampaignName, Inline: new(true)},
+			discord.EmbedField{Name: "Started By", Value: fmt.Sprintf("<@%s>", info.StartedBy), Inline: new(true)},
+			discord.EmbedField{Name: "Duration", Value: time.Since(info.StartedAt).Truncate(time.Second).String(), Inline: new(true)},
+			discord.EmbedField{Name: "Channel", Value: fmt.Sprintf("<#%s>", info.ChannelID), Inline: new(true)},
+		)
+	}
+
+	if npcList != "" {
+		fields = append(fields, discord.EmbedField{Name: "NPCs", Value: npcList})
+	}
+
+	if rc.sessionStore != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		count, err := rc.sessionStore.EntryCount(ctx, sessionID)
+		if err != nil {
+			slog.Warn("recap: failed to get entry count", "session_id", sessionID, "err", err)
+		} else {
+			fields = append(fields, discord.EmbedField{
+				Name: "Transcript Entries", Value: fmt.Sprintf("%d", count), Inline: new(true),
+			})
+		}
+	}
+
+	embeds := buildGatewayRecapEmbeds(fields, summary)
+
+	if len(embeds) > 0 {
+		discordbot.FollowUpEmbed(e, embeds[0])
+	}
+	for _, extra := range embeds[1:] {
+		discordbot.FollowUpEmbed(e, extra)
+	}
+}
+
+// buildNPCList fetches NPC status from the worker via gRPC and formats it.
+func (rc *GatewayRecapCommands) buildNPCList(sessionID string) string {
+	if sessionID == "" || rc.npcCtrl == nil {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	npcs, err := rc.npcCtrl.ListNPCs(ctx, sessionID)
+	if err != nil {
+		slog.Warn("recap: failed to list npcs", "session_id", sessionID, "err", err)
+		return "NPC data unavailable."
+	}
+	if len(npcs) == 0 {
+		return "No NPCs active."
+	}
+
+	var sb strings.Builder
+	for _, n := range npcs {
+		muteLabel := ""
+		if n.Muted {
+			muteLabel = " (muted)"
+		}
+		fmt.Fprintf(&sb, "- %s%s\n", n.Name, muteLabel)
+	}
+	return sb.String()
+}
+
+// buildSummary retrieves the session transcript and optionally summarises it.
+func (rc *GatewayRecapCommands) buildSummary(sessionID string) string {
+	if rc.sessionStore == nil {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	entries, err := rc.sessionStore.GetRecent(ctx, sessionID, 24*time.Hour)
+	if err != nil {
+		slog.Warn("recap: failed to get transcript", "session_id", sessionID, "err", err)
+		return "Failed to retrieve transcript."
+	}
+	if len(entries) == 0 {
+		return "No transcript entries recorded."
+	}
+
+	if rc.summariser != nil {
+		messages := gatewayTranscriptToMessages(entries)
+		summary, err := rc.summariser.Summarise(ctx, messages)
+		if err != nil {
+			slog.Warn("recap: summarisation failed, falling back to raw transcript",
+				"session_id", sessionID, "err", err)
+		} else if summary != "" {
+			return summary
+		}
+	}
+
+	return gatewayFormatTranscript(entries)
+}
+
+// gatewayTranscriptToMessages converts transcript entries to LLM messages.
+func gatewayTranscriptToMessages(entries []memory.TranscriptEntry) []llm.Message {
+	messages := make([]llm.Message, 0, len(entries))
+	for _, e := range entries {
+		role := "user"
+		if e.IsNPC() {
+			role = "assistant"
+		}
+		messages = append(messages, llm.Message{
+			Role:    role,
+			Name:    e.SpeakerName,
+			Content: e.Text,
+		})
+	}
+	return messages
+}
+
+// gatewayFormatTranscript creates a simple chronological transcript listing.
+func gatewayFormatTranscript(entries []memory.TranscriptEntry) string {
+	var sb strings.Builder
+	for _, e := range entries {
+		ts := e.Timestamp.Format("15:04:05")
+		fmt.Fprintf(&sb, "**[%s] %s:** %s\n", ts, e.SpeakerName, e.Text)
+	}
+	result := sb.String()
+	if len(result) > maxEmbedDescriptionLen-100 {
+		result = result[:maxEmbedDescriptionLen-150] + "\n\n*... (truncated)*"
+	}
+	return result
+}
+
+// buildGatewayRecapEmbeds builds one or more embeds for the recap.
+func buildGatewayRecapEmbeds(fields []discord.EmbedField, summary string) []discord.Embed {
+	now := time.Now().UTC()
+
+	if summary == "" {
+		return []discord.Embed{{
+			Title:     "Session Recap",
+			Color:     recapColor,
+			Fields:    fields,
+			Footer:    &discord.EmbedFooter{Text: "Session recap"},
+			Timestamp: &now,
+		}}
+	}
+
+	if len(summary) <= maxEmbedDescriptionLen {
+		return []discord.Embed{{
+			Title:       "Session Recap",
+			Description: summary,
+			Color:       recapColor,
+			Fields:      fields,
+			Footer:      &discord.EmbedFooter{Text: "Session recap"},
+			Timestamp:   &now,
+		}}
+	}
+
+	var embeds []discord.Embed
+	remaining := summary
+	first := true
+	for len(remaining) > 0 {
+		chunk := remaining
+		if len(chunk) > maxEmbedDescriptionLen {
+			chunk = remaining[:maxEmbedDescriptionLen]
+			remaining = remaining[maxEmbedDescriptionLen:]
+		} else {
+			remaining = ""
+		}
+
+		embed := discord.Embed{
+			Description: chunk,
+			Color:       recapColor,
+		}
+		if first {
+			embed.Title = "Session Recap"
+			embed.Fields = fields
+			first = false
+		}
+		if remaining == "" {
+			embed.Footer = &discord.EmbedFooter{Text: "Session recap"}
+			embed.Timestamp = &now
+		}
+		embeds = append(embeds, embed)
+	}
+	return embeds
+}

--- a/internal/discord/commands/session_gateway.go
+++ b/internal/discord/commands/session_gateway.go
@@ -40,10 +40,21 @@ func (sc *GatewaySessionCommands) Register(router *discordbot.CommandRouter) {
 				Name:        "stop",
 				Description: "Stop the active voice session",
 			},
+			discord.ApplicationCommandOptionSubCommand{
+				Name:        "recap",
+				Description: "Show a recap of the current or most recent session",
+				Options: []discord.ApplicationCommandOption{
+					discord.ApplicationCommandOptionString{
+						Name:        "session_id",
+						Description: "Session ID (defaults to current or most recent)",
+						Required:    false,
+					},
+				},
+			},
 		},
 	}
 	router.RegisterCommand("session", def, func(e *events.ApplicationCommandInteractionCreate) {
-		discordbot.RespondEphemeral(e, "Please use a subcommand: /session start, /session stop.")
+		discordbot.RespondEphemeral(e, "Please use a subcommand: /session start, /session stop, /session recap.")
 	})
 	router.RegisterHandler("session/start", sc.handleStart)
 	router.RegisterHandler("session/stop", sc.handleStop)

--- a/internal/gateway/contract.go
+++ b/internal/gateway/contract.go
@@ -79,6 +79,13 @@ type SessionStatus struct {
 	Error     string
 }
 
+// NPCStatus describes an NPC within a running session.
+type NPCStatus struct {
+	ID    string
+	Name  string
+	Muted bool
+}
+
 // WorkerClient is the interface for gateway-to-worker communication.
 // The gateway uses this to start/stop sessions and query worker status.
 //
@@ -89,6 +96,21 @@ type WorkerClient interface {
 	StartSession(ctx context.Context, req StartSessionRequest) error
 	StopSession(ctx context.Context, sessionID string) error
 	GetStatus(ctx context.Context) ([]SessionStatus, error)
+}
+
+// NPCController is the interface for gateway-to-worker NPC management.
+// It extends the base WorkerClient with per-session NPC operations.
+//
+// Two implementations exist:
+//   - grpctransport.Client implements via gRPC (distributed mode)
+//   - local.NPCClient calls the orchestrator directly (full mode)
+type NPCController interface {
+	ListNPCs(ctx context.Context, sessionID string) ([]NPCStatus, error)
+	MuteNPC(ctx context.Context, sessionID, npcName string) error
+	UnmuteNPC(ctx context.Context, sessionID, npcName string) error
+	MuteAllNPCs(ctx context.Context, sessionID string) (int, error)
+	UnmuteAllNPCs(ctx context.Context, sessionID string) (int, error)
+	SpeakNPC(ctx context.Context, sessionID, npcName, text string) error
 }
 
 // GatewayCallback is the interface for worker-to-gateway communication.

--- a/internal/gateway/grpctransport/client.go
+++ b/internal/gateway/grpctransport/client.go
@@ -16,8 +16,11 @@ import (
 	"github.com/MrWong99/glyphoxa/internal/resilience"
 )
 
-// Compile-time interface assertion.
-var _ gateway.WorkerClient = (*Client)(nil)
+// Compile-time interface assertions.
+var (
+	_ gateway.WorkerClient  = (*Client)(nil)
+	_ gateway.NPCController = (*Client)(nil)
+)
 
 // Client implements WorkerClient by wrapping a gRPC connection to a worker.
 // Each connection is protected by a circuit breaker that fast-fails on
@@ -122,6 +125,88 @@ func (c *Client) GetStatus(ctx context.Context) ([]gateway.SessionStatus, error)
 		return nil
 	})
 	return result, err
+}
+
+// ListNPCs queries the worker for NPCs in a session.
+func (c *Client) ListNPCs(ctx context.Context, sessionID string) ([]gateway.NPCStatus, error) {
+	var result []gateway.NPCStatus
+	err := c.breaker.Execute(func() error {
+		resp, err := c.client.ListNPCs(ctx, &pb.ListNPCsRequest{SessionId: sessionID})
+		if err != nil {
+			return fmt.Errorf("grpctransport: list npcs: %w", err)
+		}
+		result = make([]gateway.NPCStatus, len(resp.GetNpcs()))
+		for i, n := range resp.GetNpcs() {
+			result[i] = gateway.NPCStatus{
+				ID:    n.GetId(),
+				Name:  n.GetName(),
+				Muted: n.GetMuted(),
+			}
+		}
+		return nil
+	})
+	return result, err
+}
+
+// MuteNPC mutes a named NPC on the worker.
+func (c *Client) MuteNPC(ctx context.Context, sessionID, npcName string) error {
+	return c.breaker.Execute(func() error {
+		_, err := c.client.MuteNPC(ctx, &pb.MuteNPCRequest{SessionId: sessionID, NpcName: npcName})
+		if err != nil {
+			return fmt.Errorf("grpctransport: mute npc: %w", err)
+		}
+		return nil
+	})
+}
+
+// UnmuteNPC unmutes a named NPC on the worker.
+func (c *Client) UnmuteNPC(ctx context.Context, sessionID, npcName string) error {
+	return c.breaker.Execute(func() error {
+		_, err := c.client.UnmuteNPC(ctx, &pb.UnmuteNPCRequest{SessionId: sessionID, NpcName: npcName})
+		if err != nil {
+			return fmt.Errorf("grpctransport: unmute npc: %w", err)
+		}
+		return nil
+	})
+}
+
+// MuteAllNPCs mutes all NPCs in a session on the worker.
+func (c *Client) MuteAllNPCs(ctx context.Context, sessionID string) (int, error) {
+	var count int
+	err := c.breaker.Execute(func() error {
+		resp, err := c.client.MuteAllNPCs(ctx, &pb.MuteAllNPCsRequest{SessionId: sessionID})
+		if err != nil {
+			return fmt.Errorf("grpctransport: mute all npcs: %w", err)
+		}
+		count = int(resp.GetCount())
+		return nil
+	})
+	return count, err
+}
+
+// UnmuteAllNPCs unmutes all NPCs in a session on the worker.
+func (c *Client) UnmuteAllNPCs(ctx context.Context, sessionID string) (int, error) {
+	var count int
+	err := c.breaker.Execute(func() error {
+		resp, err := c.client.UnmuteAllNPCs(ctx, &pb.UnmuteAllNPCsRequest{SessionId: sessionID})
+		if err != nil {
+			return fmt.Errorf("grpctransport: unmute all npcs: %w", err)
+		}
+		count = int(resp.GetCount())
+		return nil
+	})
+	return count, err
+}
+
+// SpeakNPC forces an NPC to speak on the worker.
+func (c *Client) SpeakNPC(ctx context.Context, sessionID, npcName, text string) error {
+	return c.breaker.Execute(func() error {
+		_, err := c.client.SpeakNPC(ctx, &pb.SpeakNPCRequest{SessionId: sessionID, NpcName: npcName, Text: text})
+		if err != nil {
+			return fmt.Errorf("grpctransport: speak npc: %w", err)
+		}
+		return nil
+	})
 }
 
 // Close closes the underlying gRPC connection.

--- a/internal/gateway/grpctransport/server.go
+++ b/internal/gateway/grpctransport/server.go
@@ -26,6 +26,12 @@ type WorkerHandler interface {
 	StartSession(ctx context.Context, req gateway.StartSessionRequest) error
 	StopSession(ctx context.Context, sessionID string) error
 	GetStatus(ctx context.Context) ([]gateway.SessionStatus, error)
+	ListNPCs(ctx context.Context, sessionID string) ([]gateway.NPCStatus, error)
+	MuteNPC(ctx context.Context, sessionID, npcName string) error
+	UnmuteNPC(ctx context.Context, sessionID, npcName string) error
+	MuteAllNPCs(ctx context.Context, sessionID string) (int, error)
+	UnmuteAllNPCs(ctx context.Context, sessionID string) (int, error)
+	SpeakNPC(ctx context.Context, sessionID, npcName, text string) error
 }
 
 // NewWorkerServer creates a gRPC server that delegates to the given handler.
@@ -99,6 +105,66 @@ func (s *WorkerServer) GetStatus(ctx context.Context, _ *pb.GetStatusRequest) (*
 	}
 
 	return &pb.GetStatusResponse{Sessions: pbStatuses}, nil
+}
+
+// ListNPCs implements the gRPC ListNPCs RPC.
+func (s *WorkerServer) ListNPCs(ctx context.Context, req *pb.ListNPCsRequest) (*pb.ListNPCsResponse, error) {
+	npcs, err := s.handler.ListNPCs(ctx, req.GetSessionId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list npcs: %v", err)
+	}
+
+	pbNPCs := make([]*pb.NPCInfo, len(npcs))
+	for i, n := range npcs {
+		pbNPCs[i] = &pb.NPCInfo{
+			Id:    n.ID,
+			Name:  n.Name,
+			Muted: n.Muted,
+		}
+	}
+	return &pb.ListNPCsResponse{Npcs: pbNPCs}, nil
+}
+
+// MuteNPC implements the gRPC MuteNPC RPC.
+func (s *WorkerServer) MuteNPC(ctx context.Context, req *pb.MuteNPCRequest) (*pb.MuteNPCResponse, error) {
+	if err := s.handler.MuteNPC(ctx, req.GetSessionId(), req.GetNpcName()); err != nil {
+		return nil, status.Errorf(codes.Internal, "mute npc: %v", err)
+	}
+	return &pb.MuteNPCResponse{}, nil
+}
+
+// UnmuteNPC implements the gRPC UnmuteNPC RPC.
+func (s *WorkerServer) UnmuteNPC(ctx context.Context, req *pb.UnmuteNPCRequest) (*pb.UnmuteNPCResponse, error) {
+	if err := s.handler.UnmuteNPC(ctx, req.GetSessionId(), req.GetNpcName()); err != nil {
+		return nil, status.Errorf(codes.Internal, "unmute npc: %v", err)
+	}
+	return &pb.UnmuteNPCResponse{}, nil
+}
+
+// MuteAllNPCs implements the gRPC MuteAllNPCs RPC.
+func (s *WorkerServer) MuteAllNPCs(ctx context.Context, req *pb.MuteAllNPCsRequest) (*pb.MuteAllNPCsResponse, error) {
+	count, err := s.handler.MuteAllNPCs(ctx, req.GetSessionId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "mute all npcs: %v", err)
+	}
+	return &pb.MuteAllNPCsResponse{Count: int32(count)}, nil
+}
+
+// UnmuteAllNPCs implements the gRPC UnmuteAllNPCs RPC.
+func (s *WorkerServer) UnmuteAllNPCs(ctx context.Context, req *pb.UnmuteAllNPCsRequest) (*pb.UnmuteAllNPCsResponse, error) {
+	count, err := s.handler.UnmuteAllNPCs(ctx, req.GetSessionId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unmute all npcs: %v", err)
+	}
+	return &pb.UnmuteAllNPCsResponse{Count: int32(count)}, nil
+}
+
+// SpeakNPC implements the gRPC SpeakNPC RPC.
+func (s *WorkerServer) SpeakNPC(ctx context.Context, req *pb.SpeakNPCRequest) (*pb.SpeakNPCResponse, error) {
+	if err := s.handler.SpeakNPC(ctx, req.GetSessionId(), req.GetNpcName(), req.GetText()); err != nil {
+		return nil, status.Errorf(codes.Internal, "speak npc: %v", err)
+	}
+	return &pb.SpeakNPCResponse{}, nil
 }
 
 // GatewayServer implements the SessionGateway gRPC service on the gateway side.

--- a/internal/gateway/local/local.go
+++ b/internal/gateway/local/local.go
@@ -17,6 +17,7 @@ import (
 var (
 	_ gateway.WorkerClient    = (*Client)(nil)
 	_ gateway.GatewayCallback = (*Callback)(nil)
+	_ gateway.NPCController   = (*NPCClient)(nil)
 )
 
 // SessionStartFunc is called by Client.StartSession to run the voice pipeline.
@@ -106,6 +107,46 @@ func (c *Client) GetStatus(_ context.Context) ([]gateway.SessionStatus, error) {
 		result = append(result, s)
 	}
 	return result, nil
+}
+
+// NPCClient implements NPCController via direct orchestrator calls for full mode.
+type NPCClient struct {
+	handler gateway.NPCController
+}
+
+// NewNPCClient creates a local NPCController that delegates to the given handler.
+func NewNPCClient(handler gateway.NPCController) *NPCClient {
+	return &NPCClient{handler: handler}
+}
+
+// ListNPCs delegates to the handler.
+func (n *NPCClient) ListNPCs(ctx context.Context, sessionID string) ([]gateway.NPCStatus, error) {
+	return n.handler.ListNPCs(ctx, sessionID)
+}
+
+// MuteNPC delegates to the handler.
+func (n *NPCClient) MuteNPC(ctx context.Context, sessionID, npcName string) error {
+	return n.handler.MuteNPC(ctx, sessionID, npcName)
+}
+
+// UnmuteNPC delegates to the handler.
+func (n *NPCClient) UnmuteNPC(ctx context.Context, sessionID, npcName string) error {
+	return n.handler.UnmuteNPC(ctx, sessionID, npcName)
+}
+
+// MuteAllNPCs delegates to the handler.
+func (n *NPCClient) MuteAllNPCs(ctx context.Context, sessionID string) (int, error) {
+	return n.handler.MuteAllNPCs(ctx, sessionID)
+}
+
+// UnmuteAllNPCs delegates to the handler.
+func (n *NPCClient) UnmuteAllNPCs(ctx context.Context, sessionID string) (int, error) {
+	return n.handler.UnmuteAllNPCs(ctx, sessionID)
+}
+
+// SpeakNPC delegates to the handler.
+func (n *NPCClient) SpeakNPC(ctx context.Context, sessionID, npcName, text string) error {
+	return n.handler.SpeakNPC(ctx, sessionID, npcName, text)
 }
 
 // Callback implements GatewayCallback as no-ops for full mode.

--- a/internal/session/worker_handler.go
+++ b/internal/session/worker_handler.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MrWong99/glyphoxa/internal/agent/orchestrator"
 	"github.com/MrWong99/glyphoxa/internal/gateway"
 	"github.com/MrWong99/glyphoxa/internal/gateway/grpctransport"
 )
@@ -149,6 +150,111 @@ func (h *WorkerHandler) ActiveSessionIDs() []string {
 		ids = append(ids, id)
 	}
 	return ids
+}
+
+// ListNPCs returns the NPCs in a running session with their mute state.
+func (h *WorkerHandler) ListNPCs(_ context.Context, sessionID string) ([]gateway.NPCStatus, error) {
+	h.mu.Lock()
+	ms, ok := h.sessions[sessionID]
+	h.mu.Unlock()
+
+	if !ok {
+		return nil, fmt.Errorf("session: %q not found", sessionID)
+	}
+
+	orch := ms.runtime.Orchestrator()
+	if orch == nil {
+		return nil, fmt.Errorf("session: %q has no orchestrator", sessionID)
+	}
+
+	agents := orch.ActiveAgents()
+	result := make([]gateway.NPCStatus, len(agents))
+	for i, a := range agents {
+		muted, _ := orch.IsMuted(a.ID())
+		result[i] = gateway.NPCStatus{
+			ID:    a.ID(),
+			Name:  a.Name(),
+			Muted: muted,
+		}
+	}
+	return result, nil
+}
+
+// MuteNPC mutes a named NPC in a running session.
+func (h *WorkerHandler) MuteNPC(_ context.Context, sessionID, npcName string) error {
+	orch, err := h.sessionOrch(sessionID)
+	if err != nil {
+		return err
+	}
+
+	a := orch.AgentByName(npcName)
+	if a == nil {
+		return fmt.Errorf("session: npc %q not found in session %q", npcName, sessionID)
+	}
+	return orch.MuteAgent(a.ID())
+}
+
+// UnmuteNPC unmutes a named NPC in a running session.
+func (h *WorkerHandler) UnmuteNPC(_ context.Context, sessionID, npcName string) error {
+	orch, err := h.sessionOrch(sessionID)
+	if err != nil {
+		return err
+	}
+
+	a := orch.AgentByName(npcName)
+	if a == nil {
+		return fmt.Errorf("session: npc %q not found in session %q", npcName, sessionID)
+	}
+	return orch.UnmuteAgent(a.ID())
+}
+
+// MuteAllNPCs mutes all NPCs in a running session and returns the count.
+func (h *WorkerHandler) MuteAllNPCs(_ context.Context, sessionID string) (int, error) {
+	orch, err := h.sessionOrch(sessionID)
+	if err != nil {
+		return 0, err
+	}
+	return orch.MuteAll(), nil
+}
+
+// UnmuteAllNPCs unmutes all NPCs in a running session and returns the count.
+func (h *WorkerHandler) UnmuteAllNPCs(_ context.Context, sessionID string) (int, error) {
+	orch, err := h.sessionOrch(sessionID)
+	if err != nil {
+		return 0, err
+	}
+	return orch.UnmuteAll(), nil
+}
+
+// SpeakNPC forces a named NPC in a running session to speak pre-written text.
+func (h *WorkerHandler) SpeakNPC(ctx context.Context, sessionID, npcName, text string) error {
+	orch, err := h.sessionOrch(sessionID)
+	if err != nil {
+		return err
+	}
+
+	a := orch.AgentByName(npcName)
+	if a == nil {
+		return fmt.Errorf("session: npc %q not found in session %q", npcName, sessionID)
+	}
+	return a.SpeakText(ctx, text)
+}
+
+// sessionOrch returns the orchestrator for a running session.
+func (h *WorkerHandler) sessionOrch(sessionID string) (*orchestrator.Orchestrator, error) {
+	h.mu.Lock()
+	ms, ok := h.sessions[sessionID]
+	h.mu.Unlock()
+
+	if !ok {
+		return nil, fmt.Errorf("session: %q not found", sessionID)
+	}
+
+	orch := ms.runtime.Orchestrator()
+	if orch == nil {
+		return nil, fmt.Errorf("session: %q has no orchestrator", sessionID)
+	}
+	return orch, nil
 }
 
 // StopAll stops all running sessions. Used during graceful shutdown.

--- a/internal/session/worker_handler_npc_test.go
+++ b/internal/session/worker_handler_npc_test.go
@@ -1,0 +1,224 @@
+package session
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MrWong99/glyphoxa/internal/agent"
+	agentmock "github.com/MrWong99/glyphoxa/internal/agent/mock"
+	"github.com/MrWong99/glyphoxa/internal/agent/orchestrator"
+	"github.com/MrWong99/glyphoxa/internal/gateway"
+)
+
+// newTestHandlerWithNPCs creates a WorkerHandler with a session containing mock NPCs.
+func newTestHandlerWithNPCs(t *testing.T, sessionID string, agents ...agent.NPCAgent) *WorkerHandler {
+	t.Helper()
+
+	orch := orchestrator.New(agents)
+	rt := NewRuntime(RuntimeConfig{
+		SessionID:    sessionID,
+		Agents:       agents,
+		Orchestrator: orch,
+	})
+
+	handler := NewWorkerHandler(
+		func(_ context.Context, req gateway.StartSessionRequest) (*Runtime, error) {
+			return rt, nil
+		},
+		nil,
+	)
+
+	if err := handler.StartSession(context.Background(), gateway.StartSessionRequest{SessionID: sessionID}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	return handler
+}
+
+func TestWorkerHandler_ListNPCs(t *testing.T) {
+	t.Parallel()
+
+	npc1 := &agentmock.NPCAgent{IDResult: "npc-1", NameResult: "Greymantle"}
+	npc2 := &agentmock.NPCAgent{IDResult: "npc-2", NameResult: "Thorn"}
+	handler := newTestHandlerWithNPCs(t, "s1", npc1, npc2)
+	defer handler.StopAll(context.Background())
+
+	npcs, err := handler.ListNPCs(context.Background(), "s1")
+	if err != nil {
+		t.Fatalf("ListNPCs: %v", err)
+	}
+	if len(npcs) != 2 {
+		t.Fatalf("got %d npcs, want 2", len(npcs))
+	}
+
+	names := make(map[string]bool)
+	for _, n := range npcs {
+		names[n.Name] = true
+		if n.Muted {
+			t.Errorf("NPC %q should not be muted initially", n.Name)
+		}
+	}
+	if !names["Greymantle"] || !names["Thorn"] {
+		t.Errorf("expected Greymantle and Thorn, got %v", names)
+	}
+}
+
+func TestWorkerHandler_ListNPCs_NotFound(t *testing.T) {
+	t.Parallel()
+
+	handler := NewWorkerHandler(
+		func(_ context.Context, req gateway.StartSessionRequest) (*Runtime, error) {
+			return NewRuntime(RuntimeConfig{SessionID: req.SessionID}), nil
+		},
+		nil,
+	)
+
+	_, err := handler.ListNPCs(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for unknown session")
+	}
+}
+
+func TestWorkerHandler_MuteUnmuteNPC(t *testing.T) {
+	t.Parallel()
+
+	npc := &agentmock.NPCAgent{IDResult: "npc-1", NameResult: "Greymantle"}
+	handler := newTestHandlerWithNPCs(t, "s1", npc)
+	defer handler.StopAll(context.Background())
+
+	ctx := context.Background()
+
+	// Mute.
+	if err := handler.MuteNPC(ctx, "s1", "Greymantle"); err != nil {
+		t.Fatalf("MuteNPC: %v", err)
+	}
+
+	npcs, _ := handler.ListNPCs(ctx, "s1")
+	if len(npcs) != 1 || !npcs[0].Muted {
+		t.Error("expected NPC to be muted after MuteNPC")
+	}
+
+	// Unmute.
+	if err := handler.UnmuteNPC(ctx, "s1", "Greymantle"); err != nil {
+		t.Fatalf("UnmuteNPC: %v", err)
+	}
+
+	npcs, _ = handler.ListNPCs(ctx, "s1")
+	if len(npcs) != 1 || npcs[0].Muted {
+		t.Error("expected NPC to be unmuted after UnmuteNPC")
+	}
+}
+
+func TestWorkerHandler_MuteNPC_NotFound(t *testing.T) {
+	t.Parallel()
+
+	npc := &agentmock.NPCAgent{IDResult: "npc-1", NameResult: "Greymantle"}
+	handler := newTestHandlerWithNPCs(t, "s1", npc)
+	defer handler.StopAll(context.Background())
+
+	if err := handler.MuteNPC(context.Background(), "s1", "Nonexistent"); err == nil {
+		t.Fatal("expected error for unknown NPC name")
+	}
+}
+
+func TestWorkerHandler_MuteAllUnmuteAll(t *testing.T) {
+	t.Parallel()
+
+	npc1 := &agentmock.NPCAgent{IDResult: "npc-1", NameResult: "Greymantle"}
+	npc2 := &agentmock.NPCAgent{IDResult: "npc-2", NameResult: "Thorn"}
+	handler := newTestHandlerWithNPCs(t, "s1", npc1, npc2)
+	defer handler.StopAll(context.Background())
+
+	ctx := context.Background()
+
+	// Mute all.
+	count, err := handler.MuteAllNPCs(ctx, "s1")
+	if err != nil {
+		t.Fatalf("MuteAllNPCs: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("MuteAllNPCs returned %d, want 2", count)
+	}
+
+	npcs, _ := handler.ListNPCs(ctx, "s1")
+	for _, n := range npcs {
+		if !n.Muted {
+			t.Errorf("NPC %q should be muted after MuteAll", n.Name)
+		}
+	}
+
+	// Unmute all.
+	count, err = handler.UnmuteAllNPCs(ctx, "s1")
+	if err != nil {
+		t.Fatalf("UnmuteAllNPCs: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("UnmuteAllNPCs returned %d, want 2", count)
+	}
+
+	npcs, _ = handler.ListNPCs(ctx, "s1")
+	for _, n := range npcs {
+		if n.Muted {
+			t.Errorf("NPC %q should be unmuted after UnmuteAll", n.Name)
+		}
+	}
+}
+
+func TestWorkerHandler_SpeakNPC(t *testing.T) {
+	t.Parallel()
+
+	npc := &agentmock.NPCAgent{IDResult: "npc-1", NameResult: "Greymantle"}
+	handler := newTestHandlerWithNPCs(t, "s1", npc)
+	defer handler.StopAll(context.Background())
+
+	ctx := context.Background()
+
+	if err := handler.SpeakNPC(ctx, "s1", "Greymantle", "Hello, traveler!"); err != nil {
+		t.Fatalf("SpeakNPC: %v", err)
+	}
+
+	// SpeakNPC is synchronous so SpeakTextCalls is safe to read after return.
+	if len(npc.SpeakTextCalls) != 1 || npc.SpeakTextCalls[0] != "Hello, traveler!" {
+		t.Errorf("expected SpeakText to be called with %q, got %v", "Hello, traveler!", npc.SpeakTextCalls)
+	}
+}
+
+func TestWorkerHandler_SpeakNPC_NotFound(t *testing.T) {
+	t.Parallel()
+
+	npc := &agentmock.NPCAgent{IDResult: "npc-1", NameResult: "Greymantle"}
+	handler := newTestHandlerWithNPCs(t, "s1", npc)
+	defer handler.StopAll(context.Background())
+
+	if err := handler.SpeakNPC(context.Background(), "s1", "Nonexistent", "test"); err == nil {
+		t.Fatal("expected error for unknown NPC name")
+	}
+}
+
+func TestWorkerHandler_NPCOps_SessionNotFound(t *testing.T) {
+	t.Parallel()
+
+	handler := NewWorkerHandler(
+		func(_ context.Context, req gateway.StartSessionRequest) (*Runtime, error) {
+			return NewRuntime(RuntimeConfig{SessionID: req.SessionID}), nil
+		},
+		nil,
+	)
+
+	ctx := context.Background()
+
+	if err := handler.MuteNPC(ctx, "bad", "test"); err == nil {
+		t.Error("MuteNPC: expected error for unknown session")
+	}
+	if err := handler.UnmuteNPC(ctx, "bad", "test"); err == nil {
+		t.Error("UnmuteNPC: expected error for unknown session")
+	}
+	if _, err := handler.MuteAllNPCs(ctx, "bad"); err == nil {
+		t.Error("MuteAllNPCs: expected error for unknown session")
+	}
+	if _, err := handler.UnmuteAllNPCs(ctx, "bad"); err == nil {
+		t.Error("UnmuteAllNPCs: expected error for unknown session")
+	}
+	if err := handler.SpeakNPC(ctx, "bad", "test", "text"); err == nil {
+		t.Error("SpeakNPC: expected error for unknown session")
+	}
+}

--- a/proto/glyphoxa/v1/session.proto
+++ b/proto/glyphoxa/v1/session.proto
@@ -92,6 +92,71 @@ message HeartbeatRequest {
 // HeartbeatResponse is the gateway's acknowledgement of a heartbeat.
 message HeartbeatResponse {}
 
+// NPCInfo describes an NPC within a running session.
+message NPCInfo {
+  string id = 1;
+  string name = 2;
+  bool muted = 3;
+}
+
+// ListNPCsRequest asks a worker for the NPCs in a session.
+message ListNPCsRequest {
+  string session_id = 1;
+}
+
+// ListNPCsResponse returns the NPCs in a session.
+message ListNPCsResponse {
+  repeated NPCInfo npcs = 1;
+}
+
+// MuteNPCRequest asks a worker to mute a specific NPC.
+message MuteNPCRequest {
+  string session_id = 1;
+  string npc_name = 2;
+}
+
+// MuteNPCResponse is the worker's reply after muting an NPC.
+message MuteNPCResponse {}
+
+// UnmuteNPCRequest asks a worker to unmute a specific NPC.
+message UnmuteNPCRequest {
+  string session_id = 1;
+  string npc_name = 2;
+}
+
+// UnmuteNPCResponse is the worker's reply after unmuting an NPC.
+message UnmuteNPCResponse {}
+
+// MuteAllNPCsRequest asks a worker to mute all NPCs in a session.
+message MuteAllNPCsRequest {
+  string session_id = 1;
+}
+
+// MuteAllNPCsResponse returns how many NPCs were muted.
+message MuteAllNPCsResponse {
+  int32 count = 1;
+}
+
+// UnmuteAllNPCsRequest asks a worker to unmute all NPCs in a session.
+message UnmuteAllNPCsRequest {
+  string session_id = 1;
+}
+
+// UnmuteAllNPCsResponse returns how many NPCs were unmuted.
+message UnmuteAllNPCsResponse {
+  int32 count = 1;
+}
+
+// SpeakNPCRequest asks a worker to make an NPC speak pre-written text.
+message SpeakNPCRequest {
+  string session_id = 1;
+  string npc_name = 2;
+  string text = 3;
+}
+
+// SpeakNPCResponse is the worker's reply after triggering NPC speech.
+message SpeakNPCResponse {}
+
 // SessionWorkerService is the gRPC service exposed by workers, called by the gateway.
 service SessionWorkerService {
   // StartSession tells the worker to begin a new voice session.
@@ -100,6 +165,18 @@ service SessionWorkerService {
   rpc StopSession(StopSessionRequest) returns (StopSessionResponse);
   // GetStatus returns the status of one or all sessions on this worker.
   rpc GetStatus(GetStatusRequest) returns (GetStatusResponse);
+  // ListNPCs returns the NPCs in a running session.
+  rpc ListNPCs(ListNPCsRequest) returns (ListNPCsResponse);
+  // MuteNPC mutes a specific NPC in a session.
+  rpc MuteNPC(MuteNPCRequest) returns (MuteNPCResponse);
+  // UnmuteNPC unmutes a specific NPC in a session.
+  rpc UnmuteNPC(UnmuteNPCRequest) returns (UnmuteNPCResponse);
+  // MuteAllNPCs mutes all NPCs in a session.
+  rpc MuteAllNPCs(MuteAllNPCsRequest) returns (MuteAllNPCsResponse);
+  // UnmuteAllNPCs unmutes all NPCs in a session.
+  rpc UnmuteAllNPCs(UnmuteAllNPCsRequest) returns (UnmuteAllNPCsResponse);
+  // SpeakNPC forces an NPC to speak pre-written text.
+  rpc SpeakNPC(SpeakNPCRequest) returns (SpeakNPCResponse);
 }
 
 // SessionGatewayService is the gRPC service exposed by the gateway, called by workers.


### PR DESCRIPTION
## Summary
- NPC gRPC extensions: ListNPCs, MuteNPC, UnmuteNPC, SpeakNPC, MuteAllNPCs, UnmuteAllNPCs
- Gateway NPC slash command handlers (`/npc list`, `/npc mute`, `/npc unmute`, `/npc speak`)
- Recap command for gateway mode (text-only, reads from shared PostgreSQL)
- Rebased cleanly onto main after Lane K merge

Cherry-picked from original Lane J branch, conflicts with Lane K resolved.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>