### PR TITLE
fix(gateway): don't unregister slash commands on bot close

### DIFF
--- a/internal/gateway/botconnector.go
+++ b/internal/gateway/botconnector.go
@@ -124,8 +124,14 @@ func (c *DiscordBotConnector) ConnectBotForTenant(ctx context.Context, tenant Te
 	return nil
 }
 
-// DisconnectBot removes and closes the bot for the given tenant.
+// DisconnectBot unregisters commands and then removes and closes the bot for
+// the given tenant. This should only be called when the tenant is being
+// permanently deleted — reconnects use [BotManager.RemoveBot] directly which
+// skips command unregistration.
 func (c *DiscordBotConnector) DisconnectBot(tenantID string) {
+	if gwBot, ok := c.mgr.GetBot(tenantID); ok {
+		gwBot.UnregisterCommands()
+	}
 	if err := c.mgr.RemoveBot(tenantID); err != nil {
 		slog.Debug("admin: disconnect bot (no-op)", "tenant_id", tenantID, "reason", err)
 	} else {

--- a/internal/gateway/gateway_bot.go
+++ b/internal/gateway/gateway_bot.go
@@ -80,16 +80,24 @@ func (g *GatewayBot) RegisterCommands(_ context.Context) error {
 	return nil
 }
 
-// Close unregisters commands and closes the Discord client.
-func (g *GatewayBot) Close(ctx context.Context) {
+// UnregisterCommands removes all slash commands from Discord for each guild.
+// Call this only when the tenant is being permanently deleted, not on
+// reconnect or restart — commands persist across bot restarts and the new
+// connection will overwrite them via [RegisterCommands].
+func (g *GatewayBot) UnregisterCommands() {
 	for _, guildID := range g.guildIDs {
 		if _, err := g.client.Rest.SetGuildCommands(g.client.ApplicationID, guildID, nil); err != nil {
-			slog.Debug("gateway: failed to unregister commands on close",
+			slog.Debug("gateway: failed to unregister commands",
 				"tenant_id", g.tenantID,
 				"guild_id", guildID,
 				"err", err,
 			)
 		}
 	}
+}
+
+// Close closes the Discord client without unregistering commands.
+// Commands are left in place so they remain available across restarts.
+func (g *GatewayBot) Close(ctx context.Context) {
 	g.client.Close(ctx)
 }


### PR DESCRIPTION
## Summary
- **Removed** `SetGuildCommands(nil)` from `GatewayBot.Close()` — commands now persist across restarts/reconnects
- **Added** `GatewayBot.UnregisterCommands()` for explicit cleanup, called only from `DisconnectBot()` (tenant deletion path)
- Eliminates the ~33s window where users see no slash commands after a gateway restart or bot reconnect

## Test plan
- [x] `go test -race -count=1 ./internal/gateway/...` — all pass
- [ ] Deploy and verify commands remain visible during bot reconnect
- [ ] Verify commands are cleaned up on tenant DELETE