### PR TITLE
fix(sessionorch): clean up stale pending sessions + fix worker job template

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -537,6 +537,14 @@ func runGateway(cfg *config.Config) int {
 				} else if n > 0 {
 					slog.Info("cleaned up zombie sessions", "count", n)
 				}
+				// Clean up sessions stuck in 'pending' beyond the dispatch
+				// timeout + buffer. These are sessions where dispatch failed
+				// but the transition to 'ended' was missed.
+				if n, err := orch.CleanupStalePending(ctx, 3*time.Minute); err != nil {
+					slog.Warn("stale pending cleanup error", "err", err)
+				} else if n > 0 {
+					slog.Info("cleaned up stale pending sessions", "count", n)
+				}
 				// Clean up orphaned K8s Jobs alongside zombie sessions.
 				if dispatcher != nil {
 					activeSessions, orchErr := orch.ActiveSessions(ctx, "")

--- a/deploy/zhi/workspace/templates/worker-job-template-configmap.yaml.tmpl
+++ b/deploy/zhi/workspace/templates/worker-job-template-configmap.yaml.tmpl
@@ -72,13 +72,16 @@ data:
 {{- end }}
           securityContext:
             runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
+            fsGroup: 999
             seccompProfile:
               type: RuntimeDefault
           containers:
             - name: worker
               image: {{ $repo }}:{{ $tag }}
               imagePullPolicy: {{ $pullPolicy }}
-              args: ["--mode=worker"]
+              args: ["--mode=worker", "--config=/etc/glyphoxa/config.yaml"]
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/internal/gateway/sessionorch/memory.go
+++ b/internal/gateway/sessionorch/memory.go
@@ -163,3 +163,28 @@ func (m *MemoryOrchestrator) CleanupZombies(_ context.Context, timeout time.Dura
 
 	return count, nil
 }
+
+// CleanupStalePending transitions sessions stuck in 'pending' state
+// older than maxAge to ended.
+func (m *MemoryOrchestrator) CleanupStalePending(_ context.Context, maxAge time.Duration) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cutoff := time.Now().UTC().Add(-maxAge)
+	count := 0
+
+	for _, s := range m.sessions {
+		if s.State != gateway.SessionPending {
+			continue
+		}
+		if s.StartedAt.Before(cutoff) {
+			s.State = gateway.SessionEnded
+			now := time.Now().UTC()
+			s.EndedAt = &now
+			s.Error = "stale pending: dispatch timeout"
+			count++
+		}
+	}
+
+	return count, nil
+}

--- a/internal/gateway/sessionorch/memory_test.go
+++ b/internal/gateway/sessionorch/memory_test.go
@@ -358,3 +358,145 @@ func TestMemoryOrchestrator_CleanupZombies(t *testing.T) {
 		t.Errorf("got error %q, want %q", s.Error, "heartbeat timeout")
 	}
 }
+
+func TestMemoryOrchestrator_CleanupStalePending(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cleans up old pending sessions", func(t *testing.T) {
+		t.Parallel()
+		m := NewMemoryOrchestrator()
+		ctx := context.Background()
+
+		id, _ := m.ValidateAndCreate(ctx, SessionRequest{
+			TenantID:    "t1",
+			CampaignID:  "c1",
+			GuildID:     "g1",
+			LicenseTier: config.TierShared,
+		})
+
+		// Backdate the session's StartedAt to simulate an old pending session.
+		m.mu.Lock()
+		m.sessions[id].StartedAt = time.Now().UTC().Add(-5 * time.Minute)
+		m.mu.Unlock()
+
+		count, err := m.CleanupStalePending(ctx, 2*time.Minute)
+		if err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+		if count != 1 {
+			t.Fatalf("got %d cleaned up, want 1", count)
+		}
+
+		s, _ := m.GetSession(ctx, id)
+		if s.State != gateway.SessionEnded {
+			t.Errorf("got state %v, want %v", s.State, gateway.SessionEnded)
+		}
+		if s.Error != "stale pending: dispatch timeout" {
+			t.Errorf("got error %q, want %q", s.Error, "stale pending: dispatch timeout")
+		}
+	})
+
+	t.Run("ignores recent pending sessions", func(t *testing.T) {
+		t.Parallel()
+		m := NewMemoryOrchestrator()
+		ctx := context.Background()
+
+		_, _ = m.ValidateAndCreate(ctx, SessionRequest{
+			TenantID:    "t1",
+			CampaignID:  "c1",
+			GuildID:     "g1",
+			LicenseTier: config.TierShared,
+		})
+
+		// Session was just created — should not be cleaned up.
+		count, err := m.CleanupStalePending(ctx, 2*time.Minute)
+		if err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("got %d cleaned up, want 0", count)
+		}
+	})
+
+	t.Run("ignores active and ended sessions", func(t *testing.T) {
+		t.Parallel()
+		m := NewMemoryOrchestrator()
+		ctx := context.Background()
+
+		id1, _ := m.ValidateAndCreate(ctx, SessionRequest{
+			TenantID:    "t1",
+			CampaignID:  "c1",
+			GuildID:     "g1",
+			LicenseTier: config.TierDedicated,
+		})
+		id2, _ := m.ValidateAndCreate(ctx, SessionRequest{
+			TenantID:    "t1",
+			CampaignID:  "c2",
+			GuildID:     "g2",
+			LicenseTier: config.TierDedicated,
+		})
+
+		// Transition one to active, one to ended.
+		_ = m.Transition(ctx, id1, gateway.SessionActive, "")
+		_ = m.Transition(ctx, id2, gateway.SessionEnded, "done")
+
+		// Backdate both to be old.
+		m.mu.Lock()
+		old := time.Now().UTC().Add(-10 * time.Minute)
+		m.sessions[id1].StartedAt = old
+		m.sessions[id2].StartedAt = old
+		m.mu.Unlock()
+
+		count, err := m.CleanupStalePending(ctx, 2*time.Minute)
+		if err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("got %d cleaned up, want 0 (neither is pending)", count)
+		}
+	})
+
+	t.Run("frees tenant slot after cleanup", func(t *testing.T) {
+		t.Parallel()
+		m := NewMemoryOrchestrator()
+		ctx := context.Background()
+
+		_, _ = m.ValidateAndCreate(ctx, SessionRequest{
+			TenantID:    "t1",
+			CampaignID:  "c1",
+			GuildID:     "g1",
+			LicenseTier: config.TierShared,
+		})
+
+		// Second session for same shared tenant should fail.
+		_, err := m.ValidateAndCreate(ctx, SessionRequest{
+			TenantID:    "t1",
+			CampaignID:  "c2",
+			GuildID:     "g2",
+			LicenseTier: config.TierShared,
+		})
+		if err == nil {
+			t.Fatal("expected constraint error")
+		}
+
+		// Backdate and clean up the stale pending session.
+		m.mu.Lock()
+		for _, s := range m.sessions {
+			s.StartedAt = time.Now().UTC().Add(-5 * time.Minute)
+		}
+		m.mu.Unlock()
+
+		_, _ = m.CleanupStalePending(ctx, 2*time.Minute)
+
+		// Now the tenant slot should be free.
+		_, err = m.ValidateAndCreate(ctx, SessionRequest{
+			TenantID:    "t1",
+			CampaignID:  "c2",
+			GuildID:     "g2",
+			LicenseTier: config.TierShared,
+		})
+		if err != nil {
+			t.Fatalf("expected slot freed after cleanup, got: %v", err)
+		}
+	})
+}

--- a/internal/gateway/sessionorch/orchestrator.go
+++ b/internal/gateway/sessionorch/orchestrator.go
@@ -64,4 +64,10 @@ type Orchestrator interface {
 	// CleanupZombies transitions sessions with stale heartbeats to ended.
 	// Called periodically by the gateway.
 	CleanupZombies(ctx context.Context, timeout time.Duration) (int, error)
+
+	// CleanupStalePending transitions sessions stuck in 'pending' state
+	// older than the given age to ended. These are sessions where dispatch
+	// failed but the transition to 'ended' was missed (e.g., gateway crash
+	// during dispatch, context cancellation before DB write).
+	CleanupStalePending(ctx context.Context, maxAge time.Duration) (int, error)
 }

--- a/internal/gateway/sessionorch/postgres.go
+++ b/internal/gateway/sessionorch/postgres.go
@@ -180,6 +180,26 @@ func (p *PostgresOrchestrator) CleanupZombies(ctx context.Context, timeout time.
 	return count, nil
 }
 
+// CleanupStalePending transitions sessions stuck in 'pending' state
+// older than maxAge to ended.
+func (p *PostgresOrchestrator) CleanupStalePending(ctx context.Context, maxAge time.Duration) (int, error) {
+	tag, err := p.pool.Exec(ctx, `
+		UPDATE sessions
+		SET state = 'ended', error = 'stale pending: dispatch timeout', ended_at = now()
+		WHERE state = 'pending'
+		  AND started_at < now() - $1::interval
+	`, maxAge.String())
+	if err != nil {
+		return 0, fmt.Errorf("sessionorch: cleanup stale pending: %w", err)
+	}
+
+	count := int(tag.RowsAffected())
+	if count > 0 {
+		slog.Warn("sessionorch: cleaned up stale pending sessions", "count", count)
+	}
+	return count, nil
+}
+
 // scanSessions reads session rows into a slice.
 func scanSessions(rows pgx.Rows) ([]Session, error) {
 	var sessions []Session

--- a/internal/gateway/usage/quota_guard.go
+++ b/internal/gateway/usage/quota_guard.go
@@ -74,3 +74,8 @@ func (g *QuotaGuard) GetSession(ctx context.Context, sessionID string) (sessiono
 func (g *QuotaGuard) CleanupZombies(ctx context.Context, timeout time.Duration) (int, error) {
 	return g.inner.CleanupZombies(ctx, timeout)
 }
+
+// CleanupStalePending delegates to the inner orchestrator.
+func (g *QuotaGuard) CleanupStalePending(ctx context.Context, maxAge time.Duration) (int, error) {
+	return g.inner.CleanupStalePending(ctx, maxAge)
+}


### PR DESCRIPTION
## Summary
- **Stale pending cleanup**: Added `CleanupStalePending` to the `Orchestrator` interface (Postgres, Memory, QuotaGuard implementations). Sessions stuck in `pending` state for longer than 3 minutes are transitioned to `ended` with error `stale pending: dispatch timeout`. Runs on the existing 15s zombie cleanup ticker.
- **Bug context**: When a worker pod fails (crash, image pull error, security context issue), the dispatch path in `sessionctrl.go` already transitions the session to `ended`. But if *that* transition itself fails (DB unreachable, gateway crash mid-dispatch), the session stays pending forever, blocking the tenant's shared-tier unique constraint.
- **Worker job template fixes**: Added `runAsUser: 999`, `runAsGroup: 999`, `fsGroup: 999` to pod security context, and `--config=/etc/glyphoxa/config.yaml` to container args — matching the manual fixes applied to the K3s cluster.

## Test plan
- [x] `go test -race -count=1 ./internal/gateway/...` — all pass
- [x] New tests in `memory_test.go`: `TestMemoryOrchestrator_CleanupStalePending` covers old pending cleanup, recent pending preservation, active/ended session exclusion, and tenant slot freeing after cleanup
- [ ] Deploy to staging and verify: create a session, kill the worker pod before it's ready, confirm the pending session gets cleaned up within ~3 minutes