### PR TITLE
feat(voice): voice state proxy — gateway captures creds, worker connects directly

### DIFF
--- a/cmd/glyphoxa/worker_factory.go
+++ b/cmd/glyphoxa/worker_factory.go
@@ -107,30 +107,62 @@ func (wf *workerFactory) CreateRuntime(ctx context.Context, req gw.StartSessionR
 	}
 
 	// ── 3. Discord voice connection ──────────────────────────────────────────
-	if req.BotToken == "" {
+	if req.BotToken == "" && req.VoiceSessionID == "" {
 		if storeCloser != nil {
 			_ = storeCloser()
 		}
-		return nil, fmt.Errorf("worker: bot_token is required in StartSessionRequest")
+		return nil, fmt.Errorf("worker: bot_token or voice proxy credentials required in StartSessionRequest")
 	}
 
-	platform, err := discord.NewVoiceOnlyPlatform(sessionCtx, req.BotToken, req.GuildID,
-		discord.WithVoiceManagerOpts(voice.WithDaveSessionCreateFunc(golibdave.NewSession)),
-	)
-	if err != nil {
-		if storeCloser != nil {
-			_ = storeCloser()
-		}
-		return nil, fmt.Errorf("worker: create voice platform: %w", err)
-	}
+	var voicePlatformCloser func() error
+	var voiceProxy *discord.VoiceProxyPlatform
+	var conn audio.Connection
 
-	conn, err := platform.Connect(sessionCtx, req.ChannelID)
-	if err != nil {
-		_ = platform.Close()
-		if storeCloser != nil {
-			_ = storeCloser()
+	if req.VoiceSessionID != "" && req.VoiceToken != "" && req.VoiceEndpoint != "" {
+		// Distributed mode with voice proxy: use pre-captured credentials.
+		proxyPlatform, err := discord.NewVoiceProxyPlatform(
+			req.GuildID, req.BotUserID,
+			voice.WithConnDaveSessionCreateFunc(golibdave.NewSession),
+		)
+		if err != nil {
+			if storeCloser != nil {
+				_ = storeCloser()
+			}
+			return nil, fmt.Errorf("worker: create voice proxy platform: %w", err)
 		}
-		return nil, fmt.Errorf("worker: connect to voice channel %s: %w", req.ChannelID, err)
+
+		conn, err = proxyPlatform.Connect(sessionCtx,
+			req.ChannelID, req.VoiceSessionID, req.VoiceToken, req.VoiceEndpoint)
+		if err != nil {
+			_ = proxyPlatform.Close()
+			if storeCloser != nil {
+				_ = storeCloser()
+			}
+			return nil, fmt.Errorf("worker: voice proxy connect to %s: %w", req.ChannelID, err)
+		}
+		voicePlatformCloser = proxyPlatform.Close
+		voiceProxy = proxyPlatform
+	} else {
+		// Full mode: open own gateway (existing code path).
+		platform, err := discord.NewVoiceOnlyPlatform(sessionCtx, req.BotToken, req.GuildID,
+			discord.WithVoiceManagerOpts(voice.WithDaveSessionCreateFunc(golibdave.NewSession)),
+		)
+		if err != nil {
+			if storeCloser != nil {
+				_ = storeCloser()
+			}
+			return nil, fmt.Errorf("worker: create voice platform: %w", err)
+		}
+
+		conn, err = platform.Connect(sessionCtx, req.ChannelID)
+		if err != nil {
+			_ = voicePlatformCloser()
+			if storeCloser != nil {
+				_ = storeCloser()
+			}
+			return nil, fmt.Errorf("worker: connect to voice channel %s: %w", req.ChannelID, err)
+		}
+		voicePlatformCloser = platform.Close
 	}
 
 	// ── 4. Mixer ─────────────────────────────────────────────────────────────
@@ -145,7 +177,7 @@ func (wf *workerFactory) CreateRuntime(ctx context.Context, req gw.StartSessionR
 	if len(npcs) == 0 {
 		_ = pm.Close()
 		_ = conn.Disconnect()
-		_ = platform.Close()
+		_ = voicePlatformCloser()
 		if storeCloser != nil {
 			_ = storeCloser()
 		}
@@ -192,7 +224,7 @@ func (wf *workerFactory) CreateRuntime(ctx context.Context, req gw.StartSessionR
 	if err != nil {
 		_ = pm.Close()
 		_ = conn.Disconnect()
-		_ = platform.Close()
+		_ = voicePlatformCloser()
 		if storeCloser != nil {
 			_ = storeCloser()
 		}
@@ -210,7 +242,7 @@ func (wf *workerFactory) CreateRuntime(ctx context.Context, req gw.StartSessionR
 			}
 			_ = pm.Close()
 			_ = conn.Disconnect()
-			_ = platform.Close()
+			_ = voicePlatformCloser()
 			if storeCloser != nil {
 				_ = storeCloser()
 			}
@@ -229,7 +261,7 @@ func (wf *workerFactory) CreateRuntime(ctx context.Context, req gw.StartSessionR
 			}
 			_ = pm.Close()
 			_ = conn.Disconnect()
-			_ = platform.Close()
+			_ = voicePlatformCloser()
 			if storeCloser != nil {
 				_ = storeCloser()
 			}
@@ -321,6 +353,7 @@ func (wf *workerFactory) CreateRuntime(ctx context.Context, req gw.StartSessionR
 		Mixer:        pm,
 		Connection:   conn,
 		SessionStore: sessionStore,
+		VoiceProxy:   voiceProxy,
 	})
 
 	// Register closers in correct teardown order:
@@ -350,9 +383,7 @@ func (wf *workerFactory) CreateRuntime(ctx context.Context, req gw.StartSessionR
 		return conn.Disconnect()
 	})
 
-	rt.AddCloser(func() error {
-		return platform.Close()
-	})
+	rt.AddCloser(voicePlatformCloser)
 
 	if storeCloser != nil {
 		rt.AddCloser(storeCloser)

--- a/gen/glyphoxa/v1/session.pb.go
+++ b/gen/glyphoxa/v1/session.pb.go
@@ -178,17 +178,24 @@ func (x *NPCConfig) GetAddressOnly() bool {
 
 // StartSessionRequest is sent by the gateway to a worker to start a new voice session.
 type StartSessionRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	TenantId      string                 `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
-	CampaignId    string                 `protobuf:"bytes,2,opt,name=campaign_id,json=campaignId,proto3" json:"campaign_id,omitempty"`
-	GuildId       string                 `protobuf:"bytes,3,opt,name=guild_id,json=guildId,proto3" json:"guild_id,omitempty"`
-	ChannelId     string                 `protobuf:"bytes,4,opt,name=channel_id,json=channelId,proto3" json:"channel_id,omitempty"`
-	LicenseTier   string                 `protobuf:"bytes,5,opt,name=license_tier,json=licenseTier,proto3" json:"license_tier,omitempty"`
-	SessionId     string                 `protobuf:"bytes,6,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	NpcConfigs    []*NPCConfig           `protobuf:"bytes,7,rep,name=npc_configs,json=npcConfigs,proto3" json:"npc_configs,omitempty"`
-	BotToken      string                 `protobuf:"bytes,8,opt,name=bot_token,json=botToken,proto3" json:"bot_token,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	TenantId    string                 `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	CampaignId  string                 `protobuf:"bytes,2,opt,name=campaign_id,json=campaignId,proto3" json:"campaign_id,omitempty"`
+	GuildId     string                 `protobuf:"bytes,3,opt,name=guild_id,json=guildId,proto3" json:"guild_id,omitempty"`
+	ChannelId   string                 `protobuf:"bytes,4,opt,name=channel_id,json=channelId,proto3" json:"channel_id,omitempty"`
+	LicenseTier string                 `protobuf:"bytes,5,opt,name=license_tier,json=licenseTier,proto3" json:"license_tier,omitempty"`
+	SessionId   string                 `protobuf:"bytes,6,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	NpcConfigs  []*NPCConfig           `protobuf:"bytes,7,rep,name=npc_configs,json=npcConfigs,proto3" json:"npc_configs,omitempty"`
+	BotToken    string                 `protobuf:"bytes,8,opt,name=bot_token,json=botToken,proto3" json:"bot_token,omitempty"`
+	// Voice proxy credentials (populated by gateway in distributed mode).
+	// When set, the worker connects directly to the Discord voice server
+	// without opening its own bot gateway connection.
+	VoiceSessionId string `protobuf:"bytes,9,opt,name=voice_session_id,json=voiceSessionId,proto3" json:"voice_session_id,omitempty"` // from VOICE_STATE_UPDATE
+	VoiceToken     string `protobuf:"bytes,10,opt,name=voice_token,json=voiceToken,proto3" json:"voice_token,omitempty"`              // from VOICE_SERVER_UPDATE
+	VoiceEndpoint  string `protobuf:"bytes,11,opt,name=voice_endpoint,json=voiceEndpoint,proto3" json:"voice_endpoint,omitempty"`     // from VOICE_SERVER_UPDATE
+	BotUserId      string `protobuf:"bytes,12,opt,name=bot_user_id,json=botUserId,proto3" json:"bot_user_id,omitempty"`               // bot's Discord user snowflake
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *StartSessionRequest) Reset() {
@@ -273,6 +280,34 @@ func (x *StartSessionRequest) GetNpcConfigs() []*NPCConfig {
 func (x *StartSessionRequest) GetBotToken() string {
 	if x != nil {
 		return x.BotToken
+	}
+	return ""
+}
+
+func (x *StartSessionRequest) GetVoiceSessionId() string {
+	if x != nil {
+		return x.VoiceSessionId
+	}
+	return ""
+}
+
+func (x *StartSessionRequest) GetVoiceToken() string {
+	if x != nil {
+		return x.VoiceToken
+	}
+	return ""
+}
+
+func (x *StartSessionRequest) GetVoiceEndpoint() string {
+	if x != nil {
+		return x.VoiceEndpoint
+	}
+	return ""
+}
+
+func (x *StartSessionRequest) GetBotUserId() string {
+	if x != nil {
+		return x.BotUserId
 	}
 	return ""
 }
@@ -1377,6 +1412,105 @@ func (*SpeakNPCResponse) Descriptor() ([]byte, []int) {
 	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{24}
 }
 
+// UpdateVoiceServerRequest forwards a mid-session VOICE_SERVER_UPDATE from
+// the gateway to the worker so it can reconnect to a new voice server.
+type UpdateVoiceServerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Token         string                 `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty"`
+	Endpoint      string                 `protobuf:"bytes,3,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateVoiceServerRequest) Reset() {
+	*x = UpdateVoiceServerRequest{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateVoiceServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateVoiceServerRequest) ProtoMessage() {}
+
+func (x *UpdateVoiceServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateVoiceServerRequest.ProtoReflect.Descriptor instead.
+func (*UpdateVoiceServerRequest) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *UpdateVoiceServerRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *UpdateVoiceServerRequest) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
+func (x *UpdateVoiceServerRequest) GetEndpoint() string {
+	if x != nil {
+		return x.Endpoint
+	}
+	return ""
+}
+
+// UpdateVoiceServerResponse is the worker's acknowledgement.
+type UpdateVoiceServerResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateVoiceServerResponse) Reset() {
+	*x = UpdateVoiceServerResponse{}
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateVoiceServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateVoiceServerResponse) ProtoMessage() {}
+
+func (x *UpdateVoiceServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_glyphoxa_v1_session_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateVoiceServerResponse.ProtoReflect.Descriptor instead.
+func (*UpdateVoiceServerResponse) Descriptor() ([]byte, []int) {
+	return file_glyphoxa_v1_session_proto_rawDescGZIP(), []int{26}
+}
+
 var File_glyphoxa_v1_session_proto protoreflect.FileDescriptor
 
 const file_glyphoxa_v1_session_proto_rawDesc = "" +
@@ -1391,7 +1525,7 @@ const file_glyphoxa_v1_session_proto_rawDesc = "" +
 	"\vbudget_tier\x18\x06 \x01(\tR\n" +
 	"budgetTier\x12\x1b\n" +
 	"\tgm_helper\x18\a \x01(\bR\bgmHelper\x12!\n" +
-	"\faddress_only\x18\b \x01(\bR\vaddressOnly\"\xa5\x02\n" +
+	"\faddress_only\x18\b \x01(\bR\vaddressOnly\"\xb7\x03\n" +
 	"\x13StartSessionRequest\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x1f\n" +
 	"\vcampaign_id\x18\x02 \x01(\tR\n" +
@@ -1404,7 +1538,13 @@ const file_glyphoxa_v1_session_proto_rawDesc = "" +
 	"session_id\x18\x06 \x01(\tR\tsessionId\x127\n" +
 	"\vnpc_configs\x18\a \x03(\v2\x16.glyphoxa.v1.NPCConfigR\n" +
 	"npcConfigs\x12\x1b\n" +
-	"\tbot_token\x18\b \x01(\tR\bbotToken\"K\n" +
+	"\tbot_token\x18\b \x01(\tR\bbotToken\x12(\n" +
+	"\x10voice_session_id\x18\t \x01(\tR\x0evoiceSessionId\x12\x1f\n" +
+	"\vvoice_token\x18\n" +
+	" \x01(\tR\n" +
+	"voiceToken\x12%\n" +
+	"\x0evoice_endpoint\x18\v \x01(\tR\rvoiceEndpoint\x12\x1e\n" +
+	"\vbot_user_id\x18\f \x01(\tR\tbotUserId\"K\n" +
 	"\x14StartSessionResponse\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x14\n" +
@@ -1472,12 +1612,18 @@ const file_glyphoxa_v1_session_proto_rawDesc = "" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x19\n" +
 	"\bnpc_name\x18\x02 \x01(\tR\anpcName\x12\x12\n" +
 	"\x04text\x18\x03 \x01(\tR\x04text\"\x12\n" +
-	"\x10SpeakNPCResponse*{\n" +
+	"\x10SpeakNPCResponse\"k\n" +
+	"\x18UpdateVoiceServerRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x14\n" +
+	"\x05token\x18\x02 \x01(\tR\x05token\x12\x1a\n" +
+	"\bendpoint\x18\x03 \x01(\tR\bendpoint\"\x1b\n" +
+	"\x19UpdateVoiceServerResponse*{\n" +
 	"\fSessionState\x12\x1d\n" +
 	"\x19SESSION_STATE_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15SESSION_STATE_PENDING\x10\x01\x12\x18\n" +
 	"\x14SESSION_STATE_ACTIVE\x10\x02\x12\x17\n" +
-	"\x13SESSION_STATE_ENDED\x10\x032\xd7\x05\n" +
+	"\x13SESSION_STATE_ENDED\x10\x032\xbb\x06\n" +
 	"\x14SessionWorkerService\x12S\n" +
 	"\fStartSession\x12 .glyphoxa.v1.StartSessionRequest\x1a!.glyphoxa.v1.StartSessionResponse\x12P\n" +
 	"\vStopSession\x12\x1f.glyphoxa.v1.StopSessionRequest\x1a .glyphoxa.v1.StopSessionResponse\x12J\n" +
@@ -1487,7 +1633,8 @@ const file_glyphoxa_v1_session_proto_rawDesc = "" +
 	"\tUnmuteNPC\x12\x1d.glyphoxa.v1.UnmuteNPCRequest\x1a\x1e.glyphoxa.v1.UnmuteNPCResponse\x12P\n" +
 	"\vMuteAllNPCs\x12\x1f.glyphoxa.v1.MuteAllNPCsRequest\x1a .glyphoxa.v1.MuteAllNPCsResponse\x12V\n" +
 	"\rUnmuteAllNPCs\x12!.glyphoxa.v1.UnmuteAllNPCsRequest\x1a\".glyphoxa.v1.UnmuteAllNPCsResponse\x12G\n" +
-	"\bSpeakNPC\x12\x1c.glyphoxa.v1.SpeakNPCRequest\x1a\x1d.glyphoxa.v1.SpeakNPCResponse2\xb5\x01\n" +
+	"\bSpeakNPC\x12\x1c.glyphoxa.v1.SpeakNPCRequest\x1a\x1d.glyphoxa.v1.SpeakNPCResponse\x12b\n" +
+	"\x11UpdateVoiceServer\x12%.glyphoxa.v1.UpdateVoiceServerRequest\x1a&.glyphoxa.v1.UpdateVoiceServerResponse2\xb5\x01\n" +
 	"\x15SessionGatewayService\x12P\n" +
 	"\vReportState\x12\x1f.glyphoxa.v1.ReportStateRequest\x1a .glyphoxa.v1.ReportStateResponse\x12J\n" +
 	"\tHeartbeat\x12\x1d.glyphoxa.v1.HeartbeatRequest\x1a\x1e.glyphoxa.v1.HeartbeatResponseB9Z7github.com/MrWong99/glyphoxa/gen/glyphoxa/v1;glyphoxav1b\x06proto3"
@@ -1505,40 +1652,42 @@ func file_glyphoxa_v1_session_proto_rawDescGZIP() []byte {
 }
 
 var file_glyphoxa_v1_session_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_glyphoxa_v1_session_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_glyphoxa_v1_session_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
 var file_glyphoxa_v1_session_proto_goTypes = []any{
-	(SessionState)(0),             // 0: glyphoxa.v1.SessionState
-	(*NPCConfig)(nil),             // 1: glyphoxa.v1.NPCConfig
-	(*StartSessionRequest)(nil),   // 2: glyphoxa.v1.StartSessionRequest
-	(*StartSessionResponse)(nil),  // 3: glyphoxa.v1.StartSessionResponse
-	(*StopSessionRequest)(nil),    // 4: glyphoxa.v1.StopSessionRequest
-	(*StopSessionResponse)(nil),   // 5: glyphoxa.v1.StopSessionResponse
-	(*GetStatusRequest)(nil),      // 6: glyphoxa.v1.GetStatusRequest
-	(*SessionStatus)(nil),         // 7: glyphoxa.v1.SessionStatus
-	(*GetStatusResponse)(nil),     // 8: glyphoxa.v1.GetStatusResponse
-	(*ReportStateRequest)(nil),    // 9: glyphoxa.v1.ReportStateRequest
-	(*ReportStateResponse)(nil),   // 10: glyphoxa.v1.ReportStateResponse
-	(*HeartbeatRequest)(nil),      // 11: glyphoxa.v1.HeartbeatRequest
-	(*HeartbeatResponse)(nil),     // 12: glyphoxa.v1.HeartbeatResponse
-	(*NPCInfo)(nil),               // 13: glyphoxa.v1.NPCInfo
-	(*ListNPCsRequest)(nil),       // 14: glyphoxa.v1.ListNPCsRequest
-	(*ListNPCsResponse)(nil),      // 15: glyphoxa.v1.ListNPCsResponse
-	(*MuteNPCRequest)(nil),        // 16: glyphoxa.v1.MuteNPCRequest
-	(*MuteNPCResponse)(nil),       // 17: glyphoxa.v1.MuteNPCResponse
-	(*UnmuteNPCRequest)(nil),      // 18: glyphoxa.v1.UnmuteNPCRequest
-	(*UnmuteNPCResponse)(nil),     // 19: glyphoxa.v1.UnmuteNPCResponse
-	(*MuteAllNPCsRequest)(nil),    // 20: glyphoxa.v1.MuteAllNPCsRequest
-	(*MuteAllNPCsResponse)(nil),   // 21: glyphoxa.v1.MuteAllNPCsResponse
-	(*UnmuteAllNPCsRequest)(nil),  // 22: glyphoxa.v1.UnmuteAllNPCsRequest
-	(*UnmuteAllNPCsResponse)(nil), // 23: glyphoxa.v1.UnmuteAllNPCsResponse
-	(*SpeakNPCRequest)(nil),       // 24: glyphoxa.v1.SpeakNPCRequest
-	(*SpeakNPCResponse)(nil),      // 25: glyphoxa.v1.SpeakNPCResponse
-	(*timestamppb.Timestamp)(nil), // 26: google.protobuf.Timestamp
+	(SessionState)(0),                 // 0: glyphoxa.v1.SessionState
+	(*NPCConfig)(nil),                 // 1: glyphoxa.v1.NPCConfig
+	(*StartSessionRequest)(nil),       // 2: glyphoxa.v1.StartSessionRequest
+	(*StartSessionResponse)(nil),      // 3: glyphoxa.v1.StartSessionResponse
+	(*StopSessionRequest)(nil),        // 4: glyphoxa.v1.StopSessionRequest
+	(*StopSessionResponse)(nil),       // 5: glyphoxa.v1.StopSessionResponse
+	(*GetStatusRequest)(nil),          // 6: glyphoxa.v1.GetStatusRequest
+	(*SessionStatus)(nil),             // 7: glyphoxa.v1.SessionStatus
+	(*GetStatusResponse)(nil),         // 8: glyphoxa.v1.GetStatusResponse
+	(*ReportStateRequest)(nil),        // 9: glyphoxa.v1.ReportStateRequest
+	(*ReportStateResponse)(nil),       // 10: glyphoxa.v1.ReportStateResponse
+	(*HeartbeatRequest)(nil),          // 11: glyphoxa.v1.HeartbeatRequest
+	(*HeartbeatResponse)(nil),         // 12: glyphoxa.v1.HeartbeatResponse
+	(*NPCInfo)(nil),                   // 13: glyphoxa.v1.NPCInfo
+	(*ListNPCsRequest)(nil),           // 14: glyphoxa.v1.ListNPCsRequest
+	(*ListNPCsResponse)(nil),          // 15: glyphoxa.v1.ListNPCsResponse
+	(*MuteNPCRequest)(nil),            // 16: glyphoxa.v1.MuteNPCRequest
+	(*MuteNPCResponse)(nil),           // 17: glyphoxa.v1.MuteNPCResponse
+	(*UnmuteNPCRequest)(nil),          // 18: glyphoxa.v1.UnmuteNPCRequest
+	(*UnmuteNPCResponse)(nil),         // 19: glyphoxa.v1.UnmuteNPCResponse
+	(*MuteAllNPCsRequest)(nil),        // 20: glyphoxa.v1.MuteAllNPCsRequest
+	(*MuteAllNPCsResponse)(nil),       // 21: glyphoxa.v1.MuteAllNPCsResponse
+	(*UnmuteAllNPCsRequest)(nil),      // 22: glyphoxa.v1.UnmuteAllNPCsRequest
+	(*UnmuteAllNPCsResponse)(nil),     // 23: glyphoxa.v1.UnmuteAllNPCsResponse
+	(*SpeakNPCRequest)(nil),           // 24: glyphoxa.v1.SpeakNPCRequest
+	(*SpeakNPCResponse)(nil),          // 25: glyphoxa.v1.SpeakNPCResponse
+	(*UpdateVoiceServerRequest)(nil),  // 26: glyphoxa.v1.UpdateVoiceServerRequest
+	(*UpdateVoiceServerResponse)(nil), // 27: glyphoxa.v1.UpdateVoiceServerResponse
+	(*timestamppb.Timestamp)(nil),     // 28: google.protobuf.Timestamp
 }
 var file_glyphoxa_v1_session_proto_depIdxs = []int32{
 	1,  // 0: glyphoxa.v1.StartSessionRequest.npc_configs:type_name -> glyphoxa.v1.NPCConfig
 	0,  // 1: glyphoxa.v1.SessionStatus.state:type_name -> glyphoxa.v1.SessionState
-	26, // 2: glyphoxa.v1.SessionStatus.started_at:type_name -> google.protobuf.Timestamp
+	28, // 2: glyphoxa.v1.SessionStatus.started_at:type_name -> google.protobuf.Timestamp
 	7,  // 3: glyphoxa.v1.GetStatusResponse.sessions:type_name -> glyphoxa.v1.SessionStatus
 	0,  // 4: glyphoxa.v1.ReportStateRequest.state:type_name -> glyphoxa.v1.SessionState
 	13, // 5: glyphoxa.v1.ListNPCsResponse.npcs:type_name -> glyphoxa.v1.NPCInfo
@@ -1551,21 +1700,23 @@ var file_glyphoxa_v1_session_proto_depIdxs = []int32{
 	20, // 12: glyphoxa.v1.SessionWorkerService.MuteAllNPCs:input_type -> glyphoxa.v1.MuteAllNPCsRequest
 	22, // 13: glyphoxa.v1.SessionWorkerService.UnmuteAllNPCs:input_type -> glyphoxa.v1.UnmuteAllNPCsRequest
 	24, // 14: glyphoxa.v1.SessionWorkerService.SpeakNPC:input_type -> glyphoxa.v1.SpeakNPCRequest
-	9,  // 15: glyphoxa.v1.SessionGatewayService.ReportState:input_type -> glyphoxa.v1.ReportStateRequest
-	11, // 16: glyphoxa.v1.SessionGatewayService.Heartbeat:input_type -> glyphoxa.v1.HeartbeatRequest
-	3,  // 17: glyphoxa.v1.SessionWorkerService.StartSession:output_type -> glyphoxa.v1.StartSessionResponse
-	5,  // 18: glyphoxa.v1.SessionWorkerService.StopSession:output_type -> glyphoxa.v1.StopSessionResponse
-	8,  // 19: glyphoxa.v1.SessionWorkerService.GetStatus:output_type -> glyphoxa.v1.GetStatusResponse
-	15, // 20: glyphoxa.v1.SessionWorkerService.ListNPCs:output_type -> glyphoxa.v1.ListNPCsResponse
-	17, // 21: glyphoxa.v1.SessionWorkerService.MuteNPC:output_type -> glyphoxa.v1.MuteNPCResponse
-	19, // 22: glyphoxa.v1.SessionWorkerService.UnmuteNPC:output_type -> glyphoxa.v1.UnmuteNPCResponse
-	21, // 23: glyphoxa.v1.SessionWorkerService.MuteAllNPCs:output_type -> glyphoxa.v1.MuteAllNPCsResponse
-	23, // 24: glyphoxa.v1.SessionWorkerService.UnmuteAllNPCs:output_type -> glyphoxa.v1.UnmuteAllNPCsResponse
-	25, // 25: glyphoxa.v1.SessionWorkerService.SpeakNPC:output_type -> glyphoxa.v1.SpeakNPCResponse
-	10, // 26: glyphoxa.v1.SessionGatewayService.ReportState:output_type -> glyphoxa.v1.ReportStateResponse
-	12, // 27: glyphoxa.v1.SessionGatewayService.Heartbeat:output_type -> glyphoxa.v1.HeartbeatResponse
-	17, // [17:28] is the sub-list for method output_type
-	6,  // [6:17] is the sub-list for method input_type
+	26, // 15: glyphoxa.v1.SessionWorkerService.UpdateVoiceServer:input_type -> glyphoxa.v1.UpdateVoiceServerRequest
+	9,  // 16: glyphoxa.v1.SessionGatewayService.ReportState:input_type -> glyphoxa.v1.ReportStateRequest
+	11, // 17: glyphoxa.v1.SessionGatewayService.Heartbeat:input_type -> glyphoxa.v1.HeartbeatRequest
+	3,  // 18: glyphoxa.v1.SessionWorkerService.StartSession:output_type -> glyphoxa.v1.StartSessionResponse
+	5,  // 19: glyphoxa.v1.SessionWorkerService.StopSession:output_type -> glyphoxa.v1.StopSessionResponse
+	8,  // 20: glyphoxa.v1.SessionWorkerService.GetStatus:output_type -> glyphoxa.v1.GetStatusResponse
+	15, // 21: glyphoxa.v1.SessionWorkerService.ListNPCs:output_type -> glyphoxa.v1.ListNPCsResponse
+	17, // 22: glyphoxa.v1.SessionWorkerService.MuteNPC:output_type -> glyphoxa.v1.MuteNPCResponse
+	19, // 23: glyphoxa.v1.SessionWorkerService.UnmuteNPC:output_type -> glyphoxa.v1.UnmuteNPCResponse
+	21, // 24: glyphoxa.v1.SessionWorkerService.MuteAllNPCs:output_type -> glyphoxa.v1.MuteAllNPCsResponse
+	23, // 25: glyphoxa.v1.SessionWorkerService.UnmuteAllNPCs:output_type -> glyphoxa.v1.UnmuteAllNPCsResponse
+	25, // 26: glyphoxa.v1.SessionWorkerService.SpeakNPC:output_type -> glyphoxa.v1.SpeakNPCResponse
+	27, // 27: glyphoxa.v1.SessionWorkerService.UpdateVoiceServer:output_type -> glyphoxa.v1.UpdateVoiceServerResponse
+	10, // 28: glyphoxa.v1.SessionGatewayService.ReportState:output_type -> glyphoxa.v1.ReportStateResponse
+	12, // 29: glyphoxa.v1.SessionGatewayService.Heartbeat:output_type -> glyphoxa.v1.HeartbeatResponse
+	18, // [18:30] is the sub-list for method output_type
+	6,  // [6:18] is the sub-list for method input_type
 	6,  // [6:6] is the sub-list for extension type_name
 	6,  // [6:6] is the sub-list for extension extendee
 	0,  // [0:6] is the sub-list for field type_name
@@ -1582,7 +1733,7 @@ func file_glyphoxa_v1_session_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_glyphoxa_v1_session_proto_rawDesc), len(file_glyphoxa_v1_session_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   25,
+			NumMessages:   27,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/gen/glyphoxa/v1/session_grpc.pb.go
+++ b/gen/glyphoxa/v1/session_grpc.pb.go
@@ -19,15 +19,16 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	SessionWorkerService_StartSession_FullMethodName  = "/glyphoxa.v1.SessionWorkerService/StartSession"
-	SessionWorkerService_StopSession_FullMethodName   = "/glyphoxa.v1.SessionWorkerService/StopSession"
-	SessionWorkerService_GetStatus_FullMethodName     = "/glyphoxa.v1.SessionWorkerService/GetStatus"
-	SessionWorkerService_ListNPCs_FullMethodName      = "/glyphoxa.v1.SessionWorkerService/ListNPCs"
-	SessionWorkerService_MuteNPC_FullMethodName       = "/glyphoxa.v1.SessionWorkerService/MuteNPC"
-	SessionWorkerService_UnmuteNPC_FullMethodName     = "/glyphoxa.v1.SessionWorkerService/UnmuteNPC"
-	SessionWorkerService_MuteAllNPCs_FullMethodName   = "/glyphoxa.v1.SessionWorkerService/MuteAllNPCs"
-	SessionWorkerService_UnmuteAllNPCs_FullMethodName = "/glyphoxa.v1.SessionWorkerService/UnmuteAllNPCs"
-	SessionWorkerService_SpeakNPC_FullMethodName      = "/glyphoxa.v1.SessionWorkerService/SpeakNPC"
+	SessionWorkerService_StartSession_FullMethodName      = "/glyphoxa.v1.SessionWorkerService/StartSession"
+	SessionWorkerService_StopSession_FullMethodName       = "/glyphoxa.v1.SessionWorkerService/StopSession"
+	SessionWorkerService_GetStatus_FullMethodName         = "/glyphoxa.v1.SessionWorkerService/GetStatus"
+	SessionWorkerService_ListNPCs_FullMethodName          = "/glyphoxa.v1.SessionWorkerService/ListNPCs"
+	SessionWorkerService_MuteNPC_FullMethodName           = "/glyphoxa.v1.SessionWorkerService/MuteNPC"
+	SessionWorkerService_UnmuteNPC_FullMethodName         = "/glyphoxa.v1.SessionWorkerService/UnmuteNPC"
+	SessionWorkerService_MuteAllNPCs_FullMethodName       = "/glyphoxa.v1.SessionWorkerService/MuteAllNPCs"
+	SessionWorkerService_UnmuteAllNPCs_FullMethodName     = "/glyphoxa.v1.SessionWorkerService/UnmuteAllNPCs"
+	SessionWorkerService_SpeakNPC_FullMethodName          = "/glyphoxa.v1.SessionWorkerService/SpeakNPC"
+	SessionWorkerService_UpdateVoiceServer_FullMethodName = "/glyphoxa.v1.SessionWorkerService/UpdateVoiceServer"
 )
 
 // SessionWorkerServiceClient is the client API for SessionWorkerService service.
@@ -54,6 +55,8 @@ type SessionWorkerServiceClient interface {
 	UnmuteAllNPCs(ctx context.Context, in *UnmuteAllNPCsRequest, opts ...grpc.CallOption) (*UnmuteAllNPCsResponse, error)
 	// SpeakNPC forces an NPC to speak pre-written text.
 	SpeakNPC(ctx context.Context, in *SpeakNPCRequest, opts ...grpc.CallOption) (*SpeakNPCResponse, error)
+	// UpdateVoiceServer forwards a mid-session voice server change to the worker.
+	UpdateVoiceServer(ctx context.Context, in *UpdateVoiceServerRequest, opts ...grpc.CallOption) (*UpdateVoiceServerResponse, error)
 }
 
 type sessionWorkerServiceClient struct {
@@ -154,6 +157,16 @@ func (c *sessionWorkerServiceClient) SpeakNPC(ctx context.Context, in *SpeakNPCR
 	return out, nil
 }
 
+func (c *sessionWorkerServiceClient) UpdateVoiceServer(ctx context.Context, in *UpdateVoiceServerRequest, opts ...grpc.CallOption) (*UpdateVoiceServerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpdateVoiceServerResponse)
+	err := c.cc.Invoke(ctx, SessionWorkerService_UpdateVoiceServer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SessionWorkerServiceServer is the server API for SessionWorkerService service.
 // All implementations must embed UnimplementedSessionWorkerServiceServer
 // for forward compatibility.
@@ -178,6 +191,8 @@ type SessionWorkerServiceServer interface {
 	UnmuteAllNPCs(context.Context, *UnmuteAllNPCsRequest) (*UnmuteAllNPCsResponse, error)
 	// SpeakNPC forces an NPC to speak pre-written text.
 	SpeakNPC(context.Context, *SpeakNPCRequest) (*SpeakNPCResponse, error)
+	// UpdateVoiceServer forwards a mid-session voice server change to the worker.
+	UpdateVoiceServer(context.Context, *UpdateVoiceServerRequest) (*UpdateVoiceServerResponse, error)
 	mustEmbedUnimplementedSessionWorkerServiceServer()
 }
 
@@ -214,6 +229,9 @@ func (UnimplementedSessionWorkerServiceServer) UnmuteAllNPCs(context.Context, *U
 }
 func (UnimplementedSessionWorkerServiceServer) SpeakNPC(context.Context, *SpeakNPCRequest) (*SpeakNPCResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SpeakNPC not implemented")
+}
+func (UnimplementedSessionWorkerServiceServer) UpdateVoiceServer(context.Context, *UpdateVoiceServerRequest) (*UpdateVoiceServerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateVoiceServer not implemented")
 }
 func (UnimplementedSessionWorkerServiceServer) mustEmbedUnimplementedSessionWorkerServiceServer() {}
 func (UnimplementedSessionWorkerServiceServer) testEmbeddedByValue()                              {}
@@ -398,6 +416,24 @@ func _SessionWorkerService_SpeakNPC_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SessionWorkerService_UpdateVoiceServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateVoiceServerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SessionWorkerServiceServer).UpdateVoiceServer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SessionWorkerService_UpdateVoiceServer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SessionWorkerServiceServer).UpdateVoiceServer(ctx, req.(*UpdateVoiceServerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SessionWorkerService_ServiceDesc is the grpc.ServiceDesc for SessionWorkerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -440,6 +476,10 @@ var SessionWorkerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SpeakNPC",
 			Handler:    _SessionWorkerService_SpeakNPC_Handler,
+		},
+		{
+			MethodName: "UpdateVoiceServer",
+			Handler:    _SessionWorkerService_UpdateVoiceServer_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/gateway/contract.go
+++ b/internal/gateway/contract.go
@@ -69,6 +69,14 @@ type StartSessionRequest struct {
 	LicenseTier string
 	NPCConfigs  []NPCConfigMsg
 	BotToken    string
+
+	// Voice proxy credentials (populated by gateway in distributed mode).
+	// When set, the worker connects directly to the Discord voice server
+	// without opening its own bot gateway connection.
+	VoiceSessionID string // from VOICE_STATE_UPDATE
+	VoiceToken     string // from VOICE_SERVER_UPDATE
+	VoiceEndpoint  string // from VOICE_SERVER_UPDATE
+	BotUserID      string // bot's Discord user snowflake
 }
 
 // SessionStatus describes the current state of a session.
@@ -96,6 +104,7 @@ type WorkerClient interface {
 	StartSession(ctx context.Context, req StartSessionRequest) error
 	StopSession(ctx context.Context, sessionID string) error
 	GetStatus(ctx context.Context) ([]SessionStatus, error)
+	UpdateVoiceServer(ctx context.Context, sessionID, token, endpoint string) error
 }
 
 // NPCController is the interface for gateway-to-worker NPC management.

--- a/internal/gateway/grpctransport/client.go
+++ b/internal/gateway/grpctransport/client.go
@@ -73,17 +73,36 @@ func (c *Client) StartSession(ctx context.Context, req gateway.StartSessionReque
 
 	return c.breaker.Execute(func() error {
 		_, err := c.client.StartSession(ctx, &pb.StartSessionRequest{
-			SessionId:   req.SessionID,
-			TenantId:    req.TenantID,
-			CampaignId:  req.CampaignID,
-			GuildId:     req.GuildID,
-			ChannelId:   req.ChannelID,
-			LicenseTier: req.LicenseTier,
-			NpcConfigs:  pbNPCConfigs,
-			BotToken:    req.BotToken,
+			SessionId:      req.SessionID,
+			TenantId:       req.TenantID,
+			CampaignId:     req.CampaignID,
+			GuildId:        req.GuildID,
+			ChannelId:      req.ChannelID,
+			LicenseTier:    req.LicenseTier,
+			NpcConfigs:     pbNPCConfigs,
+			BotToken:       req.BotToken,
+			VoiceSessionId: req.VoiceSessionID,
+			VoiceToken:     req.VoiceToken,
+			VoiceEndpoint:  req.VoiceEndpoint,
+			BotUserId:      req.BotUserID,
 		})
 		if err != nil {
 			return fmt.Errorf("grpctransport: start session: %w", err)
+		}
+		return nil
+	})
+}
+
+// UpdateVoiceServer forwards a mid-session voice server change to the worker.
+func (c *Client) UpdateVoiceServer(ctx context.Context, sessionID, token, endpoint string) error {
+	return c.breaker.Execute(func() error {
+		_, err := c.client.UpdateVoiceServer(ctx, &pb.UpdateVoiceServerRequest{
+			SessionId: sessionID,
+			Token:     token,
+			Endpoint:  endpoint,
+		})
+		if err != nil {
+			return fmt.Errorf("grpctransport: update voice server: %w", err)
 		}
 		return nil
 	})

--- a/internal/gateway/grpctransport/server.go
+++ b/internal/gateway/grpctransport/server.go
@@ -32,6 +32,7 @@ type WorkerHandler interface {
 	MuteAllNPCs(ctx context.Context, sessionID string) (int, error)
 	UnmuteAllNPCs(ctx context.Context, sessionID string) (int, error)
 	SpeakNPC(ctx context.Context, sessionID, npcName, text string) error
+	UpdateVoiceServer(ctx context.Context, sessionID, token, endpoint string) error
 }
 
 // NewWorkerServer creates a gRPC server that delegates to the given handler.
@@ -61,14 +62,18 @@ func (s *WorkerServer) StartSession(ctx context.Context, req *pb.StartSessionReq
 	}
 
 	err := s.handler.StartSession(ctx, gateway.StartSessionRequest{
-		SessionID:   req.GetSessionId(),
-		TenantID:    req.GetTenantId(),
-		CampaignID:  req.GetCampaignId(),
-		GuildID:     req.GetGuildId(),
-		ChannelID:   req.GetChannelId(),
-		LicenseTier: req.GetLicenseTier(),
-		NPCConfigs:  npcConfigs,
-		BotToken:    req.GetBotToken(),
+		SessionID:      req.GetSessionId(),
+		TenantID:       req.GetTenantId(),
+		CampaignID:     req.GetCampaignId(),
+		GuildID:        req.GetGuildId(),
+		ChannelID:      req.GetChannelId(),
+		LicenseTier:    req.GetLicenseTier(),
+		NPCConfigs:     npcConfigs,
+		BotToken:       req.GetBotToken(),
+		VoiceSessionID: req.GetVoiceSessionId(),
+		VoiceToken:     req.GetVoiceToken(),
+		VoiceEndpoint:  req.GetVoiceEndpoint(),
+		BotUserID:      req.GetBotUserId(),
 	})
 	if err != nil {
 		slog.Warn("grpc: start session failed", "session_id", req.GetSessionId(), "err", err)
@@ -165,6 +170,14 @@ func (s *WorkerServer) SpeakNPC(ctx context.Context, req *pb.SpeakNPCRequest) (*
 		return nil, status.Errorf(codes.Internal, "speak npc: %v", err)
 	}
 	return &pb.SpeakNPCResponse{}, nil
+}
+
+// UpdateVoiceServer implements the gRPC UpdateVoiceServer RPC.
+func (s *WorkerServer) UpdateVoiceServer(ctx context.Context, req *pb.UpdateVoiceServerRequest) (*pb.UpdateVoiceServerResponse, error) {
+	if err := s.handler.UpdateVoiceServer(ctx, req.GetSessionId(), req.GetToken(), req.GetEndpoint()); err != nil {
+		return nil, status.Errorf(codes.Internal, "update voice server: %v", err)
+	}
+	return &pb.UpdateVoiceServerResponse{}, nil
 }
 
 // GatewayServer implements the SessionGateway gRPC service on the gateway side.

--- a/internal/gateway/local/local.go
+++ b/internal/gateway/local/local.go
@@ -97,6 +97,12 @@ func (c *Client) StopSession(ctx context.Context, sessionID string) error {
 	return nil
 }
 
+// UpdateVoiceServer is a no-op in full mode — the local client owns the
+// voice connection directly and does not receive proxied credentials.
+func (c *Client) UpdateVoiceServer(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 // GetStatus returns the status of all tracked sessions.
 func (c *Client) GetStatus(_ context.Context) ([]gateway.SessionStatus, error) {
 	c.mu.Lock()

--- a/internal/gateway/sessionctrl.go
+++ b/internal/gateway/sessionctrl.go
@@ -369,7 +369,12 @@ func (gc *GatewaySessionController) registerVoiceServerForwarder(sessionID, guil
 		if e.VoiceState.ChannelID == nil {
 			slog.Info("gateway: bot disconnected from voice externally",
 				"session_id", sessionID, "guild_id", guildID)
-			go gc.Stop(context.Background(), sessionID)
+			go func() {
+				if err := gc.Stop(context.Background(), sessionID); err != nil {
+					slog.Error("gateway: failed to stop session after voice disconnect",
+						"session_id", sessionID, "err", err)
+				}
+			}()
 		}
 	})
 

--- a/internal/gateway/sessionctrl.go
+++ b/internal/gateway/sessionctrl.go
@@ -7,6 +7,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/disgo/events"
+	"github.com/disgoorg/snowflake/v2"
+
 	"github.com/MrWong99/glyphoxa/internal/config"
 	"github.com/MrWong99/glyphoxa/internal/gateway/dispatch"
 )
@@ -37,10 +41,14 @@ type GatewaySessionController struct {
 	botToken   string
 	npcConfigs []NPCConfigMsg
 	dialer     WorkerDialer
-	gwBot      *GatewayBot // for gateway handoff (suspend/resume)
+	gwBot      *GatewayBot // for voice credential capture and voice channel management
 
-	mu     sync.Mutex
-	active map[string]string // guildID -> sessionID
+	mu          sync.Mutex
+	active      map[string]string // guildID -> sessionID
+	workerAddrs map[string]string // sessionID -> worker gRPC address
+
+	voiceForwardersMu sync.Mutex
+	voiceForwarders   map[string]func() // sessionID -> unregister func
 }
 
 // NewGatewaySessionController creates a GatewaySessionController.
@@ -52,12 +60,14 @@ func NewGatewaySessionController(
 	opts ...SessionControllerOption,
 ) *GatewaySessionController {
 	gc := &GatewaySessionController{
-		orch:       orch,
-		dispatcher: dispatcher,
-		tenantID:   tenantID,
-		campaignID: campaignID,
-		tier:       tier,
-		active:     make(map[string]string),
+		orch:            orch,
+		dispatcher:      dispatcher,
+		tenantID:        tenantID,
+		campaignID:      campaignID,
+		tier:            tier,
+		active:          make(map[string]string),
+		workerAddrs:     make(map[string]string),
+		voiceForwarders: make(map[string]func()),
 	}
 	for _, opt := range opts {
 		opt(gc)
@@ -87,7 +97,8 @@ func WithWorkerDialer(d WorkerDialer) SessionControllerOption {
 	return func(gc *GatewaySessionController) { gc.dialer = d }
 }
 
-// WithGatewayBot sets the GatewayBot for gateway handoff during sessions.
+// WithGatewayBot sets the GatewayBot used for voice credential capture
+// and voice channel management.
 func WithGatewayBot(gwBot *GatewayBot) SessionControllerOption {
 	return func(gc *GatewaySessionController) { gc.gwBot = gwBot }
 }
@@ -107,12 +118,6 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 	}
 
 	if gc.dispatcher != nil {
-		// Suspend the gateway bot so the worker can take over the Discord
-		// gateway connection (only one gateway per bot token is allowed).
-		if gc.gwBot != nil {
-			gc.gwBot.SuspendGateway(ctx)
-		}
-
 		startReq := StartSessionRequest{
 			SessionID:   sessionID,
 			TenantID:    gc.tenantID,
@@ -123,6 +128,26 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 			BotToken:    gc.botToken,
 			NPCConfigs:  gc.npcConfigs,
 		}
+
+		// Capture voice credentials from the gateway bot if available.
+		// The gateway bot joins voice and stays connected for slash commands.
+		if gc.gwBot != nil {
+			voiceCtx, voiceCancel := context.WithTimeout(ctx, 10*time.Second)
+			defer voiceCancel()
+
+			vsID, vToken, vEndpoint, botUserID, captureErr := gc.captureVoiceCredentials(
+				voiceCtx, req.GuildID, req.ChannelID)
+			if captureErr != nil {
+				_ = gc.orch.Transition(ctx, sessionID, SessionEnded, captureErr.Error())
+				return fmt.Errorf("gateway: capture voice credentials: %w", captureErr)
+			}
+
+			startReq.VoiceSessionID = vsID
+			startReq.VoiceToken = vToken
+			startReq.VoiceEndpoint = vEndpoint
+			startReq.BotUserID = botUserID
+		}
+
 		starter := func(callCtx context.Context, addr string) error {
 			if gc.dialer == nil {
 				return fmt.Errorf("gateway: no worker dialer configured")
@@ -138,11 +163,10 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 		}
 		result, dispErr := gc.dispatcher.Dispatch(ctx, sessionID, gc.tenantID, starter)
 		if dispErr != nil {
-			// Resume gateway bot on dispatch failure.
+			// Leave voice on dispatch failure.
 			if gc.gwBot != nil {
-				if err := gc.gwBot.ResumeGateway(context.Background()); err != nil {
-					slog.Error("gateway: failed to resume gateway after dispatch failure", "err", err)
-				}
+				gID, _ := snowflake.Parse(req.GuildID)
+				_ = gc.gwBot.Client().UpdateVoiceState(ctx, gID, nil, false, false)
 			}
 			if transErr := gc.orch.Transition(ctx, sessionID, SessionEnded, dispErr.Error()); transErr != nil {
 				slog.Error("gateway: failed to transition session after dispatch failure",
@@ -150,6 +174,15 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 			}
 			return fmt.Errorf("gateway: dispatch worker: %w", dispErr)
 		}
+
+		// Register listener for mid-session voice server changes.
+		if gc.gwBot != nil {
+			gc.mu.Lock()
+			gc.workerAddrs[sessionID] = result.Address
+			gc.mu.Unlock()
+			gc.registerVoiceServerForwarder(sessionID, req.GuildID)
+		}
+
 		slog.Info("gateway: worker dispatched",
 			"session_id", sessionID,
 			"tenant_id", gc.tenantID,
@@ -174,21 +207,23 @@ func (gc *GatewaySessionController) Stop(ctx context.Context, sessionID string) 
 	if err := gc.orch.Transition(ctx, sessionID, SessionEnded, ""); err != nil {
 		return fmt.Errorf("gateway: transition session to ended: %w", err)
 	}
+
+	// Leave the voice channel and clean up forwarders.
 	gc.mu.Lock()
+	delete(gc.workerAddrs, sessionID)
 	for guildID, sid := range gc.active {
 		if sid == sessionID {
 			delete(gc.active, guildID)
+			if gc.gwBot != nil {
+				gID, _ := snowflake.Parse(guildID)
+				_ = gc.gwBot.Client().UpdateVoiceState(ctx, gID, nil, false, false)
+			}
 			break
 		}
 	}
 	gc.mu.Unlock()
 
-	// Resume the gateway bot now that the worker is done.
-	if gc.gwBot != nil {
-		if err := gc.gwBot.ResumeGateway(context.Background()); err != nil {
-			slog.Error("gateway: failed to resume gateway after session stop", "err", err)
-		}
-	}
+	gc.unregisterVoiceServerForwarder(sessionID)
 	return nil
 }
 
@@ -221,4 +256,143 @@ func (gc *GatewaySessionController) Info(guildID string) (SessionInfo, bool) {
 		}, true
 	}
 	return info, true
+}
+
+// captureVoiceCredentials joins the voice channel via the gateway bot and
+// captures the voice server credentials (session_id, token, endpoint) from
+// the resulting VOICE_STATE_UPDATE and VOICE_SERVER_UPDATE dispatch events.
+func (gc *GatewaySessionController) captureVoiceCredentials(
+	ctx context.Context, guildID, channelID string,
+) (sessionID, token, endpoint, botUserID string, err error) {
+	gID, _ := snowflake.Parse(guildID)
+	chID, _ := snowflake.Parse(channelID)
+
+	type creds struct {
+		sessionID string
+		token     string
+		endpoint  string
+	}
+	credsCh := make(chan creds, 1)
+
+	var (
+		mu        sync.Mutex
+		c         creds
+		gotState  bool
+		gotServer bool
+	)
+
+	// Temporary event listeners — removed after capture.
+	stateListener := bot.NewListenerFunc(func(e *events.GuildVoiceStateUpdate) {
+		if e.VoiceState.GuildID != gID || e.VoiceState.UserID != gc.gwBot.Client().ApplicationID {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		c.sessionID = e.VoiceState.SessionID
+		gotState = true
+		if gotServer {
+			select {
+			case credsCh <- c:
+			default:
+			}
+		}
+	})
+	serverListener := bot.NewListenerFunc(func(e *events.VoiceServerUpdate) {
+		if e.GuildID != gID || e.Endpoint == nil {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		c.token = e.Token
+		c.endpoint = *e.Endpoint
+		gotServer = true
+		if gotState {
+			select {
+			case credsCh <- c:
+			default:
+			}
+		}
+	})
+
+	gc.gwBot.Client().AddEventListeners(stateListener, serverListener)
+	defer gc.gwBot.Client().RemoveEventListeners(stateListener, serverListener)
+
+	// Send Opcode 4 to join voice channel.
+	if err := gc.gwBot.Client().UpdateVoiceState(ctx, gID, &chID, false, false); err != nil {
+		return "", "", "", "", fmt.Errorf("send voice state update: %w", err)
+	}
+
+	select {
+	case vc := <-credsCh:
+		return vc.sessionID, vc.token, vc.endpoint,
+			gc.gwBot.Client().ApplicationID.String(), nil
+	case <-ctx.Done():
+		return "", "", "", "", fmt.Errorf("capture voice credentials: %w", ctx.Err())
+	}
+}
+
+// registerVoiceServerForwarder listens for mid-session VOICE_SERVER_UPDATE
+// events and forwards them to the worker via gRPC.
+func (gc *GatewaySessionController) registerVoiceServerForwarder(sessionID, guildID string) {
+	gID, _ := snowflake.Parse(guildID)
+
+	listener := bot.NewListenerFunc(func(e *events.VoiceServerUpdate) {
+		if e.GuildID != gID || e.Endpoint == nil {
+			return
+		}
+		gc.mu.Lock()
+		addr := gc.workerAddrs[sessionID]
+		gc.mu.Unlock()
+
+		if addr == "" || gc.dialer == nil {
+			return
+		}
+		client, err := gc.dialer(addr)
+		if err != nil {
+			slog.Error("gateway: failed to dial worker for voice server forward",
+				"session_id", sessionID, "err", err)
+			return
+		}
+		fwdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := client.UpdateVoiceServer(fwdCtx, sessionID, e.Token, *e.Endpoint); err != nil {
+			slog.Error("gateway: failed to forward voice server update",
+				"session_id", sessionID, "err", err)
+		}
+	})
+
+	// Also listen for external disconnections (admin kicks the bot).
+	disconnectListener := bot.NewListenerFunc(func(e *events.GuildVoiceStateUpdate) {
+		if e.VoiceState.GuildID != gID || e.VoiceState.UserID != gc.gwBot.Client().ApplicationID {
+			return
+		}
+		if e.VoiceState.ChannelID == nil {
+			slog.Info("gateway: bot disconnected from voice externally",
+				"session_id", sessionID, "guild_id", guildID)
+			go gc.Stop(context.Background(), sessionID)
+		}
+	})
+
+	gc.gwBot.Client().AddEventListeners(listener, disconnectListener)
+
+	gc.voiceForwardersMu.Lock()
+	gc.voiceForwarders[sessionID] = func() {
+		gc.gwBot.Client().RemoveEventListeners(listener, disconnectListener)
+	}
+	gc.voiceForwardersMu.Unlock()
+}
+
+// unregisterVoiceServerForwarder removes the VOICE_SERVER_UPDATE listener
+// for the given session.
+func (gc *GatewaySessionController) unregisterVoiceServerForwarder(sessionID string) {
+	gc.voiceForwardersMu.Lock()
+	unregister, ok := gc.voiceForwarders[sessionID]
+	if ok {
+		delete(gc.voiceForwarders, sessionID)
+	}
+	gc.voiceForwardersMu.Unlock()
+
+	if ok {
+		unregister()
+	}
 }

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -31,6 +31,9 @@ type Runtime struct {
 	mixer     audio.Mixer
 	conn      audio.Connection
 
+	// voiceProxy forwards voice server updates in distributed mode.
+	voiceProxy VoiceServerUpdater
+
 	// closers are called in reverse order during Stop.
 	closers []func() error
 
@@ -43,6 +46,12 @@ type Runtime struct {
 	running bool
 }
 
+// VoiceServerUpdater can forward mid-session voice server changes
+// to the underlying voice connection.
+type VoiceServerUpdater interface {
+	UpdateVoiceServer(token, endpoint string)
+}
+
 // RuntimeConfig holds the dependencies for creating a Runtime.
 type RuntimeConfig struct {
 	SessionID    string
@@ -52,17 +61,19 @@ type RuntimeConfig struct {
 	Mixer        audio.Mixer
 	Connection   audio.Connection
 	SessionStore memory.SessionStore
+	VoiceProxy   VoiceServerUpdater // nil in full mode
 }
 
 // NewRuntime creates a Runtime. Call Start to begin processing, Stop to tear down.
 func NewRuntime(cfg RuntimeConfig) *Runtime {
 	return &Runtime{
-		sessionID: cfg.SessionID,
-		agents:    cfg.Agents,
-		engines:   cfg.Engines,
-		orch:      cfg.Orchestrator,
-		mixer:     cfg.Mixer,
-		conn:      cfg.Connection,
+		sessionID:  cfg.SessionID,
+		agents:     cfg.Agents,
+		engines:    cfg.Engines,
+		orch:       cfg.Orchestrator,
+		mixer:      cfg.Mixer,
+		conn:       cfg.Connection,
+		voiceProxy: cfg.VoiceProxy,
 	}
 }
 
@@ -156,6 +167,14 @@ func (rt *Runtime) Orchestrator() *orchestrator.Orchestrator {
 // Agents returns the loaded NPC agents.
 func (rt *Runtime) Agents() []agent.NPCAgent {
 	return rt.agents
+}
+
+// UpdateVoiceServer forwards a mid-session voice server change to the
+// underlying voice connection. No-op if the runtime has no voice proxy.
+func (rt *Runtime) UpdateVoiceServer(token, endpoint string) {
+	if rt.voiceProxy != nil {
+		rt.voiceProxy.UpdateVoiceServer(token, endpoint)
+	}
 }
 
 // recordTranscripts drains an agent's transcript channel and writes entries

--- a/internal/session/worker_handler.go
+++ b/internal/session/worker_handler.go
@@ -257,6 +257,19 @@ func (h *WorkerHandler) sessionOrch(sessionID string) (*orchestrator.Orchestrato
 	return orch, nil
 }
 
+// UpdateVoiceServer forwards a mid-session voice server change to the
+// running session's voice proxy.
+func (h *WorkerHandler) UpdateVoiceServer(_ context.Context, sessionID, token, endpoint string) error {
+	h.mu.Lock()
+	ms, ok := h.sessions[sessionID]
+	h.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("session: %q not found", sessionID)
+	}
+	ms.runtime.UpdateVoiceServer(token, endpoint)
+	return nil
+}
+
 // StopAll stops all running sessions. Used during graceful shutdown.
 func (h *WorkerHandler) StopAll(ctx context.Context) {
 	h.mu.Lock()

--- a/pkg/audio/discord/voice_proxy.go
+++ b/pkg/audio/discord/voice_proxy.go
@@ -1,0 +1,138 @@
+package discord
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MrWong99/glyphoxa/pkg/audio"
+	discodiscord "github.com/disgoorg/disgo/discord"
+	botgateway "github.com/disgoorg/disgo/gateway"
+	"github.com/disgoorg/disgo/voice"
+	"github.com/disgoorg/snowflake/v2"
+)
+
+// VoiceProxyPlatform connects to a Discord voice server using pre-captured
+// credentials (session_id, token, endpoint) from the gateway pod. The worker
+// does NOT need its own Discord gateway connection.
+//
+// All exported methods are safe for concurrent use.
+type VoiceProxyPlatform struct {
+	conn      voice.Conn
+	guildID   snowflake.ID
+	botUserID snowflake.ID
+	readyCh   chan struct{}
+	closeOnce sync.Once
+}
+
+// NewVoiceProxyPlatform creates a voice platform that connects using
+// pre-captured credentials rather than its own Discord gateway.
+func NewVoiceProxyPlatform(
+	guildIDStr, botUserIDStr string,
+	opts ...voice.ConnConfigOpt,
+) (*VoiceProxyPlatform, error) {
+	guildID, err := snowflake.Parse(guildIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("discord: parse guild ID %q: %w", guildIDStr, err)
+	}
+	botUserID, err := snowflake.Parse(botUserIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("discord: parse bot user ID %q: %w", botUserIDStr, err)
+	}
+
+	vp := &VoiceProxyPlatform{
+		guildID:   guildID,
+		botUserID: botUserID,
+		readyCh:   make(chan struct{}, 1),
+	}
+
+	// No-op: the gateway pod handles Opcode 4 (join/leave voice channel).
+	noopStateUpdate := func(_ context.Context, _ snowflake.ID,
+		_ *snowflake.ID, _, _ bool) error {
+		return nil
+	}
+
+	allOpts := append([]voice.ConnConfigOpt{
+		voice.WithConnEventHandlerFunc(func(_ voice.Gateway, _ voice.Opcode,
+			_ int, data voice.GatewayMessageData) {
+			if _, ok := data.(voice.GatewayMessageDataSessionDescription); ok {
+				select {
+				case vp.readyCh <- struct{}{}:
+				default:
+				}
+			}
+		}),
+	}, opts...)
+
+	vp.conn = voice.NewConn(guildID, botUserID, noopStateUpdate, func() {}, allOpts...)
+	return vp, nil
+}
+
+// Connect feeds pre-captured voice credentials into the connection, triggering
+// the voice WebSocket + UDP handshake. The ctx governs the setup phase only.
+func (vp *VoiceProxyPlatform) Connect(
+	ctx context.Context,
+	channelIDStr, voiceSessionID, voiceToken, voiceEndpoint string,
+) (audio.Connection, error) {
+	channelID, err := snowflake.Parse(channelIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("discord: parse channel ID: %w", err)
+	}
+
+	slog.Info("discord: voice proxy connecting",
+		"guild_id", vp.guildID,
+		"channel_id", channelID,
+		"endpoint", voiceEndpoint,
+	)
+
+	// Feed the credentials that the gateway captured.
+	// Order matters: HandleVoiceStateUpdate sets SessionID,
+	// HandleVoiceServerUpdate triggers gateway.Open() which needs SessionID.
+	vp.conn.HandleVoiceStateUpdate(botgateway.EventVoiceStateUpdate{
+		VoiceState: discodiscord.VoiceState{
+			GuildID:   vp.guildID,
+			ChannelID: &channelID,
+			UserID:    vp.botUserID,
+			SessionID: voiceSessionID,
+		},
+	})
+	vp.conn.HandleVoiceServerUpdate(botgateway.EventVoiceServerUpdate{
+		Token:    voiceToken,
+		GuildID:  vp.guildID,
+		Endpoint: &voiceEndpoint,
+	})
+
+	// Wait for the voice WebSocket handshake to complete.
+	select {
+	case <-vp.readyCh:
+		slog.Info("discord: voice proxy connected", "guild_id", vp.guildID)
+		return newConnection(vp.conn, vp.guildID), nil
+	case <-ctx.Done():
+		vp.conn.Close(ctx)
+		return nil, fmt.Errorf("discord: voice proxy connect: %w", ctx.Err())
+	}
+}
+
+// UpdateVoiceServer handles mid-session voice server changes. Discord sends
+// a new VOICE_SERVER_UPDATE when migrating voice servers. The gateway
+// forwards this to the worker, which calls this method.
+func (vp *VoiceProxyPlatform) UpdateVoiceServer(token, endpoint string) {
+	vp.conn.HandleVoiceServerUpdate(botgateway.EventVoiceServerUpdate{
+		Token:    token,
+		GuildID:  vp.guildID,
+		Endpoint: &endpoint,
+	})
+}
+
+// Close tears down the voice connection. It is safe to call more than once.
+func (vp *VoiceProxyPlatform) Close() error {
+	vp.closeOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		vp.conn.Close(ctx)
+		slog.Info("discord: voice proxy closed", "guild_id", vp.guildID)
+	})
+	return nil
+}

--- a/proto/glyphoxa/v1/session.proto
+++ b/proto/glyphoxa/v1/session.proto
@@ -36,6 +36,14 @@ message StartSessionRequest {
   string session_id = 6;
   repeated NPCConfig npc_configs = 7;
   string bot_token = 8;
+
+  // Voice proxy credentials (populated by gateway in distributed mode).
+  // When set, the worker connects directly to the Discord voice server
+  // without opening its own bot gateway connection.
+  string voice_session_id = 9;  // from VOICE_STATE_UPDATE
+  string voice_token = 10;      // from VOICE_SERVER_UPDATE
+  string voice_endpoint = 11;   // from VOICE_SERVER_UPDATE
+  string bot_user_id = 12;      // bot's Discord user snowflake
 }
 
 // StartSessionResponse is the worker's reply after attempting to start a session.
@@ -157,6 +165,17 @@ message SpeakNPCRequest {
 // SpeakNPCResponse is the worker's reply after triggering NPC speech.
 message SpeakNPCResponse {}
 
+// UpdateVoiceServerRequest forwards a mid-session VOICE_SERVER_UPDATE from
+// the gateway to the worker so it can reconnect to a new voice server.
+message UpdateVoiceServerRequest {
+  string session_id = 1;
+  string token = 2;
+  string endpoint = 3;
+}
+
+// UpdateVoiceServerResponse is the worker's acknowledgement.
+message UpdateVoiceServerResponse {}
+
 // SessionWorkerService is the gRPC service exposed by workers, called by the gateway.
 service SessionWorkerService {
   // StartSession tells the worker to begin a new voice session.
@@ -177,6 +196,8 @@ service SessionWorkerService {
   rpc UnmuteAllNPCs(UnmuteAllNPCsRequest) returns (UnmuteAllNPCsResponse);
   // SpeakNPC forces an NPC to speak pre-written text.
   rpc SpeakNPC(SpeakNPCRequest) returns (SpeakNPCResponse);
+  // UpdateVoiceServer forwards a mid-session voice server change to the worker.
+  rpc UpdateVoiceServer(UpdateVoiceServerRequest) returns (UpdateVoiceServerResponse);
 }
 
 // SessionGatewayService is the gRPC service exposed by the gateway, called by workers.


### PR DESCRIPTION
## Summary

- **Voice State Proxy**: Replace suspend/resume gateway handoff with credential forwarding. The gateway bot stays connected permanently, joins voice, captures VOICE_STATE_UPDATE + VOICE_SERVER_UPDATE credentials, and forwards them to the worker via gRPC.
- **VoiceProxyPlatform**: New `pkg/audio/discord/voice_proxy.go` creates a `voice.Conn` directly via `voice.NewConn()` using pre-captured credentials — no Discord gateway needed on the worker.
- **Mid-session voice server migration**: `UpdateVoiceServer` gRPC RPC forwards VOICE_SERVER_UPDATE events from gateway to worker during active sessions.
- **External disconnect detection**: Gateway listens for the bot being kicked from voice and auto-stops the session.
- **Backward compatible**: Worker falls back to `VoiceOnlyPlatform` (own gateway) when no voice credentials are present (--mode=full).

## Changed files

| File | Change |
|------|--------|
| `proto/glyphoxa/v1/session.proto` | Add voice credential fields to StartSessionRequest + UpdateVoiceServer RPC |
| `gen/glyphoxa/v1/session{,_grpc}.pb.go` | Regenerated proto |
| `internal/gateway/contract.go` | Voice credential fields on StartSessionRequest, UpdateVoiceServer on WorkerClient |
| `internal/gateway/sessionctrl.go` | captureVoiceCredentials, voice server forwarder, remove suspend/resume |
| `internal/gateway/grpctransport/{client,server}.go` | Pass voice credentials, add UpdateVoiceServer RPC |
| `internal/gateway/local/local.go` | No-op UpdateVoiceServer for full mode |
| `pkg/audio/discord/voice_proxy.go` | **New** — VoiceProxyPlatform |
| `cmd/glyphoxa/worker_factory.go` | Use VoiceProxyPlatform when credentials present |
| `internal/session/runtime.go` | VoiceServerUpdater interface, voiceProxy field |
| `internal/session/worker_handler.go` | Route UpdateVoiceServer to session runtime |

## Test plan

- [x] `go vet ./...` passes on all modified packages
- [x] `go test -race -count=1 ./internal/gateway/...` passes
- [x] `go test -race -count=1 ./pkg/audio/discord/...` passes
- [x] `go test -race -count=1 ./internal/session/...` passes
- [ ] Manual integration test: gateway + worker with real Discord bot
- [ ] Test external disconnect (admin kicks bot from voice)
- [ ] Test mid-session voice server migration