### PR TITLE
fix(gateway): configure DAVE encryption and guard nil store/config in commands

### DIFF
--- a/internal/discord/commands/campaign.go
+++ b/internal/discord/commands/campaign.go
@@ -89,6 +89,10 @@ func (cc *CampaignCommands) handleInfo(e *events.ApplicationCommandInteractionCr
 
 	cfg := cc.getCfg()
 	store := cc.getStore()
+	if cfg == nil || store == nil {
+		discordbot.RespondEphemeral(e, "Campaign commands are not available in gateway mode.")
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -189,6 +193,10 @@ func (cc *CampaignCommands) handleLoad(e *events.ApplicationCommandInteractionCr
 	}
 
 	store := cc.getStore()
+	if store == nil {
+		discordbot.FollowUp(e, "Campaign commands are not available in gateway mode.")
+		return
+	}
 	count, importErr := entity.ImportCampaign(ctx, store, cf)
 	if importErr != nil {
 		discordbot.FollowUp(e, fmt.Sprintf("Import error: %v (imported %d entities before error)", importErr, count))

--- a/internal/discord/commands/entity.go
+++ b/internal/discord/commands/entity.go
@@ -157,6 +157,10 @@ func (ec *EntityCommands) handleList(e *events.ApplicationCommandInteractionCrea
 	}
 
 	store := ec.getStore()
+	if store == nil {
+		discordbot.RespondEphemeral(e, "Entity commands are not available in gateway mode.")
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -222,6 +226,10 @@ func (ec *EntityCommands) handleRemove(e *events.ApplicationCommandInteractionCr
 	}
 
 	store := ec.getStore()
+	if store == nil {
+		discordbot.RespondEphemeral(e, "Entity commands are not available in gateway mode.")
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -278,6 +286,10 @@ func (ec *EntityCommands) handleRemoveConfirm(e *events.ComponentInteractionCrea
 	}
 
 	store := ec.getStore()
+	if store == nil {
+		discordbot.RespondEphemeral(e, "Entity commands are not available in gateway mode.")
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -292,6 +304,10 @@ func (ec *EntityCommands) handleRemoveConfirm(e *events.ComponentInteractionCrea
 // autocompleteRemove provides name autocomplete for /entity remove.
 func (ec *EntityCommands) autocompleteRemove(e *events.AutocompleteInteractionCreate) {
 	store := ec.getStore()
+	if store == nil {
+		_ = e.AutocompleteResult(nil)
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -359,6 +375,10 @@ func (ec *EntityCommands) handleImport(e *events.ApplicationCommandInteractionCr
 	defer dl.Body.Close()
 
 	store := ec.getStore()
+	if store == nil {
+		discordbot.FollowUp(e, "Entity commands are not available in gateway mode.")
+		return
+	}
 	var count int
 
 	switch format {

--- a/internal/discord/commands/entity_modal.go
+++ b/internal/discord/commands/entity_modal.go
@@ -56,6 +56,10 @@ func (ec *EntityCommands) handleAddModal(e *events.ModalSubmitInteractionCreate)
 	}
 
 	store := ec.getStore()
+	if store == nil {
+		discordbot.RespondEphemeral(e, "Entity commands are not available in gateway mode.")
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/internal/gateway/botconnector.go
+++ b/internal/gateway/botconnector.go
@@ -10,6 +10,8 @@ import (
 	"github.com/disgoorg/disgo/cache"
 	"github.com/disgoorg/disgo/events"
 	"github.com/disgoorg/disgo/gateway"
+	"github.com/disgoorg/disgo/voice"
+	"github.com/disgoorg/godave/golibdave"
 	"github.com/disgoorg/snowflake/v2"
 
 	discordbot "github.com/MrWong99/glyphoxa/internal/discord"
@@ -89,6 +91,9 @@ func (c *DiscordBotConnector) ConnectBotForTenant(ctx context.Context, tenant Te
 		bot.WithEventListenerFunc(func(e *events.ModalSubmitInteractionCreate) {
 			router.HandleModal(e)
 		}),
+		bot.WithVoiceManagerConfigOpts(
+			voice.WithDaveSessionCreateFunc(golibdave.NewSession),
+		),
 	}
 
 	client, err := disgo.New(tenant.BotToken, opts...)


### PR DESCRIPTION
## Summary

- **DAVE encryption on gateway bot**: The gateway bot was missing DAVE encryption configuration (`WithDaveSessionCreateFunc`), causing voice connection failures. Added the same DAVE setup used in full and worker modes.
- **Nil pointer crash in campaign/entity commands**: Gateway mode wires campaign and entity commands with `getStore`/`getCfg` closures that return `nil`. Calling methods on nil values caused panics. Added nil guards across all handlers that respond with "not available in gateway mode" instead of crashing.

## Files changed

- `internal/gateway/botconnector.go` — add DAVE voice encryption config + imports
- `internal/discord/commands/campaign.go` — nil guards in `handleInfo` and `handleLoad`
- `internal/discord/commands/entity.go` — nil guards in `handleList`, `handleRemove`, `handleRemoveConfirm`, `autocompleteRemove`, `handleImport`
- `internal/discord/commands/entity_modal.go` — nil guard in `handleAddModal`

## Test plan

- [x] `go build ./internal/gateway/ ./internal/discord/commands/` compiles clean
- [x] `go test -race -count=1 ./internal/gateway/... ./internal/discord/commands/...` passes
- [x] `go vet ./internal/gateway/... ./internal/discord/commands/...` clean
- [ ] Manual test: invoke `/campaign info` and `/entity list` in gateway mode — should get friendly error instead of crash
- [ ] Manual test: gateway bot joins voice channel with DAVE encryption enabled