### PR TITLE
fix(gateway): wire campaign config, NPC commands, and recap for gateway mode

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -28,7 +28,6 @@ import (
 	anyllmlib "github.com/mozilla-ai/any-llm-go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/MrWong99/glyphoxa/internal/agent/orchestrator"
 	"github.com/MrWong99/glyphoxa/internal/app"
 	"github.com/MrWong99/glyphoxa/internal/config"
 	discordbot "github.com/MrWong99/glyphoxa/internal/discord"
@@ -391,23 +390,32 @@ func runGateway(cfg *config.Config) int {
 		// Session start/stop commands.
 		commands.NewGatewaySessionCommands(gwBot, sessionCtrl, perms)
 
-		// NPC commands — not yet available in gateway mode (requires gRPC
-		// extensions); handlers return "no active session" gracefully.
-		npcCmds := commands.NewNPCCommands(perms, func() *orchestrator.Orchestrator { return nil })
-		npcCmds.Register(router)
+		// NPC commands — proxied to the worker via gRPC NPCController.
+		commands.NewGatewayNPCCommands(gwBot, sessionCtrl, sessionCtrl, perms)
 
 		// Entity commands.
 		entityCmds := commands.NewEntityCommands(perms, func() entity.Store { return nil })
 		entityCmds.Register(router)
 
-		// Campaign commands.
+		// Campaign commands — config is available on the gateway; entity
+		// store is nil because entities live on the worker.
 		campaignCmds := commands.NewCampaignCommands(
 			perms,
 			func() entity.Store { return nil },
-			func() *config.CampaignConfig { return nil },
+			func() *config.CampaignConfig { return &cfg.Campaign },
 			func() bool { return sessionCtrl.IsActive("") },
 		)
 		campaignCmds.Register(router)
+
+		// Recap commands — text-only for gateway mode (no TTS providers on
+		// gateway). Session store is nil for now; transcript reading can be
+		// added once schema-per-tenant is wired.
+		commands.NewGatewayRecapCommands(commands.GatewayRecapConfig{
+			GatewayBot: gwBot,
+			Ctrl:       sessionCtrl,
+			NPCCtrl:    sessionCtrl,
+			Perms:      perms,
+		})
 
 		// Feedback commands.
 		feedbackCmds := commands.NewFeedbackCommands(

--- a/internal/discord/commands/campaign.go
+++ b/internal/discord/commands/campaign.go
@@ -88,18 +88,9 @@ func (cc *CampaignCommands) handleInfo(e *events.ApplicationCommandInteractionCr
 	}
 
 	cfg := cc.getCfg()
-	store := cc.getStore()
-	if cfg == nil || store == nil {
-		discordbot.RespondEphemeral(e, "Campaign commands are not available in gateway mode.")
+	if cfg == nil {
+		discordbot.RespondEphemeral(e, "No campaign configuration available.")
 		return
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	entities, err := store.List(ctx, entity.ListOptions{})
-	if err != nil {
-		slog.Warn("discord: failed to count entities for campaign info", "err", err)
 	}
 
 	name := cfg.Name
@@ -111,35 +102,51 @@ func (cc *CampaignCommands) handleInfo(e *events.ApplicationCommandInteractionCr
 		system = "(not set)"
 	}
 
-	typeCounts := make(map[entity.EntityType]int)
-	for _, ent := range entities {
-		typeCounts[ent.Type]++
-	}
-
-	var breakdown strings.Builder
-	for _, t := range []entity.EntityType{
-		entity.EntityNPC, entity.EntityLocation, entity.EntityItem,
-		entity.EntityFaction, entity.EntityQuest, entity.EntityLore,
-	} {
-		if c := typeCounts[t]; c > 0 {
-			fmt.Fprintf(&breakdown, "%s: %d\n", t, c)
-		}
-	}
-
 	embed := discord.Embed{
 		Title: "Campaign Info",
 		Fields: []discord.EmbedField{
 			{Name: "Name", Value: name, Inline: new(true)},
 			{Name: "System", Value: system, Inline: new(true)},
-			{Name: "Total Entities", Value: fmt.Sprintf("%d", len(entities)), Inline: new(true)},
 		},
 	}
 
-	if breakdown.Len() > 0 {
+	// Entity breakdown is only available when an entity store is present
+	// (full mode). In gateway mode the store runs on the worker.
+	store := cc.getStore()
+	if store != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		entities, err := store.List(ctx, entity.ListOptions{})
+		if err != nil {
+			slog.Warn("discord: failed to count entities for campaign info", "err", err)
+		}
+
 		embed.Fields = append(embed.Fields, discord.EmbedField{
-			Name:  "Entity Breakdown",
-			Value: breakdown.String(),
+			Name: "Total Entities", Value: fmt.Sprintf("%d", len(entities)), Inline: new(true),
 		})
+
+		typeCounts := make(map[entity.EntityType]int)
+		for _, ent := range entities {
+			typeCounts[ent.Type]++
+		}
+
+		var breakdown strings.Builder
+		for _, t := range []entity.EntityType{
+			entity.EntityNPC, entity.EntityLocation, entity.EntityItem,
+			entity.EntityFaction, entity.EntityQuest, entity.EntityLore,
+		} {
+			if c := typeCounts[t]; c > 0 {
+				fmt.Fprintf(&breakdown, "%s: %d\n", t, c)
+			}
+		}
+
+		if breakdown.Len() > 0 {
+			embed.Fields = append(embed.Fields, discord.EmbedField{
+				Name:  "Entity Breakdown",
+				Value: breakdown.String(),
+			})
+		}
 	}
 
 	discordbot.RespondEmbed(e, embed)

--- a/internal/gateway/sessionctrl.go
+++ b/internal/gateway/sessionctrl.go
@@ -16,8 +16,11 @@ import (
 	"github.com/MrWong99/glyphoxa/internal/gateway/dispatch"
 )
 
-// Compile-time interface assertion.
-var _ SessionController = (*GatewaySessionController)(nil)
+// Compile-time interface assertions.
+var (
+	_ SessionController = (*GatewaySessionController)(nil)
+	_ NPCController     = (*GatewaySessionController)(nil)
+)
 
 // SessionOrchestrator is the subset of sessionorch.Orchestrator needed by
 // GatewaySessionController. Defined here to avoid an import cycle between
@@ -325,4 +328,86 @@ func (gc *GatewaySessionController) registerDisconnectListener(sessionID, guildI
 		}
 	}
 	gc.voiceCleanupsMu.Unlock()
+}
+
+// ── NPCController implementation ────────────────────────────────────────────
+// GatewaySessionController proxies NPC operations to the worker that owns the
+// session. It dials the worker on each call; connections are lightweight and
+// NPC commands are infrequent (slash command interactions).
+
+// dialNPCController dials the worker for the given session and returns an
+// NPCController. The caller should not cache the returned controller.
+func (gc *GatewaySessionController) dialNPCController(sessionID string) (NPCController, error) {
+	gc.mu.Lock()
+	addr, ok := gc.workerAddrs[sessionID]
+	gc.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("gateway: no worker address for session %s", sessionID)
+	}
+	if gc.dialer == nil {
+		return nil, fmt.Errorf("gateway: no worker dialer configured")
+	}
+	client, err := gc.dialer(addr)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: dial worker at %s: %w", addr, err)
+	}
+	npcCtrl, ok := client.(NPCController)
+	if !ok {
+		return nil, fmt.Errorf("gateway: worker client does not implement NPCController")
+	}
+	return npcCtrl, nil
+}
+
+// ListNPCs implements [NPCController].
+func (gc *GatewaySessionController) ListNPCs(ctx context.Context, sessionID string) ([]NPCStatus, error) {
+	ctrl, err := gc.dialNPCController(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	return ctrl.ListNPCs(ctx, sessionID)
+}
+
+// MuteNPC implements [NPCController].
+func (gc *GatewaySessionController) MuteNPC(ctx context.Context, sessionID, npcName string) error {
+	ctrl, err := gc.dialNPCController(sessionID)
+	if err != nil {
+		return err
+	}
+	return ctrl.MuteNPC(ctx, sessionID, npcName)
+}
+
+// UnmuteNPC implements [NPCController].
+func (gc *GatewaySessionController) UnmuteNPC(ctx context.Context, sessionID, npcName string) error {
+	ctrl, err := gc.dialNPCController(sessionID)
+	if err != nil {
+		return err
+	}
+	return ctrl.UnmuteNPC(ctx, sessionID, npcName)
+}
+
+// MuteAllNPCs implements [NPCController].
+func (gc *GatewaySessionController) MuteAllNPCs(ctx context.Context, sessionID string) (int, error) {
+	ctrl, err := gc.dialNPCController(sessionID)
+	if err != nil {
+		return 0, err
+	}
+	return ctrl.MuteAllNPCs(ctx, sessionID)
+}
+
+// UnmuteAllNPCs implements [NPCController].
+func (gc *GatewaySessionController) UnmuteAllNPCs(ctx context.Context, sessionID string) (int, error) {
+	ctrl, err := gc.dialNPCController(sessionID)
+	if err != nil {
+		return 0, err
+	}
+	return ctrl.UnmuteAllNPCs(ctx, sessionID)
+}
+
+// SpeakNPC implements [NPCController].
+func (gc *GatewaySessionController) SpeakNPC(ctx context.Context, sessionID, npcName, text string) error {
+	ctrl, err := gc.dialNPCController(sessionID)
+	if err != nil {
+		return err
+	}
+	return ctrl.SpeakNPC(ctx, sessionID, npcName, text)
 }


### PR DESCRIPTION
## Summary

- **Campaign /info**: Was returning "not available in gateway mode" because `getCfg()` was hardcoded to `nil`. Now passes `&cfg.Campaign` — the config IS available on the gateway. Entity store remains nil (lives on worker); `handleInfo` now shows campaign metadata without requiring the entity store.
- **NPC commands**: Was using full-mode `NPCCommands` with a nil orchestrator — autocomplete returned nothing and all `/npc` subcommands were dead. Switched to `GatewayNPCCommands` which proxies via gRPC `NPCController`.
- **Recap**: Wired `GatewayRecapCommands` for text-only session recap (session metadata + NPC list). Transcript reading deferred to follow-up (needs schema-per-tenant session store on gateway).
- **NPCController proxy**: `GatewaySessionController` now implements `NPCController` by dialing the worker that owns each session — no new types needed, just 7 forwarding methods.

## Test plan

- [x] `go vet ./...` passes (all packages)
- [x] `go test -race -count=1 ./internal/...` passes (24/24 packages)
- [x] `go test -race -count=1 ./pkg/...` passes (all except whisper — pre-existing CGo header issue)
- [ ] Deploy to K3s and verify `/campaign info` shows campaign metadata
- [ ] Verify `/npc speak` autocomplete shows Heinrich, Mathilde, Erzähler
- [ ] Verify `/session recap` shows session info during active session