### PR TITLE
fix(gateway): fix audio bridge stream disconnect and DAVE decryption

### DIFF
--- a/cmd/glyphoxa/worker_factory.go
+++ b/cmd/glyphoxa/worker_factory.go
@@ -404,7 +404,11 @@ func (wf *workerFactory) connectAudioBridge(ctx context.Context, sessionID strin
 	}
 
 	bridgeClient := pb.NewAudioBridgeServiceClient(conn)
-	stream, err := bridgeClient.StreamAudio(ctx)
+	// Use context.Background() because the stream must outlive the
+	// StartSession RPC whose server-side context is canceled when the
+	// handler returns. Passing the RPC context here would kill the stream
+	// within milliseconds of StartSession completing.
+	stream, err := bridgeClient.StreamAudio(context.Background())
 	if err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("worker: open audio stream: %w", err)

--- a/internal/gateway/sessionctrl.go
+++ b/internal/gateway/sessionctrl.go
@@ -168,6 +168,19 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 				"channel_id", req.ChannelID,
 			)
 
+			// Wait for DAVE E2EE handshake to complete before wiring the
+			// audio bridge. Without this, the receiver reads encrypted
+			// packets before keys are exchanged, causing decryption failures.
+			daveCtx, daveCancel := context.WithTimeout(context.Background(), daveReadyTimeout)
+			if daveErr := waitForDAVEReady(daveCtx, voiceConn, sessionID); daveErr != nil {
+				daveCancel()
+				voiceMgr.RemoveConn(gID)
+				gc.bridgeSrv.RemoveBridge(sessionID)
+				_ = gc.orch.Transition(ctx, sessionID, SessionEnded, daveErr.Error())
+				return fmt.Errorf("gateway: DAVE handshake: %w", daveErr)
+			}
+			daveCancel()
+
 			cleanup := setupVoiceBridge(voiceConn, bridge, sessionID)
 			gc.voiceCleanupsMu.Lock()
 			gc.voiceCleanups[sessionID] = func() {
@@ -336,78 +349,93 @@ func (gc *GatewaySessionController) registerDisconnectListener(sessionID, guildI
 // NPC commands are infrequent (slash command interactions).
 
 // dialNPCController dials the worker for the given session and returns an
-// NPCController. The caller should not cache the returned controller.
-func (gc *GatewaySessionController) dialNPCController(sessionID string) (NPCController, error) {
+// NPCController plus a cleanup function that closes the underlying connection.
+// The caller must call the returned cleanup function when done.
+func (gc *GatewaySessionController) dialNPCController(sessionID string) (NPCController, func(), error) {
 	gc.mu.Lock()
 	addr, ok := gc.workerAddrs[sessionID]
 	gc.mu.Unlock()
 	if !ok {
-		return nil, fmt.Errorf("gateway: no worker address for session %s", sessionID)
+		return nil, nil, fmt.Errorf("gateway: no worker address for session %s", sessionID)
 	}
 	if gc.dialer == nil {
-		return nil, fmt.Errorf("gateway: no worker dialer configured")
+		return nil, nil, fmt.Errorf("gateway: no worker dialer configured")
 	}
 	client, err := gc.dialer(addr)
 	if err != nil {
-		return nil, fmt.Errorf("gateway: dial worker at %s: %w", addr, err)
+		return nil, nil, fmt.Errorf("gateway: dial worker at %s: %w", addr, err)
 	}
 	npcCtrl, ok := client.(NPCController)
 	if !ok {
-		return nil, fmt.Errorf("gateway: worker client does not implement NPCController")
+		if c, ok := client.(interface{ Close() error }); ok {
+			c.Close()
+		}
+		return nil, nil, fmt.Errorf("gateway: worker client does not implement NPCController")
 	}
-	return npcCtrl, nil
+	cleanup := func() {
+		if c, ok := client.(interface{ Close() error }); ok {
+			c.Close()
+		}
+	}
+	return npcCtrl, cleanup, nil
 }
 
 // ListNPCs implements [NPCController].
 func (gc *GatewaySessionController) ListNPCs(ctx context.Context, sessionID string) ([]NPCStatus, error) {
-	ctrl, err := gc.dialNPCController(sessionID)
+	ctrl, cleanup, err := gc.dialNPCController(sessionID)
 	if err != nil {
 		return nil, err
 	}
+	defer cleanup()
 	return ctrl.ListNPCs(ctx, sessionID)
 }
 
 // MuteNPC implements [NPCController].
 func (gc *GatewaySessionController) MuteNPC(ctx context.Context, sessionID, npcName string) error {
-	ctrl, err := gc.dialNPCController(sessionID)
+	ctrl, cleanup, err := gc.dialNPCController(sessionID)
 	if err != nil {
 		return err
 	}
+	defer cleanup()
 	return ctrl.MuteNPC(ctx, sessionID, npcName)
 }
 
 // UnmuteNPC implements [NPCController].
 func (gc *GatewaySessionController) UnmuteNPC(ctx context.Context, sessionID, npcName string) error {
-	ctrl, err := gc.dialNPCController(sessionID)
+	ctrl, cleanup, err := gc.dialNPCController(sessionID)
 	if err != nil {
 		return err
 	}
+	defer cleanup()
 	return ctrl.UnmuteNPC(ctx, sessionID, npcName)
 }
 
 // MuteAllNPCs implements [NPCController].
 func (gc *GatewaySessionController) MuteAllNPCs(ctx context.Context, sessionID string) (int, error) {
-	ctrl, err := gc.dialNPCController(sessionID)
+	ctrl, cleanup, err := gc.dialNPCController(sessionID)
 	if err != nil {
 		return 0, err
 	}
+	defer cleanup()
 	return ctrl.MuteAllNPCs(ctx, sessionID)
 }
 
 // UnmuteAllNPCs implements [NPCController].
 func (gc *GatewaySessionController) UnmuteAllNPCs(ctx context.Context, sessionID string) (int, error) {
-	ctrl, err := gc.dialNPCController(sessionID)
+	ctrl, cleanup, err := gc.dialNPCController(sessionID)
 	if err != nil {
 		return 0, err
 	}
+	defer cleanup()
 	return ctrl.UnmuteAllNPCs(ctx, sessionID)
 }
 
 // SpeakNPC implements [NPCController].
 func (gc *GatewaySessionController) SpeakNPC(ctx context.Context, sessionID, npcName, text string) error {
-	ctrl, err := gc.dialNPCController(sessionID)
+	ctrl, cleanup, err := gc.dialNPCController(sessionID)
 	if err != nil {
 		return err
 	}
+	defer cleanup()
 	return ctrl.SpeakNPC(ctx, sessionID, npcName, text)
 }

--- a/internal/gateway/voicebridge.go
+++ b/internal/gateway/voicebridge.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -92,6 +93,34 @@ func (p *voiceBridgeProvider) Close() {
 	p.closeOnce.Do(func() {
 		close(p.done)
 	})
+}
+
+// daveReadyTimeout is the maximum time to wait for the DAVE E2EE handshake
+// to complete after the voice connection is opened.
+const daveReadyTimeout = 10 * time.Second
+
+// waitForDAVEReady registers an event handler on the voice connection and
+// blocks until an OpcodeDaveExecuteTransition event is received, signaling
+// that the DAVE MLS key exchange has completed and packets can be
+// encrypted/decrypted. Returns an error if ctx is canceled first.
+func waitForDAVEReady(ctx context.Context, voiceConn voice.Conn, sessionID string) error {
+	ready := make(chan struct{}, 1)
+	voiceConn.SetEventHandlerFunc(func(_ voice.Gateway, op voice.Opcode, _ int, _ voice.GatewayMessageData) {
+		if op == voice.OpcodeDaveExecuteTransition {
+			select {
+			case ready <- struct{}{}:
+			default:
+			}
+		}
+	})
+
+	select {
+	case <-ready:
+		slog.Info("voicebridge: DAVE handshake complete", "session_id", sessionID)
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("voicebridge: DAVE ready timeout for session %s: %w", sessionID, ctx.Err())
+	}
 }
 
 // setupVoiceBridge configures a voice.Conn to bridge audio to/from a


### PR DESCRIPTION
## Summary
- **Stream disconnect (30ms):** `connectAudioBridge` used the `StartSession` RPC server context for `StreamAudio`. When the RPC handler returned, gRPC canceled the context, killing the stream immediately. Fixed by using `context.Background()` for the long-lived bidirectional stream.
- **DAVE decryption failures:** `setupVoiceBridge` was called right after `voiceConn.Open()`, but `Open()` only waits for `SessionDescription` (basic crypto), not for the DAVE MLS key exchange to complete. Voice packets arriving before DAVE handshake completion could not be decrypted. Fixed by waiting for `OpcodeDaveExecuteTransition` (10s timeout) before wiring the audio bridge.
- **NPC controller cleanup:** `dialNPCController` now returns a cleanup function to close the underlying gRPC connection after each NPC command (linter fix included).

## Test plan
- [x] `go vet` passes on all changed packages
- [x] `go test -race -count=1` passes on all packages (whisper excluded — missing headers, pre-existing)
- [ ] Deploy to K3s and verify voice session connects without `context canceled` errors
- [ ] Verify DAVE decryption succeeds (no `failed to decrypt frame` errors)
- [ ] Verify audio flows end-to-end (player speech → NPC response)