### PR TITLE
fix(gateway): session lifecycle robustness

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -52,6 +53,7 @@ import (
 	"github.com/MrWong99/glyphoxa/internal/session"
 	"github.com/MrWong99/glyphoxa/pkg/audio"
 	"github.com/MrWong99/glyphoxa/pkg/audio/webrtc"
+	"github.com/MrWong99/glyphoxa/pkg/memory/postgres"
 	"github.com/MrWong99/glyphoxa/pkg/provider/embeddings"
 	ollamaembed "github.com/MrWong99/glyphoxa/pkg/provider/embeddings/ollama"
 	oaembed "github.com/MrWong99/glyphoxa/pkg/provider/embeddings/openai"
@@ -354,6 +356,11 @@ func runGateway(cfg *config.Config) int {
 	// and workers over gRPC bidirectional streaming.
 	audioBridgeSrv := audiobridge.NewServer()
 
+	// sessionCtrls collects per-tenant session controllers so they can be
+	// drained during graceful shutdown.
+	var sessionCtrlsMu sync.Mutex
+	var sessionCtrls []*gw.GatewaySessionController
+
 	// Configure per-tenant slash command wiring.
 	botConnector.SetCommandSetup(func(gwBot *gw.GatewayBot, tenant gw.Tenant) {
 		router := gwBot.Router()
@@ -387,6 +394,11 @@ func runGateway(cfg *config.Config) int {
 			}),
 		)
 
+		// Track session controller for graceful shutdown.
+		sessionCtrlsMu.Lock()
+		sessionCtrls = append(sessionCtrls, sessionCtrl)
+		sessionCtrlsMu.Unlock()
+
 		// Session start/stop commands.
 		commands.NewGatewaySessionCommands(gwBot, sessionCtrl, perms)
 
@@ -408,13 +420,27 @@ func runGateway(cfg *config.Config) int {
 		campaignCmds.Register(router)
 
 		// Recap commands — text-only for gateway mode (no TTS providers on
-		// gateway). Session store is nil for now; transcript reading can be
-		// added once schema-per-tenant is wired.
+		// gateway). Session store reads transcripts from the worker's
+		// tenant-scoped schema via the shared pgxpool.
+		var recapSessionStore *postgres.SessionStoreImpl
+		schemaName := fmt.Sprintf("tenant_%s", tenant.ID)
+		recapSchema, schemaErr := postgres.NewSchemaName(schemaName)
+		if schemaErr != nil {
+			slog.Warn("gateway: invalid schema name for recap, transcripts unavailable",
+				"tenant_id", tenant.ID, "schema", schemaName, "err", schemaErr)
+		} else {
+			campaignID := tenant.CampaignID
+			if campaignID == "" {
+				campaignID = "default"
+			}
+			recapSessionStore = postgres.NewSessionStore(pool, recapSchema, campaignID)
+		}
 		commands.NewGatewayRecapCommands(commands.GatewayRecapConfig{
-			GatewayBot: gwBot,
-			Ctrl:       sessionCtrl,
-			NPCCtrl:    sessionCtrl,
-			Perms:      perms,
+			GatewayBot:   gwBot,
+			Ctrl:         sessionCtrl,
+			NPCCtrl:      sessionCtrl,
+			Perms:        perms,
+			SessionStore: recapSessionStore,
 		})
 
 		// Feedback commands.
@@ -612,6 +638,15 @@ func runGateway(cfg *config.Config) int {
 	defer cancel()
 
 	slog.Info("shutdown signal received, stopping…")
+
+	// Drain active sessions — sends StopSession RPC to workers, tears down
+	// voice bridges, and transitions sessions to ended in the DB.
+	sessionCtrlsMu.Lock()
+	ctrls := append([]*gw.GatewaySessionController(nil), sessionCtrls...)
+	sessionCtrlsMu.Unlock()
+	for _, ctrl := range ctrls {
+		ctrl.StopAll(shutdownCtx)
+	}
 
 	if dispatcher != nil {
 		if err := dispatcher.Cleanup(shutdownCtx); err != nil {

--- a/internal/gateway/audiobridge/bridge.go
+++ b/internal/gateway/audiobridge/bridge.go
@@ -28,6 +28,12 @@ const (
 	handshakeTimeout = 10 * time.Second
 )
 
+// StreamDetachFunc is called when a worker's audio stream disconnects.
+// The sessionID identifies which session lost its audio connection.
+// Implementations must not block; long-running work should be spawned
+// as a goroutine.
+type StreamDetachFunc func(sessionID string, err error)
+
 // Server implements the AudioBridgeService gRPC service on the gateway side.
 // It manages per-session bridges and handles the bidirectional opus stream.
 //
@@ -37,6 +43,8 @@ type Server struct {
 
 	mu      sync.RWMutex
 	bridges map[string]*SessionBridge // sessionID -> bridge
+
+	onDetach StreamDetachFunc
 }
 
 // SessionBridge bridges audio for a single session between the gateway's
@@ -62,6 +70,16 @@ func NewServer() *Server {
 	return &Server{
 		bridges: make(map[string]*SessionBridge),
 	}
+}
+
+// SetOnStreamDetach registers a callback that fires when a worker's audio
+// stream disconnects (gRPC stream error or clean shutdown). This lets the
+// gateway detect worker death and trigger session cleanup immediately rather
+// than waiting for heartbeat timeout.
+func (s *Server) SetOnStreamDetach(fn StreamDetachFunc) {
+	s.mu.Lock()
+	s.onDetach = fn
+	s.mu.Unlock()
 }
 
 // Register adds the Server to a gRPC server.
@@ -214,6 +232,16 @@ func (s *Server) StreamAudio(stream grpc.BidiStreamingServer[pb.AudioFrame, pb.A
 		"session_id", sessionID,
 		"err", streamErr,
 	)
+
+	// Notify the gateway that this session's audio stream is gone so it can
+	// trigger cleanup (voice disconnect, DB state, K8s job) immediately.
+	s.mu.RLock()
+	fn := s.onDetach
+	s.mu.RUnlock()
+	if fn != nil && streamErr != nil {
+		fn(sessionID, streamErr)
+	}
+
 	return streamErr
 }
 

--- a/internal/gateway/sessionctrl.go
+++ b/internal/gateway/sessionctrl.go
@@ -78,6 +78,30 @@ func NewGatewaySessionController(
 	for _, opt := range opts {
 		opt(gc)
 	}
+
+	// Register audio bridge detach callback so worker death triggers
+	// immediate session cleanup instead of waiting for heartbeat timeout.
+	if gc.bridgeSrv != nil {
+		gc.bridgeSrv.SetOnStreamDetach(func(sessionID string, err error) {
+			gc.mu.Lock()
+			_, owns := gc.workerAddrs[sessionID]
+			gc.mu.Unlock()
+			if !owns {
+				return
+			}
+			slog.Warn("gateway: audio stream lost, stopping session",
+				"session_id", sessionID, "err", err)
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				if stopErr := gc.Stop(ctx, sessionID); stopErr != nil {
+					slog.Error("gateway: failed to stop session after stream loss",
+						"session_id", sessionID, "err", stopErr)
+				}
+			}()
+		})
+	}
+
 	return gc
 }
 
@@ -233,18 +257,43 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 	return nil
 }
 
-// Stop gracefully ends the session.
+// Stop gracefully ends the session. It first sends a StopSession RPC to the
+// worker so it can flush transcripts and cleanly shut down before the K8s Job
+// is deleted.
 func (gc *GatewaySessionController) Stop(ctx context.Context, sessionID string) error {
+	// 1. Tell the worker to stop gracefully (flush transcripts, etc.).
+	gc.mu.Lock()
+	addr := gc.workerAddrs[sessionID]
+	gc.mu.Unlock()
+	if addr != "" && gc.dialer != nil {
+		rpcCtx, rpcCancel := context.WithTimeout(ctx, 5*time.Second)
+		client, dialErr := gc.dialer(addr)
+		if dialErr == nil {
+			if stopErr := client.StopSession(rpcCtx, sessionID); stopErr != nil {
+				slog.Warn("gateway: worker StopSession RPC failed (may already be dead)",
+					"session_id", sessionID, "err", stopErr)
+			}
+			if c, ok := client.(interface{ Close() error }); ok {
+				c.Close()
+			}
+		}
+		rpcCancel()
+	}
+
+	// 2. Delete the K8s Job.
 	if gc.dispatcher != nil {
 		if err := gc.dispatcher.Stop(ctx, sessionID); err != nil {
 			slog.Warn("gateway: dispatcher stop error",
 				"session_id", sessionID, "err", err)
 		}
 	}
+
+	// 3. Transition session state in the DB.
 	if err := gc.orch.Transition(ctx, sessionID, SessionEnded, ""); err != nil {
 		return fmt.Errorf("gateway: transition session to ended: %w", err)
 	}
 
+	// 4. Clean up in-memory state and voice bridge.
 	gc.mu.Lock()
 	delete(gc.workerAddrs, sessionID)
 	for guildID, sid := range gc.active {
@@ -288,6 +337,25 @@ func (gc *GatewaySessionController) Info(guildID string) (SessionInfo, bool) {
 		}, true
 	}
 	return info, true
+}
+
+// StopAll gracefully stops all active sessions. Used during gateway shutdown
+// to drain sessions before the process exits.
+func (gc *GatewaySessionController) StopAll(ctx context.Context) {
+	gc.mu.Lock()
+	// Snapshot session IDs so we don't hold the lock while stopping.
+	sessionIDs := make([]string, 0, len(gc.active))
+	for _, sid := range gc.active {
+		sessionIDs = append(sessionIDs, sid)
+	}
+	gc.mu.Unlock()
+
+	for _, sid := range sessionIDs {
+		if err := gc.Stop(ctx, sid); err != nil {
+			slog.Warn("gateway: failed to stop session during shutdown",
+				"session_id", sid, "err", err)
+		}
+	}
 }
 
 // cleanupVoiceBridge tears down the voice bridge and audio bridge for a session.

--- a/pkg/memory/postgres/session_store.go
+++ b/pkg/memory/postgres/session_store.go
@@ -15,12 +15,20 @@ import (
 // SessionStoreImpl is the L1 memory layer backed by a PostgreSQL
 // session_entries table with a GIN full-text search index.
 //
-// Obtain one via [Store.L1] rather than constructing directly.
-// All methods are safe for concurrent use.
+// Obtain one via [Store.L1] or [NewSessionStore] rather than constructing
+// directly. All methods are safe for concurrent use.
 type SessionStoreImpl struct {
 	pool       *pgxpool.Pool
 	schema     SchemaName
 	campaignID string
+}
+
+// NewSessionStore creates a read-only SessionStoreImpl that shares an existing
+// [pgxpool.Pool]. This is intended for components that only need L1 transcript
+// access (e.g. the gateway recap command) without standing up the full
+// three-layer [Store].
+func NewSessionStore(pool *pgxpool.Pool, schema SchemaName, campaignID string) *SessionStoreImpl {
+	return &SessionStoreImpl{pool: pool, schema: schema, campaignID: campaignID}
 }
 
 // WriteEntry implements [memory.SessionStore]. It appends entry to the


### PR DESCRIPTION
## Summary

Four improvements to session lifecycle handling in gateway mode:

- **Recap transcripts**: Wire `SessionStore` into `/recap` command so transcripts from PostgreSQL are visible. The gateway creates a read-only `SessionStoreImpl` using the shared pgxpool and tenant-scoped schema (`tenant_<id>`), matching the worker's storage path. Fixes the bug where `/recap` showed session info but no transcripts.
- **Worker death detection**: Add `OnStreamDetach` callback to `audiobridge.Server`. When the gRPC audio stream breaks (worker pod dies/crashes), the gateway immediately triggers session cleanup instead of waiting 45s for heartbeat timeout.
- **Graceful StopSession RPC**: Before deleting the K8s Job, `Stop()` now sends a `StopSession` RPC to the worker with a 5s timeout. This gives the worker time to flush in-flight transcripts and cleanly shut down its voice pipeline.
- **Session draining on shutdown**: During graceful gateway shutdown (SIGTERM), all per-tenant session controllers drain their active sessions before the gRPC server and bot manager are stopped.

## Files changed

| File | Change |
|------|--------|
| `pkg/memory/postgres/session_store.go` | Add `NewSessionStore()` constructor for read-only L1 access |
| `cmd/glyphoxa/main.go` | Wire SessionStore into recap, collect controllers for shutdown drain |
| `internal/gateway/audiobridge/bridge.go` | Add `StreamDetachFunc` callback on stream disconnect |
| `internal/gateway/sessionctrl.go` | Graceful StopSession RPC, `StopAll()`, stream detach handler |

## Test plan

- [x] `go vet ./...` passes
- [x] All tests pass (`go test -race -count=1 ./...` — whisper build failure is pre-existing)
- [ ] Deploy to K3s and verify `/recap` shows transcripts in gateway mode
- [ ] Test worker pod kill — session should clean up immediately
- [ ] Test `/session stop` — verify worker receives StopSession RPC before job deletion
- [ ] Test gateway restart — verify active sessions are drained gracefully