### PR TITLE
fix(gateway): voice permission check, DB health probe, pipeline logging

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -583,6 +583,12 @@ func runGateway(cfg *config.Config) int {
 				return nil
 			},
 		},
+		health.Checker{
+			Name: "database",
+			Check: func(ctx context.Context) error {
+				return pool.Ping(ctx)
+			},
+		},
 	)
 
 	// ── Zombie session + orphan job cleanup ──────────────────────────────────

--- a/internal/engine/cascade/cascade.go
+++ b/internal/engine/cascade/cascade.go
@@ -220,6 +220,11 @@ func (e *Engine) Process(ctx context.Context, _ audio.AudioFrame, prompt engine.
 		textCh <- opener
 		close(textCh)
 
+		slog.Info("cascade: TTS starting (single-model path)",
+			"voice", e.voice.Name,
+			"text_preview", truncate(opener, 80),
+		)
+		ttsStart := time.Now()
 		audioCh, err := e.ttsP.SynthesizeStream(ctx, textCh, e.voice)
 		if err != nil {
 			return nil, fmt.Errorf("cascade: TTS start failed: %w", err)
@@ -239,6 +244,12 @@ func (e *Engine) Process(ctx context.Context, _ audio.AudioFrame, prompt engine.
 		// Background goroutine: wait for playback outcome, then emit transcript.
 		e.wg.Go(func() {
 			interrupted := e.waitForDone(ctx, notifyDone)
+
+			slog.Info("cascade: TTS finished (single-model path)",
+				"voice", e.voice.Name,
+				"interrupted", interrupted,
+				"duration", time.Since(ttsStart).Round(time.Millisecond),
+			)
 
 			if interrupted {
 				// Single sentence — if interrupted mid-playback, some audio
@@ -274,6 +285,11 @@ func (e *Engine) Process(ctx context.Context, _ audio.AudioFrame, prompt engine.
 	// Create the shared text channel that feeds the TTS stream.
 	// We wrap it with a tracking channel that records committed text.
 	textCh := make(chan string, defaultTextBuf)
+	slog.Info("cascade: TTS starting (dual-model path)",
+		"voice", e.voice.Name,
+		"opener_preview", truncate(opener, 80),
+	)
+	ttsStart := time.Now()
 	audioCh, err := e.ttsP.SynthesizeStream(ctx, textCh, e.voice)
 	if err != nil {
 		return nil, fmt.Errorf("cascade: TTS start failed: %w", err)
@@ -328,6 +344,12 @@ func (e *Engine) Process(ctx context.Context, _ audio.AudioFrame, prompt engine.
 		}
 		// Wait for playback outcome.
 		interrupted := e.waitForDone(ctx, notifyDone)
+
+		slog.Info("cascade: TTS finished (dual-model path)",
+			"voice", e.voice.Name,
+			"interrupted", interrupted,
+			"duration", time.Since(ttsStart).Round(time.Millisecond),
+		)
 
 		if interrupted {
 			committedMu.Lock()
@@ -887,6 +909,14 @@ func lastUserMessage(msgs []llm.Message) (llm.Message, bool) {
 		}
 	}
 	return llm.Message{}, false
+}
+
+// truncate returns s truncated to maxLen runes, with "…" appended if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "…"
 }
 
 // mergeContextUpdate applies a [engine.ContextUpdate] onto a [engine.PromptContext],

--- a/internal/gateway/sessionctrl.go
+++ b/internal/gateway/sessionctrl.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/disgo/discord"
 	"github.com/disgoorg/disgo/events"
+	"github.com/disgoorg/disgo/rest"
 	"github.com/disgoorg/snowflake/v2"
 
 	"github.com/MrWong99/glyphoxa/internal/config"
@@ -176,6 +178,14 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 				gc.bridgeSrv.RemoveBridge(sessionID)
 				_ = gc.orch.Transition(ctx, sessionID, SessionEnded, "VoiceManager not available")
 				return fmt.Errorf("gateway: VoiceManager not available on gateway bot")
+			}
+
+			// Check bot has CONNECT + SPEAK permissions before attempting to join.
+			// Discord silently ignores Op 4 without CONNECT, causing a confusing timeout.
+			if permErr := checkVoicePermissions(ctx, gc.gwBot.Client().Rest, gID, chID, gc.gwBot.Client().ApplicationID); permErr != nil {
+				gc.bridgeSrv.RemoveBridge(sessionID)
+				_ = gc.orch.Transition(ctx, sessionID, SessionEnded, permErr.Error())
+				return fmt.Errorf("gateway: voice permission check: %w", permErr)
 			}
 
 			voiceConn := voiceMgr.CreateConn(gID)
@@ -506,4 +516,135 @@ func (gc *GatewaySessionController) SpeakNPC(ctx context.Context, sessionID, npc
 	}
 	defer cleanup()
 	return ctrl.SpeakNPC(ctx, sessionID, npcName, text)
+}
+
+// ── Voice permission check ──────────────────────────────────────────────────
+
+// requiredVoicePerms are the Discord permissions the bot needs to join and
+// speak in a voice channel.
+var requiredVoicePerms = discord.PermissionConnect | discord.PermissionSpeak
+
+// checkVoicePermissions verifies via the Discord REST API that the bot has
+// CONNECT and SPEAK permissions on the target voice channel. Discord silently
+// ignores the voice connect opcode when CONNECT is missing, so failing fast
+// here prevents a confusing timeout.
+func checkVoicePermissions(ctx context.Context, restClient rest.Rest, guildID, channelID, botID snowflake.ID) error {
+	// Fetch the channel to get permission overwrites.
+	ch, err := restClient.GetChannel(channelID, rest.WithCtx(ctx))
+	if err != nil {
+		return fmt.Errorf("fetch channel %s: %w", channelID, err)
+	}
+	guildCh, ok := ch.(discord.GuildChannel)
+	if !ok {
+		return fmt.Errorf("channel %s is not a guild channel", channelID)
+	}
+
+	// Fetch guild to get roles (needed for base permission computation).
+	guild, err := restClient.GetGuild(guildID, false, rest.WithCtx(ctx))
+	if err != nil {
+		return fmt.Errorf("fetch guild %s: %w", guildID, err)
+	}
+
+	// Fetch the bot's member to get its role list.
+	member, err := restClient.GetMember(guildID, botID, rest.WithCtx(ctx))
+	if err != nil {
+		return fmt.Errorf("fetch bot member in guild %s: %w", guildID, err)
+	}
+
+	perms := computeChannelPerms(guild, member, guildCh)
+
+	if perms.Has(discord.PermissionAdministrator) {
+		return nil
+	}
+	if perms.Missing(requiredVoicePerms) {
+		missing := requiredVoicePerms.Remove(perms)
+		slog.Error("gateway: bot missing voice channel permissions",
+			"guild_id", guildID,
+			"channel_id", channelID,
+			"missing", missing,
+			"required", requiredVoicePerms,
+		)
+		return fmt.Errorf("bot missing permissions on channel %s: need CONNECT+SPEAK, missing %s", channelID, missing)
+	}
+	return nil
+}
+
+// computeChannelPerms computes the effective permissions for a member in a
+// guild channel following Discord's permission algorithm:
+//  1. Start with @everyone role permissions.
+//  2. OR in permissions from all member roles.
+//  3. Apply channel-level role permission overwrites.
+//  4. Apply channel-level member permission overwrite.
+func computeChannelPerms(guild *discord.RestGuild, member *discord.Member, ch discord.GuildChannel) discord.Permissions {
+	// Owner has all permissions.
+	if guild.OwnerID == member.User.ID {
+		return discord.PermissionsAll
+	}
+
+	// 1. Base: @everyone role (same ID as guild).
+	var base discord.Permissions
+	for _, role := range guild.Roles {
+		if role.ID == guild.ID {
+			base = role.Permissions
+			break
+		}
+	}
+
+	// 2. Accumulate role permissions.
+	memberRoles := make(map[snowflake.ID]struct{}, len(member.RoleIDs))
+	for _, rid := range member.RoleIDs {
+		memberRoles[rid] = struct{}{}
+		for _, role := range guild.Roles {
+			if role.ID == rid {
+				base = base.Add(role.Permissions)
+				break
+			}
+		}
+	}
+
+	// Administrator bypasses channel overwrites.
+	if base.Has(discord.PermissionAdministrator) {
+		return discord.PermissionsAll
+	}
+
+	// 3. Apply channel role overwrites.
+	var allow, deny discord.Permissions
+	overwrites := ch.PermissionOverwrites()
+	for _, ow := range overwrites {
+		roleOW, ok := ow.(discord.RolePermissionOverwrite)
+		if !ok {
+			continue
+		}
+		if roleOW.RoleID == guild.ID {
+			// @everyone overwrite.
+			deny = deny.Add(roleOW.Deny)
+			allow = allow.Add(roleOW.Allow)
+		}
+	}
+	base = base.Remove(deny).Add(allow)
+
+	// Other role overwrites.
+	deny = 0
+	allow = 0
+	for _, ow := range overwrites {
+		roleOW, ok := ow.(discord.RolePermissionOverwrite)
+		if !ok {
+			continue
+		}
+		if roleOW.RoleID == guild.ID {
+			continue // already handled above
+		}
+		if _, isMember := memberRoles[roleOW.RoleID]; isMember {
+			deny = deny.Add(roleOW.Deny)
+			allow = allow.Add(roleOW.Allow)
+		}
+	}
+	base = base.Remove(deny).Add(allow)
+
+	// 4. Apply member-specific overwrite.
+	if memberOW, ok := overwrites.Member(member.User.ID); ok {
+		base = base.Remove(memberOW.Deny).Add(memberOW.Allow)
+	}
+
+	return base
 }

--- a/internal/gateway/voicebridge.go
+++ b/internal/gateway/voicebridge.go
@@ -20,6 +20,10 @@ var (
 	_ voice.OpusFrameProvider = (*voiceBridgeProvider)(nil)
 )
 
+// frameLogInterval controls how often periodic frame-flow log messages are
+// emitted. One log line per this many frames (~5 s at 50 fps).
+const frameLogInterval = 250
+
 // voiceBridgeReceiver implements [voice.OpusFrameReceiver] by forwarding raw
 // opus frames to a [audiobridge.SessionBridge]. This is set on the gateway's
 // voice.Conn so incoming Discord audio is bridged to the worker.
@@ -27,8 +31,9 @@ type voiceBridgeReceiver struct {
 	bridge    *audiobridge.SessionBridge
 	sessionID string
 
-	done      chan struct{}
-	closeOnce sync.Once
+	frameCount uint64
+	done       chan struct{}
+	closeOnce  sync.Once
 }
 
 // ReceiveOpusFrame receives a raw opus packet from Discord and forwards it to
@@ -36,6 +41,15 @@ type voiceBridgeReceiver struct {
 func (r *voiceBridgeReceiver) ReceiveOpusFrame(userID snowflake.ID, packet *voice.Packet) error {
 	if packet == nil || len(packet.Opus) == 0 {
 		return nil
+	}
+
+	r.frameCount++
+	if r.frameCount%frameLogInterval == 1 {
+		slog.Info("voicebridge: forwarding Discord→worker audio",
+			"session_id", r.sessionID,
+			"frames_total", r.frameCount,
+			"user_id", userID,
+		)
 	}
 
 	r.bridge.SendToWorker(&pb.AudioFrame{
@@ -66,8 +80,10 @@ type voiceBridgeProvider struct {
 	bridge    *audiobridge.SessionBridge
 	sessionID string
 
-	done      chan struct{}
-	closeOnce sync.Once
+	frameCount uint64
+	gotFirst   bool
+	done       chan struct{}
+	closeOnce  sync.Once
 }
 
 // ProvideOpusFrame returns the next opus frame to send to Discord. It reads
@@ -80,6 +96,19 @@ func (p *voiceBridgeProvider) ProvideOpusFrame() ([]byte, error) {
 	case frame := <-p.bridge.ReceiveFromWorker():
 		if frame == nil {
 			return nil, nil
+		}
+		p.frameCount++
+		if !p.gotFirst {
+			p.gotFirst = true
+			slog.Info("voicebridge: first worker audio frame received",
+				"session_id", p.sessionID,
+			)
+		}
+		if p.frameCount%frameLogInterval == 0 {
+			slog.Info("voicebridge: forwarding worker→Discord audio",
+				"session_id", p.sessionID,
+				"frames_total", p.frameCount,
+			)
 		}
 		return frame.GetOpusData(), nil
 	default:
@@ -151,6 +180,11 @@ func setupVoiceBridge(
 	)
 
 	return func() {
+		slog.Info("voicebridge: stopping audio bridge",
+			"session_id", sessionID,
+			"discord_to_worker_frames", receiver.frameCount,
+			"worker_to_discord_frames", provider.frameCount,
+		)
 		receiver.Close()
 		provider.Close()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/pkg/audio/grpcbridge/connection.go
+++ b/pkg/audio/grpcbridge/connection.go
@@ -38,6 +38,10 @@ const (
 	opusFrameBytes = opusFrameSize * opusChannels * 2
 )
 
+// frameLogInterval controls how often periodic frame-flow log messages are
+// emitted. One log line per this many frames (~5 s at 50 fps).
+const frameLogInterval = 250
+
 // Connection implements [audio.Connection] by streaming opus frames over a
 // gRPC AudioBridgeService bidirectional stream. Incoming frames from the
 // gateway (Discord audio) are decoded from opus to PCM and demuxed by user_id
@@ -61,6 +65,9 @@ type Connection struct {
 
 	changeCb func(audio.Event)
 	changeMu sync.Mutex
+
+	recvFrames uint64
+	sendFrames uint64
 
 	done      chan struct{}
 	closeOnce sync.Once
@@ -176,6 +183,15 @@ func (c *Connection) recvLoop() {
 			Timestamp:  time.Duration(frame.GetSsrc()) * time.Second / time.Duration(opusSampleRate),
 		}
 
+		c.recvFrames++
+		if c.recvFrames%frameLogInterval == 1 {
+			slog.Info("grpcbridge: receiving gateway→worker audio",
+				"session_id", c.sessionID,
+				"frames_total", c.recvFrames,
+				"participants", len(c.inputs),
+			)
+		}
+
 		select {
 		case ch <- af:
 		default:
@@ -211,6 +227,19 @@ func (c *Connection) sendLoop() {
 				if encErr != nil {
 					slog.Warn("grpcbridge: opus encode error", "err", encErr)
 					continue
+				}
+
+				c.sendFrames++
+				if c.sendFrames == 1 {
+					slog.Info("grpcbridge: first NPC audio frame sent to gateway",
+						"session_id", c.sessionID,
+					)
+				}
+				if c.sendFrames%frameLogInterval == 0 {
+					slog.Info("grpcbridge: sending worker→gateway audio",
+						"session_id", c.sessionID,
+						"frames_total", c.sendFrames,
+					)
 				}
 
 				err := c.stream.Send(&pb.AudioFrame{


### PR DESCRIPTION
## Summary

- **Voice permission check before join**: Uses Discord REST API to verify CONNECT+SPEAK permissions on the target voice channel before attempting to join. Discord silently ignores Op 4 without CONNECT, which caused confusing timeouts during debugging. Now fails fast with a clear, actionable error message including which permissions are missing.
- **DB health check in readiness probe**: Adds a `database` checker to the gateway's `/readyz` endpoint that calls `pool.Ping(ctx)` on the PostgreSQL connection pool. Previously only checked gRPC and admin API readiness.
- **Audio pipeline logging**: Adds INFO-level logs at key points throughout the voice pipeline:
  - Voice bridge start/stop with total frame counts
  - First worker audio frame detection (gateway→Discord direction)
  - Periodic frame flow stats every ~250 frames (~5 seconds at 50fps)
  - gRPC bridge recv/send frame counts (worker side)
  - First NPC audio frame sent from worker to gateway
  - TTS start (with voice name and text preview) and finish (with duration and interruption status) for both single-model and dual-model cascade paths

## Test plan
- [x] `go test -race -count=1 ./...` passes (excluding pre-existing whisper.cpp build failures)
- [x] `go vet ./...` clean on changed packages
- [x] `gofmt -l .` clean
- [ ] Deploy to staging and verify `/readyz` includes `database: ok`
- [ ] Start a voice session and verify permission check logs appear
- [ ] Verify periodic audio frame logs appear during active sessions
- [ ] Test with a channel where bot lacks permissions — should get clear error