### PR TITLE
fix(gateway): remove DAVE ready timeout — wire audio bridge immediately

### DIFF
--- a/internal/gateway/sessionctrl.go
+++ b/internal/gateway/sessionctrl.go
@@ -190,6 +190,9 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 
 			voiceConn := voiceMgr.CreateConn(gID)
 			if joinErr := voiceConn.Open(ctx, chID, false, false); joinErr != nil {
+				closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				voiceConn.Close(closeCtx)
+				closeCancel()
 				voiceMgr.RemoveConn(gID)
 				gc.bridgeSrv.RemoveBridge(sessionID)
 				_ = gc.orch.Transition(ctx, sessionID, SessionEnded, joinErr.Error())
@@ -202,19 +205,12 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 				"channel_id", req.ChannelID,
 			)
 
-			// Wait for DAVE E2EE handshake to complete before wiring the
-			// audio bridge. Without this, the receiver reads encrypted
-			// packets before keys are exchanged, causing decryption failures.
-			daveCtx, daveCancel := context.WithTimeout(context.Background(), daveReadyTimeout)
-			if daveErr := waitForDAVEReady(daveCtx, voiceConn, sessionID); daveErr != nil {
-				daveCancel()
-				voiceMgr.RemoveConn(gID)
-				gc.bridgeSrv.RemoveBridge(sessionID)
-				_ = gc.orch.Transition(ctx, sessionID, SessionEnded, daveErr.Error())
-				return fmt.Errorf("gateway: DAVE handshake: %w", daveErr)
-			}
-			daveCancel()
-
+			// Wire the audio bridge immediately. DAVE E2EE handshake
+			// completes asynchronously inside disgo — the
+			// OpusFrameReceiver callback receives already-decrypted
+			// packets, so there is no need to block here waiting for a
+			// DAVE event. This matches the full-mode code path which
+			// also starts flowing audio right after Open().
 			cleanup := setupVoiceBridge(voiceConn, bridge, sessionID)
 			gc.voiceCleanupsMu.Lock()
 			gc.voiceCleanups[sessionID] = func() {

--- a/internal/gateway/voicebridge.go
+++ b/internal/gateway/voicebridge.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -122,34 +121,6 @@ func (p *voiceBridgeProvider) Close() {
 	p.closeOnce.Do(func() {
 		close(p.done)
 	})
-}
-
-// daveReadyTimeout is the maximum time to wait for the DAVE E2EE handshake
-// to complete after the voice connection is opened.
-const daveReadyTimeout = 10 * time.Second
-
-// waitForDAVEReady registers an event handler on the voice connection and
-// blocks until an OpcodeDaveExecuteTransition event is received, signaling
-// that the DAVE MLS key exchange has completed and packets can be
-// encrypted/decrypted. Returns an error if ctx is canceled first.
-func waitForDAVEReady(ctx context.Context, voiceConn voice.Conn, sessionID string) error {
-	ready := make(chan struct{}, 1)
-	voiceConn.SetEventHandlerFunc(func(_ voice.Gateway, op voice.Opcode, _ int, _ voice.GatewayMessageData) {
-		if op == voice.OpcodeDaveExecuteTransition {
-			select {
-			case ready <- struct{}{}:
-			default:
-			}
-		}
-	})
-
-	select {
-	case <-ready:
-		slog.Info("voicebridge: DAVE handshake complete", "session_id", sessionID)
-		return nil
-	case <-ctx.Done():
-		return fmt.Errorf("voicebridge: DAVE ready timeout for session %s: %w", sessionID, ctx.Err())
-	}
 }
 
 // setupVoiceBridge configures a voice.Conn to bridge audio to/from a


### PR DESCRIPTION
## Summary

- **Remove `waitForDAVEReady()` blocking call** — The function waited up to 10s for an `OpcodeDaveExecuteTransition` event after joining voice. In production, this consistently timed out, preventing sessions from starting entirely (`DAVE ready timeout ... context deadline exceeded`).
- **Root cause**: The wait was unnecessary. disgo handles DAVE E2EE encryption internally — the `OpusFrameReceiver` callback receives already-decrypted packets. Full mode already works this way (wires audio immediately after `Open()` with no DAVE wait). Gateway mode should do the same.
- **Fix bot stuck in voice on failure** — `VoiceManager.RemoveConn()` only deletes from its internal map without closing the underlying websocket/UDP connection. Now `voiceConn.Close()` is called before `RemoveConn()` on `Open()` failure, ensuring the bot properly leaves the voice channel.

## Changes

- `internal/gateway/sessionctrl.go`: Remove DAVE wait block, add `voiceConn.Close()` to Open failure path
- `internal/gateway/voicebridge.go`: Remove `waitForDAVEReady()` function and `daveReadyTimeout` constant (dead code)

## Test plan

- [x] `go test -race -count=1 ./internal/gateway/...` — all pass
- [x] `go vet ./internal/gateway/...` — clean
- [ ] Deploy to staging and verify voice sessions start without timeout
- [ ] Verify bot leaves voice channel on connection failure