### PR TITLE
fix(dave): thread-safe wrapper for golibdave DAVE session

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -24,8 +24,9 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/disgoorg/disgo/voice"
-	"github.com/disgoorg/godave/golibdave"
 	"github.com/disgoorg/godave/libdave"
+
+	safedave "github.com/MrWong99/glyphoxa/internal/dave"
 	"github.com/jackc/pgx/v5/pgxpool"
 	anyllmlib "github.com/mozilla-ai/any-llm-go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -1259,7 +1260,7 @@ func registerBuiltinProviders(reg *config.Registry, bot **discordbot.Bot) {
 			GuildID:  guildID,
 			DMRoleID: dmRoleID,
 			VoiceOpts: []voice.ManagerConfigOpt{
-				voice.WithDaveSessionCreateFunc(golibdave.NewSession),
+				voice.WithDaveSessionCreateFunc(safedave.NewSession),
 			},
 		})
 		if err != nil {

--- a/cmd/glyphoxa/worker_factory.go
+++ b/cmd/glyphoxa/worker_factory.go
@@ -28,7 +28,8 @@ import (
 	"github.com/MrWong99/glyphoxa/pkg/memory"
 	"github.com/MrWong99/glyphoxa/pkg/memory/postgres"
 	"github.com/disgoorg/disgo/voice"
-	"github.com/disgoorg/godave/golibdave"
+
+	safedave "github.com/MrWong99/glyphoxa/internal/dave"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure" // used in fallback when no dial opts are configured
 )
@@ -144,7 +145,7 @@ func (wf *workerFactory) CreateRuntime(ctx context.Context, req gw.StartSessionR
 	} else {
 		// Full mode: open own gateway (existing code path).
 		platform, err := discord.NewVoiceOnlyPlatform(sessionCtx, req.BotToken, req.GuildID,
-			discord.WithVoiceManagerOpts(voice.WithDaveSessionCreateFunc(golibdave.NewSession)),
+			discord.WithVoiceManagerOpts(voice.WithDaveSessionCreateFunc(safedave.NewSession)),
 		)
 		if err != nil {
 			if storeCloser != nil {

--- a/internal/dave/safedave.go
+++ b/internal/dave/safedave.go
@@ -1,0 +1,155 @@
+// Package dave provides a thread-safe wrapper around golibdave.Session.
+//
+// golibdave's session struct has no internal synchronization, but disgo calls
+// it from multiple goroutines concurrently:
+//   - The UDP reader goroutine calls Decrypt and MaxDecryptedFrameSize.
+//   - The audio sender goroutine calls Encrypt, MaxEncryptedFrameSize,
+//     and AssignSsrcToCodec.
+//   - The voice gateway goroutine calls AddUser, RemoveUser,
+//     OnSelectProtocolAck, and all DAVE transition/epoch methods.
+//
+// Without a mutex, concurrent map access on session.decryptors causes data
+// races (and potential panics). This wrapper serialises all calls through a
+// single sync.Mutex.
+//
+// Additionally, golibdave's passthrough fallback in Decrypt has a reversed
+// copy (copy(frame, decryptedFrame) instead of copy(decryptedFrame, frame)).
+// The noop session in godave does it correctly. This wrapper does NOT fix that
+// bug because the inner session handles it, but it documents the issue.
+//
+// See: https://github.com/disgoorg/godave (upstream).
+package dave
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/disgoorg/godave"
+	"github.com/disgoorg/godave/golibdave"
+)
+
+// Compile-time interface assertions.
+var (
+	_ godave.SessionCreateFunc = NewSession
+	_ godave.Session           = (*safeSession)(nil)
+)
+
+// NewSession is a drop-in replacement for golibdave.NewSession that wraps
+// the returned session in a mutex. Pass it to
+// voice.WithDaveSessionCreateFunc(dave.NewSession) wherever you would use
+// golibdave.NewSession.
+func NewSession(logger *slog.Logger, selfUserID godave.UserID, callbacks godave.Callbacks) godave.Session {
+	inner := golibdave.NewSession(logger, selfUserID, callbacks)
+	return &safeSession{inner: inner}
+}
+
+// safeSession wraps a godave.Session with a mutex so that all method calls
+// are serialised. This prevents the data race between the UDP reader goroutine
+// (which calls Decrypt) and the voice gateway goroutine (which calls AddUser,
+// RemoveUser, and the various DAVE transition methods).
+type safeSession struct {
+	mu    sync.Mutex
+	inner godave.Session
+}
+
+func (s *safeSession) MaxSupportedProtocolVersion() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inner.MaxSupportedProtocolVersion()
+}
+
+func (s *safeSession) SetChannelID(channelID godave.ChannelID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.SetChannelID(channelID)
+}
+
+func (s *safeSession) AssignSsrcToCodec(ssrc uint32, codec godave.Codec) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.AssignSsrcToCodec(ssrc, codec)
+}
+
+func (s *safeSession) MaxEncryptedFrameSize(frameSize int) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inner.MaxEncryptedFrameSize(frameSize)
+}
+
+func (s *safeSession) Encrypt(ssrc uint32, frame []byte, encryptedFrame []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inner.Encrypt(ssrc, frame, encryptedFrame)
+}
+
+func (s *safeSession) MaxDecryptedFrameSize(userID godave.UserID, frameSize int) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inner.MaxDecryptedFrameSize(userID, frameSize)
+}
+
+func (s *safeSession) Decrypt(userID godave.UserID, frame []byte, decryptedFrame []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inner.Decrypt(userID, frame, decryptedFrame)
+}
+
+func (s *safeSession) AddUser(userID godave.UserID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.AddUser(userID)
+}
+
+func (s *safeSession) RemoveUser(userID godave.UserID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.RemoveUser(userID)
+}
+
+func (s *safeSession) OnSelectProtocolAck(protocolVersion uint16) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.OnSelectProtocolAck(protocolVersion)
+}
+
+func (s *safeSession) OnDavePrepareTransition(transitionID uint16, protocolVersion uint16) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.OnDavePrepareTransition(transitionID, protocolVersion)
+}
+
+func (s *safeSession) OnDaveExecuteTransition(transitionID uint16) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.OnDaveExecuteTransition(transitionID)
+}
+
+func (s *safeSession) OnDavePrepareEpoch(epoch int, protocolVersion uint16) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.OnDavePrepareEpoch(epoch, protocolVersion)
+}
+
+func (s *safeSession) OnDaveMLSExternalSenderPackage(externalSenderPackage []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.OnDaveMLSExternalSenderPackage(externalSenderPackage)
+}
+
+func (s *safeSession) OnDaveMLSProposals(proposals []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.OnDaveMLSProposals(proposals)
+}
+
+func (s *safeSession) OnDaveMLSPrepareCommitTransition(transitionID uint16, commitMessage []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.OnDaveMLSPrepareCommitTransition(transitionID, commitMessage)
+}
+
+func (s *safeSession) OnDaveMLSWelcome(transitionID uint16, welcomeMessage []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.OnDaveMLSWelcome(transitionID, welcomeMessage)
+}

--- a/internal/dave/safedave_test.go
+++ b/internal/dave/safedave_test.go
@@ -1,0 +1,168 @@
+package dave
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/disgoorg/godave"
+)
+
+// stubSession is a minimal godave.Session that records method calls.
+type stubSession struct {
+	mu             sync.Mutex
+	addUserCalls   int
+	decryptCalls   int
+	encryptCalls   int
+	removeCalls    int
+	decryptorUsers map[godave.UserID]bool
+}
+
+func newStubSession() *stubSession {
+	return &stubSession{
+		decryptorUsers: make(map[godave.UserID]bool),
+	}
+}
+
+func (s *stubSession) MaxSupportedProtocolVersion() int                  { return 1 }
+func (s *stubSession) SetChannelID(_ godave.ChannelID)                   {}
+func (s *stubSession) AssignSsrcToCodec(_ uint32, _ godave.Codec)        {}
+func (s *stubSession) MaxEncryptedFrameSize(frameSize int) int           { return frameSize }
+func (s *stubSession) MaxDecryptedFrameSize(_ godave.UserID, fs int) int { return fs }
+func (s *stubSession) OnSelectProtocolAck(_ uint16)                      {}
+func (s *stubSession) OnDavePrepareTransition(_ uint16, _ uint16)        {}
+func (s *stubSession) OnDaveExecuteTransition(_ uint16)                  {}
+func (s *stubSession) OnDavePrepareEpoch(_ int, _ uint16)                {}
+func (s *stubSession) OnDaveMLSExternalSenderPackage(_ []byte)           {}
+func (s *stubSession) OnDaveMLSProposals(_ []byte)                       {}
+func (s *stubSession) OnDaveMLSPrepareCommitTransition(_ uint16, _ []byte) {
+}
+func (s *stubSession) OnDaveMLSWelcome(_ uint16, _ []byte) {}
+
+func (s *stubSession) Encrypt(_ uint32, frame []byte, encryptedFrame []byte) (int, error) {
+	s.mu.Lock()
+	s.encryptCalls++
+	s.mu.Unlock()
+	return copy(encryptedFrame, frame), nil
+}
+
+func (s *stubSession) Decrypt(_ godave.UserID, frame []byte, decryptedFrame []byte) (int, error) {
+	s.mu.Lock()
+	s.decryptCalls++
+	s.mu.Unlock()
+	return copy(decryptedFrame, frame), nil
+}
+
+func (s *stubSession) AddUser(userID godave.UserID) {
+	s.mu.Lock()
+	s.addUserCalls++
+	s.decryptorUsers[userID] = true
+	s.mu.Unlock()
+}
+
+func (s *stubSession) RemoveUser(userID godave.UserID) {
+	s.mu.Lock()
+	s.removeCalls++
+	delete(s.decryptorUsers, userID)
+	s.mu.Unlock()
+}
+
+func TestSafeSession_InterfaceCompliance(t *testing.T) {
+	t.Parallel()
+	var _ godave.Session = (*safeSession)(nil)
+}
+
+func TestSafeSession_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	stub := newStubSession()
+	ss := &safeSession{inner: stub}
+
+	const goroutines = 50
+	const opsPerGoroutine = 100
+
+	var wg sync.WaitGroup
+
+	// Simulate the UDP reader goroutine calling Decrypt concurrently
+	// with the gateway goroutine calling AddUser/RemoveUser.
+	wg.Add(goroutines * 3)
+
+	// Decrypt goroutines (simulating UDP reader).
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			frame := []byte{0x01, 0x02, 0x03}
+			out := make([]byte, 3)
+			for range opsPerGoroutine {
+				_, _ = ss.Decrypt("user-1", frame, out)
+			}
+		}()
+	}
+
+	// AddUser goroutines (simulating gateway).
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for i := range opsPerGoroutine {
+				uid := godave.UserID(string(rune('A' + i%26)))
+				ss.AddUser(uid)
+			}
+		}()
+	}
+
+	// Encrypt goroutines (simulating audio sender).
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			frame := []byte{0x04, 0x05}
+			out := make([]byte, 2)
+			for range opsPerGoroutine {
+				_, _ = ss.Encrypt(12345, frame, out)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify all operations completed.
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if stub.decryptCalls != goroutines*opsPerGoroutine {
+		t.Errorf("expected %d decrypt calls, got %d", goroutines*opsPerGoroutine, stub.decryptCalls)
+	}
+	if stub.encryptCalls != goroutines*opsPerGoroutine {
+		t.Errorf("expected %d encrypt calls, got %d", goroutines*opsPerGoroutine, stub.encryptCalls)
+	}
+	if stub.addUserCalls != goroutines*opsPerGoroutine {
+		t.Errorf("expected %d addUser calls, got %d", goroutines*opsPerGoroutine, stub.addUserCalls)
+	}
+}
+
+func TestNewSession_ReturnsSessionInterface(t *testing.T) {
+	t.Parallel()
+
+	// NewSession should return a godave.Session. We verify the create func
+	// signature matches godave.SessionCreateFunc at compile time (see var block
+	// in safedave.go). Here we also verify at runtime that the returned value
+	// satisfies the interface. We cannot call golibdave.NewSession in unit tests
+	// without the C library, so we only check the type assertion on a manually
+	// constructed safeSession.
+	var s godave.Session = &safeSession{inner: newStubSession()}
+	if s == nil {
+		t.Fatal("safeSession should satisfy godave.Session")
+	}
+}
+
+func TestNewSession_CreateFuncSignature(t *testing.T) {
+	t.Parallel()
+
+	// Verify the function signature is compatible.
+	var fn godave.SessionCreateFunc = func(logger *slog.Logger, userID godave.UserID, callbacks godave.Callbacks) godave.Session {
+		stub := newStubSession()
+		return &safeSession{inner: stub}
+	}
+	session := fn(slog.Default(), "test-user", nil)
+	if session == nil {
+		t.Fatal("create func should return non-nil session")
+	}
+}

--- a/internal/gateway/botconnector.go
+++ b/internal/gateway/botconnector.go
@@ -11,8 +11,9 @@ import (
 	"github.com/disgoorg/disgo/events"
 	"github.com/disgoorg/disgo/gateway"
 	"github.com/disgoorg/disgo/voice"
-	"github.com/disgoorg/godave/golibdave"
 	"github.com/disgoorg/snowflake/v2"
+
+	safedave "github.com/MrWong99/glyphoxa/internal/dave"
 
 	discordbot "github.com/MrWong99/glyphoxa/internal/discord"
 )
@@ -92,7 +93,7 @@ func (c *DiscordBotConnector) ConnectBotForTenant(ctx context.Context, tenant Te
 			router.HandleModal(e)
 		}),
 		bot.WithVoiceManagerConfigOpts(
-			voice.WithDaveSessionCreateFunc(golibdave.NewSession),
+			voice.WithDaveSessionCreateFunc(safedave.NewSession),
 		),
 	}
 


### PR DESCRIPTION
## Summary
- **DAVE decryption failures**: Root cause is a data race in upstream golibdave — the `session` struct has no mutex, but disgo calls `Decrypt()` from the UDP reader goroutine while `AddUser()`/`RemoveUser()`/transition methods run in the gateway websocket goroutine. Concurrent read/write on `session.decryptors` map causes Go runtime panics and corrupted decryptor state → "failed to DAVE decrypt packet" errors.
- **Fix**: New `internal/dave.NewSession` — a drop-in `godave.SessionCreateFunc` that wraps `golibdave.NewSession` with a `sync.Mutex` around all method calls. Replaced at all 3 call sites (gateway botconnector, worker factory full-mode, main.go discord provider).
- **Worker stream dying (~2 min)**: Confirmed already fixed — `connectAudioBridge()` uses `context.Background()` for the stream, and `WorkerHandler` creates its own session context.
- **Additional upstream bug documented**: golibdave's passthrough fallback has `copy(frame, decryptedFrame)` (reversed args vs the correct `copy(decryptedFrame, frame)` in godave's noop session). This corrupts audio when a decryptor hasn't been created yet. Our wrapper doesn't fix this (it's in the inner session), but the mutex prevents the worst of the race conditions that trigger it.

## Test plan
- [x] `go test -race ./internal/dave/...` — concurrent access test with 150 goroutines passes
- [x] `go test -race ./internal/gateway/...` — all gateway subtests pass
- [x] `go test -race ./internal/... ./pkg/...` — full suite passes (only pre-existing whisper.cpp build failure)
- [ ] Deploy to K3s and verify DAVE decryption errors are reduced/eliminated
- [ ] Verify bot can receive AND send voice audio in a session