### PR TITLE
fix(worker): fail fast when cascade engine lacks VAD/STT providers

### DIFF
--- a/cmd/glyphoxa/worker_factory.go
+++ b/cmd/glyphoxa/worker_factory.go
@@ -280,6 +280,31 @@ func (wf *workerFactory) CreateRuntime(ctx context.Context, req gw.StartSessionR
 	orch := orchestrator.New(agents, orchestrator.WithMixer(pm))
 
 	// ── 9. Audio pipeline (VAD → STT → routing) ─────────────────────────────
+	// Cascade engines require the audio pipeline (VAD → STT) to detect
+	// and transcribe player speech. Fail early with a clear error instead
+	// of silently running a dead session that receives audio but never
+	// processes it.
+	needsPipeline := false
+	for _, npc := range npcs {
+		if npc.Engine == config.EngineCascaded || npc.Engine == config.EngineSentenceCascade {
+			needsPipeline = true
+			break
+		}
+	}
+	if needsPipeline && (wf.providers.VAD == nil || wf.providers.STT == nil) {
+		for j := len(engineClosers) - 1; j >= 0; j-- {
+			_ = engineClosers[j]()
+		}
+		_ = pm.Close()
+		_ = conn.Disconnect()
+		_ = voicePlatformCloser()
+		if storeCloser != nil {
+			_ = storeCloser()
+		}
+		return nil, fmt.Errorf("worker: cascade engine requires VAD and STT providers — configure providers.vad and providers.stt in worker config (vad=%v, stt=%v)",
+			wf.providers.VAD != nil, wf.providers.STT != nil)
+	}
+
 	var pipelineCloser func() error
 	if wf.providers.VAD != nil && wf.providers.STT != nil {
 		var correctionPipeline transcript.Pipeline

--- a/deploy/helm/glyphoxa/values.yaml
+++ b/deploy/helm/glyphoxa/values.yaml
@@ -78,7 +78,7 @@ worker:
   activeDeadlineSeconds: 14400  # 4 hours
 
   # Seconds to keep completed Job pods before cleanup.
-  ttlSecondsAfterFinished: 300
+  ttlSecondsAfterFinished: 3600
 
   ports:
     grpc: 50051

--- a/deploy/zhi/workspace/templates/worker-job-template-configmap.yaml.tmpl
+++ b/deploy/zhi/workspace/templates/worker-job-template-configmap.yaml.tmpl
@@ -33,7 +33,7 @@ data:
       parallelism: 1
       completions: 1
       activeDeadlineSeconds: 14400
-      ttlSecondsAfterFinished: 300
+      ttlSecondsAfterFinished: 3600
       template:
         metadata:
           labels:


### PR DESCRIPTION
## Summary

- **Worker 0-frame bug**: The worker silently ran a dead session when VAD was not configured — received 1168 audio frames from the gateway but never processed any, because the audio pipeline (VAD → STT → routing) was only created when both `providers.VAD` and `providers.STT` were non-nil. Now `CreateRuntime` returns an error if any NPC uses a cascade/sentence_cascade engine but VAD or STT is missing, giving a clear diagnostic instead of 47s of silence followed by context cancellation.
- **Worker Job TTL**: Increased `ttlSecondsAfterFinished` from 300s (5 min) to 3600s (1 hour) in both Helm values and zhi template, so pod logs survive long enough for post-mortem debugging.

## Root Cause (Issue 2)

The production zhi deployment has `config/providers/vad/name` set to `""` — VAD was never configured. The worker started, connected to the audio bridge, received opus frames, but the pipeline guard at `worker_factory.go:284` silently skipped the entire VAD→STT→orchestrator chain. No speech was ever detected, no text was ever generated, no NPC ever responded.

**Fix**: Deploy with `providers.vad.name: silero` (or `energy`) and `providers.stt.name: deepgram` in the worker config. The code change ensures the worker fails immediately with a descriptive error if these are missing.

## Investigation Notes (Issue 1)

NPC autocomplete and `/session recap` command registration code is **correct** — no code regression found in PRs #84 or #85. The likely explanations:
- **NPC autocomplete empty**: The autocomplete handler checks `IsActive()` — since the worker dies without producing output, the session may not appear active, returning no NPC names.
- **`/session recap` "Unknown command"**: Needs further investigation in production. The handler is registered correctly via `GatewayRecapCommands`. Could be a Discord command sync issue or a deployment that didn't pick up the latest binary.

## Test plan

- [x] `go vet ./...` passes
- [x] All tests pass (except pre-existing whisper.cpp build failures on dev machine)
- [ ] Deploy with VAD configured (`silero` or `energy`) and verify worker processes audio
- [ ] Verify `/session recap` works after fresh deploy (commands re-sync on bot connect)
- [ ] Verify NPC autocomplete populates after successful session start