### PR TITLE
fix(worker): skip audio provider creation in worker mode

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -729,6 +729,11 @@ func runWorker(cfg *config.Config) int {
 	printStartupSummary(cfg, "worker")
 
 	// ── Provider registry + instantiation ─────────────────────────────────────
+	// Workers get audio through the gRPC AudioBridgeService (or create their
+	// own voice-only platform in full mode), so the top-level audio provider
+	// from config is not needed and would fail without a bot token.
+	cfg.Providers.Audio = config.ProviderEntry{}
+
 	reg := config.NewRegistry()
 	var bot *discordbot.Bot
 	registerBuiltinProviders(reg, &bot)


### PR DESCRIPTION
## Summary
- Workers get audio through the gRPC AudioBridgeService (distributed mode) or create their own voice-only platform (full mode via `worker_factory.go`), so the top-level audio provider from config is unnecessary
- Clear `cfg.Providers.Audio` before calling `buildProviders` in `runWorker` to prevent the error: `discord audio provider requires api_key (bot token)`
- Single-line fix in `cmd/glyphoxa/main.go`

## Test plan
- [x] `go vet ./cmd/glyphoxa/` passes
- [x] All tests pass (`go test -race -count=1 ./...`)
- [ ] Deploy worker with `--mode=worker` and verify it starts without the audio provider error
- [ ] Verify distributed gateway+worker sessions still work end-to-end