### PR TITLE
fix(gateway): audio pacing, transcript recording, and gRPC keepalive

### DIFF
--- a/internal/gateway/audiobridge/bridge.go
+++ b/internal/gateway/audiobridge/bridge.go
@@ -26,6 +26,17 @@ const (
 	// handshakeTimeout is how long the server waits for the worker to send
 	// its initial handshake frame before disconnecting.
 	handshakeTimeout = 10 * time.Second
+
+	// toWorkerBuffer is the channel capacity for Discord→worker frames.
+	// Discord sends at realtime pace (50 fps), so a small buffer suffices.
+	toWorkerBuffer = 128
+
+	// fromWorkerBuffer is the channel capacity for worker→Discord frames.
+	// TTS generates audio faster than realtime, so the worker sends bursts
+	// of opus frames that arrive well ahead of the 20 ms playback rate.
+	// A buffer of 1500 frames holds 30 seconds of audio, which covers long
+	// NPC monologues without dropping frames.
+	fromWorkerBuffer = 1500
 )
 
 // StreamDetachFunc is called when a worker's audio stream disconnects.
@@ -92,8 +103,8 @@ func (s *Server) Register(gs *grpc.Server) {
 func (s *Server) NewSessionBridge(sessionID string) *SessionBridge {
 	bridge := &SessionBridge{
 		sessionID:  sessionID,
-		toWorker:   make(chan *pb.AudioFrame, 128),
-		fromWorker: make(chan *pb.AudioFrame, 128),
+		toWorker:   make(chan *pb.AudioFrame, toWorkerBuffer),
+		fromWorker: make(chan *pb.AudioFrame, fromWorkerBuffer),
 		done:       make(chan struct{}),
 	}
 

--- a/internal/observe/grpc.go
+++ b/internal/observe/grpc.go
@@ -3,10 +3,12 @@ package observe
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/MrWong99/glyphoxa/internal/config"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -14,11 +16,29 @@ import (
 // for automatic trace propagation and RPC duration metrics. Append these to
 // any other server options (e.g. TLS credentials) when creating a
 // [grpc.Server].
+//
+// Keepalive parameters are configured to keep long-lived bidirectional streams
+// (e.g. AudioBridgeService.StreamAudio) alive across infrastructure boundaries
+// (load balancers, K8s service proxies, NAT devices) that may terminate idle
+// HTTP/2 connections.
 func GRPCServerOptions() []grpc.ServerOption {
 	return []grpc.ServerOption{
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.ChainUnaryInterceptor(TenantUnaryServerInterceptor()),
 		grpc.ChainStreamInterceptor(TenantStreamServerInterceptor()),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			// Send pings every 30s when there is no activity on the stream.
+			Time: 30 * time.Second,
+			// Wait 10s for a ping ack before considering the connection dead.
+			Timeout: 10 * time.Second,
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			// Allow clients to send pings as often as every 10s.
+			MinTime: 10 * time.Second,
+			// Allow pings even when there are no active streams, so the
+			// transport stays alive between session starts.
+			PermitWithoutStream: true,
+		}),
 	}
 }
 
@@ -26,9 +46,21 @@ func GRPCServerOptions() []grpc.ServerOption {
 // for automatic trace propagation and RPC duration metrics on the client
 // side. Append these to any other dial options (e.g. TLS credentials)
 // when creating a [grpc.ClientConn].
+//
+// Client-side keepalive pings keep long-lived streams alive across
+// infrastructure that may terminate idle HTTP/2 connections.
 func GRPCDialOptions() []grpc.DialOption {
 	return []grpc.DialOption{
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			// Send pings every 30s when there is no activity.
+			Time: 30 * time.Second,
+			// Wait 10s for a ping ack before considering the connection dead.
+			Timeout: 10 * time.Second,
+			// Send pings even when there are no active RPCs, so the
+			// transport stays alive between sessions.
+			PermitWithoutStream: true,
+		}),
 	}
 }
 

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -24,12 +24,13 @@ import (
 type Runtime struct {
 	mu sync.Mutex
 
-	sessionID string
-	agents    []agent.NPCAgent
-	engines   []engine.VoiceEngine
-	orch      *orchestrator.Orchestrator
-	mixer     audio.Mixer
-	conn      audio.Connection
+	sessionID    string
+	agents       []agent.NPCAgent
+	engines      []engine.VoiceEngine
+	orch         *orchestrator.Orchestrator
+	mixer        audio.Mixer
+	conn         audio.Connection
+	sessionStore memory.SessionStore
 
 	// closers are called in reverse order during Stop.
 	closers []func() error
@@ -57,12 +58,13 @@ type RuntimeConfig struct {
 // NewRuntime creates a Runtime. Call Start to begin processing, Stop to tear down.
 func NewRuntime(cfg RuntimeConfig) *Runtime {
 	return &Runtime{
-		sessionID: cfg.SessionID,
-		agents:    cfg.Agents,
-		engines:   cfg.Engines,
-		orch:      cfg.Orchestrator,
-		mixer:     cfg.Mixer,
-		conn:      cfg.Connection,
+		sessionID:    cfg.SessionID,
+		agents:       cfg.Agents,
+		engines:      cfg.Engines,
+		orch:         cfg.Orchestrator,
+		mixer:        cfg.Mixer,
+		conn:         cfg.Connection,
+		sessionStore: cfg.SessionStore,
 	}
 }
 
@@ -86,6 +88,13 @@ func (rt *Runtime) Start(ctx context.Context, sessionStore memory.SessionStore) 
 	sessionCtx, cancel := context.WithCancel(ctx)
 	rt.cancel = cancel
 	rt.running = true
+
+	// Fall back to the Runtime's own session store when the caller does not
+	// pass one explicitly. This covers worker mode where the factory sets
+	// SessionStore on RuntimeConfig but WorkerHandler calls Start(ctx, nil).
+	if sessionStore == nil {
+		sessionStore = rt.sessionStore
+	}
 
 	// Start transcript recorders for each NPC agent.
 	if sessionStore != nil {


### PR DESCRIPTION
## Summary

Three fixes for gateway/worker distributed mode:

- **Audio buffer overflow**: The `fromWorker` channel in `SessionBridge` was only 128 frames (2.56s). When TTS generates audio faster than realtime, the buffer overflows and frames are silently dropped — causing choppy/truncated NPC audio. Increased to 1500 frames (30s) so burst TTS output is fully buffered until disgo's 20ms ticker drains it at playback rate.

- **Empty transcript**: `WorkerHandler.StartSession()` passed `nil` as the sessionStore to `Runtime.Start()`, so `recordTranscripts` goroutines never started in worker mode. The `RuntimeConfig` already had the sessionStore, but `NewRuntime` didn't store it. Now the Runtime stores its sessionStore and falls back to it when `Start()` receives nil.

- **gRPC stream dying after ~90s**: Long-lived bidirectional audio streams had no HTTP/2 keepalive pings configured, so infrastructure (K8s service proxy, NAT, load balancers) killed idle connections after their default timeout (~90s). Added keepalive params (30s ping interval, 10s timeout) to both `GRPCServerOptions()` and `GRPCDialOptions()`.

## Test plan

- [ ] Verify `internal/gateway/audiobridge` tests pass
- [ ] Verify `internal/session` tests pass
- [ ] Verify `internal/observe` tests pass
- [ ] Deploy to K3s and test voice session — NPC audio should play completely without choppiness
- [ ] Check session recap — transcript entries should appear
- [ ] Session should survive beyond 90s without stream disconnection