### PR TITLE
fix(gateway): audio buffer flush for barge-in and mute

### DIFF
--- a/gen/glyphoxa/v1/session.pb.go
+++ b/gen/glyphoxa/v1/session.pb.go
@@ -1391,7 +1391,11 @@ type AudioFrame struct {
 	UserId string `protobuf:"bytes,4,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
 	// is_silence marks a silence frame (used to signal Discord to start
 	// routing audio to the bot at connection startup).
-	IsSilence     bool `protobuf:"varint,5,opt,name=is_silence,json=isSilence,proto3" json:"is_silence,omitempty"`
+	IsSilence bool `protobuf:"varint,5,opt,name=is_silence,json=isSilence,proto3" json:"is_silence,omitempty"`
+	// flush signals the gateway to discard all buffered audio for this session.
+	// Sent by the worker when barge-in or mute interrupts playback, so the
+	// gateway does not continue playing stale pre-buffered frames.
+	Flush         bool `protobuf:"varint,6,opt,name=flush,proto3" json:"flush,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1457,6 +1461,13 @@ func (x *AudioFrame) GetUserId() string {
 func (x *AudioFrame) GetIsSilence() bool {
 	if x != nil {
 		return x.IsSilence
+	}
+	return false
+}
+
+func (x *AudioFrame) GetFlush() bool {
+	if x != nil {
+		return x.Flush
 	}
 	return false
 }
@@ -1558,7 +1569,7 @@ const file_glyphoxa_v1_session_proto_rawDesc = "" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x19\n" +
 	"\bnpc_name\x18\x02 \x01(\tR\anpcName\x12\x12\n" +
 	"\x04text\x18\x03 \x01(\tR\x04text\"\x12\n" +
-	"\x10SpeakNPCResponse\"\x94\x01\n" +
+	"\x10SpeakNPCResponse\"\xaa\x01\n" +
 	"\n" +
 	"AudioFrame\x12\x1d\n" +
 	"\n" +
@@ -1567,7 +1578,8 @@ const file_glyphoxa_v1_session_proto_rawDesc = "" +
 	"\x04ssrc\x18\x03 \x01(\rR\x04ssrc\x12\x17\n" +
 	"\auser_id\x18\x04 \x01(\tR\x06userId\x12\x1d\n" +
 	"\n" +
-	"is_silence\x18\x05 \x01(\bR\tisSilence*{\n" +
+	"is_silence\x18\x05 \x01(\bR\tisSilence\x12\x14\n" +
+	"\x05flush\x18\x06 \x01(\bR\x05flush*{\n" +
 	"\fSessionState\x12\x1d\n" +
 	"\x19SESSION_STATE_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15SESSION_STATE_PENDING\x10\x01\x12\x18\n" +

--- a/internal/app/audio_pipeline.go
+++ b/internal/app/audio_pipeline.go
@@ -208,6 +208,12 @@ func (p *audioPipeline) processParticipant(ctx context.Context, speakerID string
 					// and fire the OnBargeIn callback.
 					p.mixer.BargeIn(speakerID)
 
+					// Flush any pre-buffered audio in the connection so the
+					// gateway stops playing stale NPC audio immediately.
+					if f, ok := p.conn.(audio.Flusher); ok {
+						f.Flush()
+					}
+
 					// Snapshot STT config under lock — UpdateKeywords may be
 					// writing p.sttCfg.Keywords concurrently.
 					p.mu.Lock()

--- a/internal/gateway/audiobridge/bridge.go
+++ b/internal/gateway/audiobridge/bridge.go
@@ -221,6 +221,21 @@ func (s *Server) StreamAudio(stream grpc.BidiStreamingServer[pb.AudioFrame, pb.A
 				errCh <- err
 				return
 			}
+
+			// Flush signal: the worker interrupted playback (barge-in
+			// or mute). Drain any buffered frames so the gateway does
+			// not continue playing stale audio.
+			if frame.GetFlush() {
+				drained := bridge.Flush()
+				if drained > 0 {
+					slog.Info("audiobridge: flushed buffered audio",
+						"session_id", sessionID,
+						"drained_frames", drained,
+					)
+				}
+				continue
+			}
+
 			select {
 			case bridge.fromWorker <- frame:
 			case <-bridge.done:
@@ -274,6 +289,22 @@ func (b *SessionBridge) ReceiveFromWorker() <-chan *pb.AudioFrame {
 // Done returns a channel that is closed when the bridge is torn down.
 func (b *SessionBridge) Done() <-chan struct{} {
 	return b.done
+}
+
+// Flush drains all buffered frames from the fromWorker channel and returns
+// the number of frames discarded. This is called when the worker signals
+// that playback was interrupted (barge-in or mute), so the gateway stops
+// playing stale pre-buffered audio immediately.
+func (b *SessionBridge) Flush() int {
+	drained := 0
+	for {
+		select {
+		case <-b.fromWorker:
+			drained++
+		default:
+			return drained
+		}
+	}
 }
 
 // Close tears down the bridge. Safe to call multiple times.

--- a/internal/gateway/audiobridge/bridge_test.go
+++ b/internal/gateway/audiobridge/bridge_test.go
@@ -419,6 +419,150 @@ func TestStreamAudio_SendGoroutineExitsOnStreamEnd(t *testing.T) {
 	bridge.Close()
 }
 
+// ---------------------------------------------------------------------------
+// Tests: flush
+// ---------------------------------------------------------------------------
+
+func TestSessionBridge_Flush_DrainsBufferedFrames(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer()
+	bridge := srv.NewSessionBridge("sess-flush")
+	defer bridge.Close()
+
+	// Pre-fill the fromWorker buffer with 10 frames.
+	for i := range 10 {
+		bridge.fromWorker <- &pb.AudioFrame{
+			SessionId: "sess-flush",
+			OpusData:  []byte{byte(i)},
+		}
+	}
+
+	// Flush should drain all buffered frames.
+	drained := bridge.Flush()
+	if drained != 10 {
+		t.Errorf("Flush drained %d frames, want 10", drained)
+	}
+
+	// Channel should be empty now.
+	select {
+	case <-bridge.ReceiveFromWorker():
+		t.Fatal("channel should be empty after Flush")
+	default:
+		// OK — channel is empty.
+	}
+}
+
+func TestSessionBridge_Flush_EmptyChannel(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer()
+	bridge := srv.NewSessionBridge("sess-flush-empty")
+	defer bridge.Close()
+
+	// Flushing an empty channel should return 0 immediately.
+	drained := bridge.Flush()
+	if drained != 0 {
+		t.Errorf("Flush drained %d frames from empty channel, want 0", drained)
+	}
+}
+
+func TestStreamAudio_FlushFrame_DrainsBuffer(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer()
+	bridge := srv.NewSessionBridge("sess-flush-stream")
+	defer srv.RemoveBridge("sess-flush-stream")
+
+	ms := newMockServerStream()
+
+	// Handshake.
+	ms.recvCh <- &pb.AudioFrame{SessionId: "sess-flush-stream"}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.StreamAudio(ms)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Pre-fill some audio frames in the fromWorker buffer.
+	for i := range 5 {
+		bridge.fromWorker <- &pb.AudioFrame{
+			SessionId: "sess-flush-stream",
+			OpusData:  []byte{byte(i)},
+		}
+	}
+
+	// Send a flush frame from the worker.
+	ms.recvCh <- &pb.AudioFrame{
+		SessionId: "sess-flush-stream",
+		Flush:     true,
+	}
+
+	// Give time for flush processing.
+	time.Sleep(50 * time.Millisecond)
+
+	// The fromWorker channel should be empty now — flush drained it.
+	select {
+	case <-bridge.ReceiveFromWorker():
+		t.Fatal("fromWorker should be empty after flush frame")
+	default:
+		// OK — drained.
+	}
+
+	ms.cancel()
+	<-errCh
+}
+
+func TestStreamAudio_FlushFrame_NotForwarded(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer()
+	bridge := srv.NewSessionBridge("sess-flush-nofwd")
+	defer srv.RemoveBridge("sess-flush-nofwd")
+
+	ms := newMockServerStream()
+
+	// Handshake.
+	ms.recvCh <- &pb.AudioFrame{SessionId: "sess-flush-nofwd"}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.StreamAudio(ms)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Send a flush frame — should NOT be forwarded to fromWorker.
+	ms.recvCh <- &pb.AudioFrame{
+		SessionId: "sess-flush-nofwd",
+		Flush:     true,
+	}
+
+	// Send a real audio frame after the flush.
+	ms.recvCh <- &pb.AudioFrame{
+		SessionId: "sess-flush-nofwd",
+		OpusData:  []byte{42},
+	}
+
+	// The only frame on fromWorker should be the audio frame, not the flush.
+	select {
+	case frame := <-bridge.ReceiveFromWorker():
+		if frame.GetFlush() {
+			t.Fatal("flush frame should not be forwarded to fromWorker")
+		}
+		if frame.GetOpusData()[0] != 42 {
+			t.Errorf("expected audio frame data 42, got %d", frame.GetOpusData()[0])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for audio frame after flush")
+	}
+
+	ms.cancel()
+	<-errCh
+}
+
 func TestStreamAudio_BridgeCloseEndsStream(t *testing.T) {
 	t.Parallel()
 

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -167,6 +167,16 @@ func (rt *Runtime) Agents() []agent.NPCAgent {
 	return rt.agents
 }
 
+// Flush discards any buffered outgoing audio in the connection. This is
+// called after mute or interrupt operations so the gateway stops playing
+// stale pre-buffered NPC audio immediately. No-op if the connection does
+// not implement [audio.Flusher].
+func (rt *Runtime) Flush() {
+	if f, ok := rt.conn.(audio.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // recordTranscripts drains an agent's transcript channel and writes entries
 // to the session store. On context cancellation it drains remaining buffered
 // entries before returning.

--- a/internal/session/worker_handler.go
+++ b/internal/session/worker_handler.go
@@ -187,16 +187,24 @@ func (h *WorkerHandler) ListNPCs(_ context.Context, sessionID string) ([]gateway
 
 // MuteNPC mutes a named NPC in a running session.
 func (h *WorkerHandler) MuteNPC(_ context.Context, sessionID, npcName string) error {
-	orch, err := h.sessionOrch(sessionID)
+	ms, err := h.managedSession(sessionID)
 	if err != nil {
 		return err
+	}
+	orch := ms.runtime.Orchestrator()
+	if orch == nil {
+		return fmt.Errorf("session: %q has no orchestrator", sessionID)
 	}
 
 	a := orch.AgentByName(npcName)
 	if a == nil {
 		return fmt.Errorf("session: npc %q not found in session %q", npcName, sessionID)
 	}
-	return orch.MuteAgent(a.ID())
+	if err := orch.MuteAgent(a.ID()); err != nil {
+		return err
+	}
+	ms.runtime.Flush()
+	return nil
 }
 
 // UnmuteNPC unmutes a named NPC in a running session.
@@ -215,11 +223,17 @@ func (h *WorkerHandler) UnmuteNPC(_ context.Context, sessionID, npcName string) 
 
 // MuteAllNPCs mutes all NPCs in a running session and returns the count.
 func (h *WorkerHandler) MuteAllNPCs(_ context.Context, sessionID string) (int, error) {
-	orch, err := h.sessionOrch(sessionID)
+	ms, err := h.managedSession(sessionID)
 	if err != nil {
 		return 0, err
 	}
-	return orch.MuteAll(), nil
+	orch := ms.runtime.Orchestrator()
+	if orch == nil {
+		return 0, fmt.Errorf("session: %q has no orchestrator", sessionID)
+	}
+	count := orch.MuteAll()
+	ms.runtime.Flush()
+	return count, nil
 }
 
 // UnmuteAllNPCs unmutes all NPCs in a running session and returns the count.
@@ -245,14 +259,23 @@ func (h *WorkerHandler) SpeakNPC(ctx context.Context, sessionID, npcName, text s
 	return a.SpeakText(ctx, text)
 }
 
-// sessionOrch returns the orchestrator for a running session.
-func (h *WorkerHandler) sessionOrch(sessionID string) (*orchestrator.Orchestrator, error) {
+// managedSession returns the managedSession for a running session.
+func (h *WorkerHandler) managedSession(sessionID string) (*managedSession, error) {
 	h.mu.Lock()
 	ms, ok := h.sessions[sessionID]
 	h.mu.Unlock()
 
 	if !ok {
 		return nil, fmt.Errorf("session: %q not found", sessionID)
+	}
+	return ms, nil
+}
+
+// sessionOrch returns the orchestrator for a running session.
+func (h *WorkerHandler) sessionOrch(sessionID string) (*orchestrator.Orchestrator, error) {
+	ms, err := h.managedSession(sessionID)
+	if err != nil {
+		return nil, err
 	}
 
 	orch := ms.runtime.Orchestrator()

--- a/pkg/audio/grpcbridge/connection.go
+++ b/pkg/audio/grpcbridge/connection.go
@@ -21,8 +21,11 @@ import (
 	"github.com/MrWong99/glyphoxa/pkg/audio"
 )
 
-// Compile-time interface assertion.
-var _ audio.Connection = (*Connection)(nil)
+// Compile-time interface assertions.
+var (
+	_ audio.Connection = (*Connection)(nil)
+	_ audio.Flusher    = (*Connection)(nil)
+)
 
 const (
 	inputChannelBuffer  = 64
@@ -66,6 +69,10 @@ type Connection struct {
 	changeCb func(audio.Event)
 	changeMu sync.Mutex
 
+	// flushCh signals sendLoop to clear its partial buffer and send a flush
+	// frame. Buffered so Flush() never blocks.
+	flushCh chan struct{}
+
 	recvFrames uint64
 	sendFrames uint64
 
@@ -92,6 +99,7 @@ func New(sessionID string, stream grpc.BidiStreamingClient[pb.AudioFrame, pb.Aud
 		output:    make(chan audio.AudioFrame, outputChannelBuffer),
 		encoder:   enc,
 		conv:      audio.FormatConverter{Target: audio.Format{SampleRate: opusSampleRate, Channels: opusChannels}},
+		flushCh:   make(chan struct{}, 1),
 		done:      make(chan struct{}),
 	}
 
@@ -207,6 +215,19 @@ func (c *Connection) sendLoop() {
 		select {
 		case <-c.done:
 			return
+
+		case <-c.flushCh:
+			// Barge-in or mute: discard partial opus buffer and tell the
+			// gateway to flush its own buffer. This runs on the sendLoop
+			// goroutine so there is no data race with buf access.
+			c.buf = c.buf[:0]
+			if err := c.stream.Send(&pb.AudioFrame{
+				SessionId: c.sessionID,
+				Flush:     true,
+			}); err != nil {
+				slog.Debug("grpcbridge: flush send failed", "session_id", c.sessionID, "err", err)
+			}
+
 		case frame, ok := <-c.output:
 			if !ok {
 				return
@@ -280,6 +301,41 @@ func (c *Connection) OnParticipantChange(cb func(audio.Event)) {
 	c.changeMu.Lock()
 	defer c.changeMu.Unlock()
 	c.changeCb = cb
+}
+
+// Flush drains any unsent frames from the local output channel and signals
+// sendLoop to clear its partial opus buffer and send a flush control frame
+// to the gateway. This ensures that after a barge-in or mute, stale NPC
+// audio stops playing immediately on both the worker and gateway sides.
+//
+// Safe for concurrent use — the output channel drain is lock-free, and
+// sendLoop handles buf clearing and the gRPC send to avoid data races.
+func (c *Connection) Flush() {
+	// Drain local output channel so sendLoop doesn't transmit stale frames.
+	// Channel receives are safe from multiple goroutines.
+	drained := 0
+	for {
+		select {
+		case <-c.output:
+			drained++
+		default:
+			goto drainDone
+		}
+	}
+drainDone:
+	if drained > 0 {
+		slog.Info("grpcbridge: flushed local output buffer",
+			"session_id", c.sessionID,
+			"drained_frames", drained,
+		)
+	}
+
+	// Signal sendLoop to clear its partial buf and send a flush frame.
+	select {
+	case c.flushCh <- struct{}{}:
+	default:
+		// Already signalled.
+	}
 }
 
 // Disconnect cleanly tears down the gRPC stream. Input channels are closed by

--- a/pkg/audio/types.go
+++ b/pkg/audio/types.go
@@ -2,6 +2,15 @@ package audio
 
 import "time"
 
+// Flusher is an optional interface that [Connection] implementations may
+// support. When called, it discards any buffered outgoing audio and signals
+// the remote end (e.g., the gateway) to do the same. This ensures that
+// after a barge-in or mute, stale pre-buffered NPC audio stops immediately
+// instead of continuing to play.
+type Flusher interface {
+	Flush()
+}
+
 // AudioFrame represents a single frame of audio data flowing through the pipeline.
 // Frames are the atomic unit of audio transport — captured from input streams,
 // processed by VAD, encoded/decoded by codecs, and played through output streams.

--- a/proto/glyphoxa/v1/session.proto
+++ b/proto/glyphoxa/v1/session.proto
@@ -180,6 +180,11 @@ message AudioFrame {
   // is_silence marks a silence frame (used to signal Discord to start
   // routing audio to the bot at connection startup).
   bool is_silence = 5;
+
+  // flush signals the gateway to discard all buffered audio for this session.
+  // Sent by the worker when barge-in or mute interrupts playback, so the
+  // gateway does not continue playing stale pre-buffered frames.
+  bool flush = 6;
 }
 
 // SessionWorkerService is the gRPC service exposed by workers, called by the gateway.


### PR DESCRIPTION
## Summary
- Add in-band flush signal through gRPC audio stream for instant barge-in/mute
- Worker sends `flush=true` AudioFrame after any interrupt (barge-in detection or mute command)
- Gateway drains its 1500-frame `fromWorker` buffer on flush receipt
- Eliminates ~30s of stale TTS audio playing after interrupt

## Test plan
- [x] Tests pass with `-race`
- [ ] Verify barge-in stops NPC audio within ~100ms
- [ ] Verify `/npc muteall` stops audio immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)