### PR TITLE
fix(session): track session lifecycle and populate transcript metadata

### DIFF
--- a/internal/agent/npc.go
+++ b/internal/agent/npc.go
@@ -274,10 +274,12 @@ func (a *liveAgent) HandleUtterance(ctx context.Context, speaker string, transcr
 	}
 
 	promptCtx := engine.PromptContext{
-		SystemPrompt: systemPrompt,
-		HotContext:   hotContextStr,
-		Messages:     msgs,
-		BudgetTier:   a.budgetTier,
+		SystemPrompt:      systemPrompt,
+		HotContext:        hotContextStr,
+		Messages:          msgs,
+		BudgetTier:        a.budgetTier,
+		UtteranceRawText:  transcript.RawText,
+		UtteranceDuration: transcript.Duration,
 	}
 
 	// 4. Create a synthetic audio frame (cascaded mode: STT already ran).

--- a/internal/app/audio_pipeline.go
+++ b/internal/app/audio_pipeline.go
@@ -303,6 +303,7 @@ func (p *audioPipeline) collectAndRoute(ctx context.Context, speakerID string, s
 							"corrected", corrected.Corrected,
 							"corrections", len(corrected.Corrections),
 						)
+						t.RawText = t.Text
 						t.Text = corrected.Corrected
 					}
 				}

--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -134,11 +134,9 @@ func (sm *SessionManager) Start(ctx context.Context, channelID string, dmUserID 
 		now.Format("20060102T1504Z"),
 	)
 
-	// Record session in sessions metadata table if Postgres-backed.
-	if starter, ok := sm.sessionStore.(interface {
-		StartSession(ctx context.Context, sessionID string) error
-	}); ok {
-		if err := starter.StartSession(ctx, sessionID); err != nil {
+	// Record session in sessions metadata table.
+	if sm.sessionStore != nil {
+		if err := sm.sessionStore.StartSession(ctx, sessionID); err != nil {
 			slog.Warn("session: failed to record session start", "session_id", sessionID, "err", err)
 		}
 	}
@@ -330,10 +328,8 @@ func (sm *SessionManager) Stop(ctx context.Context) error {
 	}
 
 	// Record session end in sessions metadata table.
-	if ender, ok := sm.sessionStore.(interface {
-		EndSession(ctx context.Context, sessionID string) error
-	}); ok {
-		if err := ender.EndSession(ctx, sessionID); err != nil {
+	if sm.sessionStore != nil {
+		if err := sm.sessionStore.EndSession(ctx, sessionID); err != nil {
 			slog.Warn("session: failed to record session end", "session_id", sessionID, "err", err)
 		}
 	}

--- a/internal/engine/cascade/cascade.go
+++ b/internal/engine/cascade/cascade.go
@@ -266,6 +266,8 @@ func (e *Engine) Process(ctx context.Context, _ audio.AudioFrame, prompt engine.
 					SpeakerID:   playerMsg.Name,
 					SpeakerName: playerMsg.Name,
 					Text:        playerMsg.Content,
+					RawText:     prompt.UtteranceRawText,
+					Duration:    prompt.UtteranceDuration,
 					Timestamp:   time.Now(),
 				})
 			}
@@ -371,6 +373,8 @@ func (e *Engine) Process(ctx context.Context, _ audio.AudioFrame, prompt engine.
 				SpeakerID:   playerMsg.Name,
 				SpeakerName: playerMsg.Name,
 				Text:        playerMsg.Content,
+				RawText:     prompt.UtteranceRawText,
+				Duration:    prompt.UtteranceDuration,
 				Timestamp:   time.Now(),
 			})
 		}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -20,6 +20,7 @@ package engine
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	"github.com/MrWong99/glyphoxa/internal/mcp"
 	"github.com/MrWong99/glyphoxa/pkg/audio"
@@ -51,6 +52,16 @@ type PromptContext struct {
 	// BudgetTier controls which tools are offered to the LLM based on latency
 	// constraints. See [mcp.BudgetTier] for tier definitions.
 	BudgetTier mcp.BudgetTier
+
+	// UtteranceRawText is the original uncorrected STT output for the current
+	// player utterance. Empty when no transcript correction was applied.
+	// Used by the engine to populate TranscriptEntry.RawText.
+	UtteranceRawText string
+
+	// UtteranceDuration is the length of the current player utterance as
+	// reported by the STT provider. Zero if unavailable.
+	// Used by the engine to populate TranscriptEntry.Duration.
+	UtteranceDuration time.Duration
 }
 
 // ContextUpdate carries a mid-session context refresh pushed via

--- a/internal/session/memory_guard.go
+++ b/internal/session/memory_guard.go
@@ -107,6 +107,34 @@ func (mg *MemoryGuard) ListSessions(ctx context.Context, limit int) ([]memory.Se
 	return sessions, nil
 }
 
+// StartSession delegates to the underlying store. On failure the error is
+// logged and swallowed; the store is marked as degraded.
+func (mg *MemoryGuard) StartSession(ctx context.Context, sessionID string) error {
+	err := mg.store.StartSession(ctx, sessionID)
+	if err != nil {
+		mg.degraded.Store(true)
+		slog.Warn("memory guard: StartSession failed, swallowing error",
+			"session_id", sessionID, "error", err)
+		return nil
+	}
+	mg.degraded.Store(false)
+	return nil
+}
+
+// EndSession delegates to the underlying store. On failure the error is
+// logged and swallowed; the store is marked as degraded.
+func (mg *MemoryGuard) EndSession(ctx context.Context, sessionID string) error {
+	err := mg.store.EndSession(ctx, sessionID)
+	if err != nil {
+		mg.degraded.Store(true)
+		slog.Warn("memory guard: EndSession failed, swallowing error",
+			"session_id", sessionID, "error", err)
+		return nil
+	}
+	mg.degraded.Store(false)
+	return nil
+}
+
 // IsDegraded reports whether the store is currently operating in degraded
 // mode (i.e., the most recent operation on the underlying store failed).
 func (mg *MemoryGuard) IsDegraded() bool {

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -96,6 +96,18 @@ func (rt *Runtime) Start(ctx context.Context, sessionStore memory.SessionStore) 
 		sessionStore = rt.sessionStore
 	}
 
+	// Record the session store for use during Stop.
+	rt.sessionStore = sessionStore
+
+	// Register the session in the sessions metadata table so we can track
+	// start/end times.
+	if sessionStore != nil {
+		if err := sessionStore.StartSession(ctx, rt.sessionID); err != nil {
+			slog.Warn("session: failed to record session start",
+				"session_id", rt.sessionID, "err", err)
+		}
+	}
+
 	// Start transcript recorders for each NPC agent.
 	if sessionStore != nil {
 		for _, ag := range rt.agents {
@@ -138,6 +150,14 @@ func (rt *Runtime) Stop(ctx context.Context) error {
 
 	// Wait for transcript recorders to finish draining.
 	rt.recorderWG.Wait()
+
+	// Record the session end in the sessions metadata table.
+	if rt.sessionStore != nil {
+		if err := rt.sessionStore.EndSession(ctx, rt.sessionID); err != nil {
+			slog.Warn("session: failed to record session end",
+				"session_id", rt.sessionID, "err", err)
+		}
+	}
 
 	// Disconnect audio.
 	if rt.conn != nil {

--- a/pkg/memory/mock/mock.go
+++ b/pkg/memory/mock/mock.go
@@ -74,6 +74,12 @@ type SessionStore struct {
 
 	// ListSessionsErr is returned by [SessionStore.ListSessions] when non-nil.
 	ListSessionsErr error
+
+	// StartSessionErr is returned by [SessionStore.StartSession] when non-nil.
+	StartSessionErr error
+
+	// EndSessionErr is returned by [SessionStore.EndSession] when non-nil.
+	EndSessionErr error
 }
 
 // Calls returns a copy of all recorded method invocations.
@@ -158,6 +164,22 @@ func (m *SessionStore) ListSessions(_ context.Context, limit int) ([]memory.Sess
 	out := make([]memory.SessionInfo, len(m.ListSessionsResult))
 	copy(out, m.ListSessionsResult)
 	return out, m.ListSessionsErr
+}
+
+// StartSession implements [memory.SessionStore].
+func (m *SessionStore) StartSession(_ context.Context, sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, Call{Method: "StartSession", Args: []any{sessionID}})
+	return m.StartSessionErr
+}
+
+// EndSession implements [memory.SessionStore].
+func (m *SessionStore) EndSession(_ context.Context, sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, Call{Method: "EndSession", Args: []any{sessionID}})
+	return m.EndSessionErr
 }
 
 // Ensure SessionStore satisfies the interface at compile time.

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -350,6 +350,14 @@ type SessionStore interface {
 	// limit caps the number of results (0 = implementation default).
 	// Returns an empty (non-nil) slice when no sessions exist.
 	ListSessions(ctx context.Context, limit int) ([]SessionInfo, error)
+
+	// StartSession records a new session in the sessions metadata table.
+	// Implementations should use ON CONFLICT DO NOTHING to tolerate duplicate
+	// calls for the same sessionID.
+	StartSession(ctx context.Context, sessionID string) error
+
+	// EndSession sets the ended_at timestamp for a session.
+	EndSession(ctx context.Context, sessionID string) error
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/pkg/provider/stt/types.go
+++ b/pkg/provider/stt/types.go
@@ -19,6 +19,11 @@ type Transcript struct {
 	// May be nil for providers that don't support word-level output.
 	Words []WordDetail
 
+	// RawText preserves the original uncorrected STT output when transcript
+	// correction is applied. Set by the audio pipeline before correction
+	// overwrites Text. Empty when no correction was applied.
+	RawText string
+
 	// SpeakerID identifies the speaker when speaker diarization is active.
 	SpeakerID string
 


### PR DESCRIPTION
## Summary
- **Sessions table empty**: `Runtime.Start()`/`Stop()` now call `StartSession()`/`EndSession()` on the session store, populating `tenant_luk.sessions` with start/end timestamps in distributed (gateway/worker) mode.
- **`raw_text` not populated**: Added `stt.Transcript.RawText` field. The audio pipeline preserves the original STT output before transcript correction overwrites `Text`. This flows through `PromptContext.UtteranceRawText` to the cascade engine's transcript entry emission.
- **`duration_ns` not populated**: The STT provider's `Duration` field is now threaded through `PromptContext.UtteranceDuration` to the cascade engine, which populates `TranscriptEntry.Duration` for player utterances.

### Interface change
`memory.SessionStore` now requires `StartSession(ctx, sessionID)` and `EndSession(ctx, sessionID)`. Updated: Postgres impl (already had them), mock, and MemoryGuard. The `session_manager.go` type assertions are simplified since the methods are now part of the interface.

## Test plan
- [x] `go vet ./...` passes
- [x] All compilable test packages pass (`make test` — whisper/elevenlabs build failures are pre-existing)
- [x] `internal/session`, `internal/agent`, `internal/engine/cascade`, `internal/app` tests pass
- [ ] Deploy to K3s and verify `tenant_luk.sessions` gets rows on session start/stop
- [ ] Verify `raw_text` populated when transcript correction fires
- [ ] Verify `duration_ns` populated for player utterances (depends on STT provider reporting duration)