### PR TITLE
feat(stt): add WebSocket connection pool for ElevenLabs STT

### DIFF
--- a/internal/agent/npc.go
+++ b/internal/agent/npc.go
@@ -274,10 +274,12 @@ func (a *liveAgent) HandleUtterance(ctx context.Context, speaker string, transcr
 	}
 
 	promptCtx := engine.PromptContext{
-		SystemPrompt: systemPrompt,
-		HotContext:   hotContextStr,
-		Messages:     msgs,
-		BudgetTier:   a.budgetTier,
+		SystemPrompt:      systemPrompt,
+		HotContext:        hotContextStr,
+		Messages:          msgs,
+		BudgetTier:        a.budgetTier,
+		UtteranceRawText:  transcript.RawText,
+		UtteranceDuration: transcript.Duration,
 	}
 
 	// 4. Create a synthetic audio frame (cascaded mode: STT already ran).

--- a/internal/app/audio_pipeline.go
+++ b/internal/app/audio_pipeline.go
@@ -303,6 +303,7 @@ func (p *audioPipeline) collectAndRoute(ctx context.Context, speakerID string, s
 							"corrected", corrected.Corrected,
 							"corrections", len(corrected.Corrections),
 						)
+						t.RawText = t.Text
 						t.Text = corrected.Corrected
 					}
 				}

--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -134,11 +134,9 @@ func (sm *SessionManager) Start(ctx context.Context, channelID string, dmUserID 
 		now.Format("20060102T1504Z"),
 	)
 
-	// Record session in sessions metadata table if Postgres-backed.
-	if starter, ok := sm.sessionStore.(interface {
-		StartSession(ctx context.Context, sessionID string) error
-	}); ok {
-		if err := starter.StartSession(ctx, sessionID); err != nil {
+	// Record session in sessions metadata table.
+	if sm.sessionStore != nil {
+		if err := sm.sessionStore.StartSession(ctx, sessionID); err != nil {
 			slog.Warn("session: failed to record session start", "session_id", sessionID, "err", err)
 		}
 	}
@@ -330,10 +328,8 @@ func (sm *SessionManager) Stop(ctx context.Context) error {
 	}
 
 	// Record session end in sessions metadata table.
-	if ender, ok := sm.sessionStore.(interface {
-		EndSession(ctx context.Context, sessionID string) error
-	}); ok {
-		if err := ender.EndSession(ctx, sessionID); err != nil {
+	if sm.sessionStore != nil {
+		if err := sm.sessionStore.EndSession(ctx, sessionID); err != nil {
 			slog.Warn("session: failed to record session end", "session_id", sessionID, "err", err)
 		}
 	}

--- a/internal/engine/cascade/cascade.go
+++ b/internal/engine/cascade/cascade.go
@@ -266,6 +266,8 @@ func (e *Engine) Process(ctx context.Context, _ audio.AudioFrame, prompt engine.
 					SpeakerID:   playerMsg.Name,
 					SpeakerName: playerMsg.Name,
 					Text:        playerMsg.Content,
+					RawText:     prompt.UtteranceRawText,
+					Duration:    prompt.UtteranceDuration,
 					Timestamp:   time.Now(),
 				})
 			}
@@ -371,6 +373,8 @@ func (e *Engine) Process(ctx context.Context, _ audio.AudioFrame, prompt engine.
 				SpeakerID:   playerMsg.Name,
 				SpeakerName: playerMsg.Name,
 				Text:        playerMsg.Content,
+				RawText:     prompt.UtteranceRawText,
+				Duration:    prompt.UtteranceDuration,
 				Timestamp:   time.Now(),
 			})
 		}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -20,6 +20,7 @@ package engine
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	"github.com/MrWong99/glyphoxa/internal/mcp"
 	"github.com/MrWong99/glyphoxa/pkg/audio"
@@ -51,6 +52,16 @@ type PromptContext struct {
 	// BudgetTier controls which tools are offered to the LLM based on latency
 	// constraints. See [mcp.BudgetTier] for tier definitions.
 	BudgetTier mcp.BudgetTier
+
+	// UtteranceRawText is the original uncorrected STT output for the current
+	// player utterance. Empty when no transcript correction was applied.
+	// Used by the engine to populate TranscriptEntry.RawText.
+	UtteranceRawText string
+
+	// UtteranceDuration is the length of the current player utterance as
+	// reported by the STT provider. Zero if unavailable.
+	// Used by the engine to populate TranscriptEntry.Duration.
+	UtteranceDuration time.Duration
 }
 
 // ContextUpdate carries a mid-session context refresh pushed via

--- a/internal/session/memory_guard.go
+++ b/internal/session/memory_guard.go
@@ -107,6 +107,34 @@ func (mg *MemoryGuard) ListSessions(ctx context.Context, limit int) ([]memory.Se
 	return sessions, nil
 }
 
+// StartSession delegates to the underlying store. On failure the error is
+// logged and swallowed; the store is marked as degraded.
+func (mg *MemoryGuard) StartSession(ctx context.Context, sessionID string) error {
+	err := mg.store.StartSession(ctx, sessionID)
+	if err != nil {
+		mg.degraded.Store(true)
+		slog.Warn("memory guard: StartSession failed, swallowing error",
+			"session_id", sessionID, "error", err)
+		return nil
+	}
+	mg.degraded.Store(false)
+	return nil
+}
+
+// EndSession delegates to the underlying store. On failure the error is
+// logged and swallowed; the store is marked as degraded.
+func (mg *MemoryGuard) EndSession(ctx context.Context, sessionID string) error {
+	err := mg.store.EndSession(ctx, sessionID)
+	if err != nil {
+		mg.degraded.Store(true)
+		slog.Warn("memory guard: EndSession failed, swallowing error",
+			"session_id", sessionID, "error", err)
+		return nil
+	}
+	mg.degraded.Store(false)
+	return nil
+}
+
 // IsDegraded reports whether the store is currently operating in degraded
 // mode (i.e., the most recent operation on the underlying store failed).
 func (mg *MemoryGuard) IsDegraded() bool {

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -96,6 +96,18 @@ func (rt *Runtime) Start(ctx context.Context, sessionStore memory.SessionStore) 
 		sessionStore = rt.sessionStore
 	}
 
+	// Record the session store for use during Stop.
+	rt.sessionStore = sessionStore
+
+	// Register the session in the sessions metadata table so we can track
+	// start/end times.
+	if sessionStore != nil {
+		if err := sessionStore.StartSession(ctx, rt.sessionID); err != nil {
+			slog.Warn("session: failed to record session start",
+				"session_id", rt.sessionID, "err", err)
+		}
+	}
+
 	// Start transcript recorders for each NPC agent.
 	if sessionStore != nil {
 		for _, ag := range rt.agents {
@@ -138,6 +150,14 @@ func (rt *Runtime) Stop(ctx context.Context) error {
 
 	// Wait for transcript recorders to finish draining.
 	rt.recorderWG.Wait()
+
+	// Record the session end in the sessions metadata table.
+	if rt.sessionStore != nil {
+		if err := rt.sessionStore.EndSession(ctx, rt.sessionID); err != nil {
+			slog.Warn("session: failed to record session end",
+				"session_id", rt.sessionID, "err", err)
+		}
+	}
 
 	// Disconnect audio.
 	if rt.conn != nil {

--- a/pkg/memory/mock/mock.go
+++ b/pkg/memory/mock/mock.go
@@ -74,6 +74,12 @@ type SessionStore struct {
 
 	// ListSessionsErr is returned by [SessionStore.ListSessions] when non-nil.
 	ListSessionsErr error
+
+	// StartSessionErr is returned by [SessionStore.StartSession] when non-nil.
+	StartSessionErr error
+
+	// EndSessionErr is returned by [SessionStore.EndSession] when non-nil.
+	EndSessionErr error
 }
 
 // Calls returns a copy of all recorded method invocations.
@@ -158,6 +164,22 @@ func (m *SessionStore) ListSessions(_ context.Context, limit int) ([]memory.Sess
 	out := make([]memory.SessionInfo, len(m.ListSessionsResult))
 	copy(out, m.ListSessionsResult)
 	return out, m.ListSessionsErr
+}
+
+// StartSession implements [memory.SessionStore].
+func (m *SessionStore) StartSession(_ context.Context, sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, Call{Method: "StartSession", Args: []any{sessionID}})
+	return m.StartSessionErr
+}
+
+// EndSession implements [memory.SessionStore].
+func (m *SessionStore) EndSession(_ context.Context, sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, Call{Method: "EndSession", Args: []any{sessionID}})
+	return m.EndSessionErr
 }
 
 // Ensure SessionStore satisfies the interface at compile time.

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -350,6 +350,14 @@ type SessionStore interface {
 	// limit caps the number of results (0 = implementation default).
 	// Returns an empty (non-nil) slice when no sessions exist.
 	ListSessions(ctx context.Context, limit int) ([]SessionInfo, error)
+
+	// StartSession records a new session in the sessions metadata table.
+	// Implementations should use ON CONFLICT DO NOTHING to tolerate duplicate
+	// calls for the same sessionID.
+	StartSession(ctx context.Context, sessionID string) error
+
+	// EndSession sets the ended_at timestamp for a session.
+	EndSession(ctx context.Context, sessionID string) error
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/pkg/provider/stt/elevenlabs/elevenlabs.go
+++ b/pkg/provider/stt/elevenlabs/elevenlabs.go
@@ -67,19 +67,49 @@ func WithBaseURL(baseURL string) Option {
 	}
 }
 
+// WithPoolSize sets the maximum number of idle pre-warmed connections per
+// unique URL configuration. Default is 2. Setting to 0 effectively disables
+// pooling (every StartStream dials fresh).
+func WithPoolSize(n int) Option {
+	return func(p *Provider) {
+		p.maxIdle = n
+	}
+}
+
+// WithPoolIdleTTL sets how long idle pooled connections live before being
+// evicted. Default is 30s. Shorter values reduce the chance of using a
+// server-side-closed connection; longer values keep connections warm across
+// longer pauses in speech.
+func WithPoolIdleTTL(d time.Duration) Option {
+	return func(p *Provider) {
+		p.idleTTL = d
+	}
+}
+
 // Provider implements stt.Provider backed by the ElevenLabs Scribe v2 Realtime
 // streaming API.
+//
+// Call [Provider.Close] when the Provider is no longer needed to release pooled
+// connections and stop background goroutines.
 type Provider struct {
 	apiKey     string
 	model      string
 	language   string
 	sampleRate int
 	baseURL    string
+
+	// Connection pool fields.
+	pool    *connPool
+	maxIdle int
+	idleTTL time.Duration
 }
 
 var _ stt.Provider = (*Provider)(nil)
 
 // New creates a new ElevenLabs STT Provider. apiKey must be non-empty.
+//
+// The Provider maintains a pool of pre-warmed WebSocket connections to reduce
+// dial latency. Call [Provider.Close] when the Provider is no longer needed.
 func New(apiKey string, opts ...Option) (*Provider, error) {
 	if apiKey == "" {
 		return nil, errors.New("elevenlabs: apiKey must not be empty")
@@ -90,31 +120,39 @@ func New(apiKey string, opts ...Option) (*Provider, error) {
 		language:   defaultLanguage,
 		sampleRate: defaultSampleRate,
 		baseURL:    defaultBaseURL,
+		maxIdle:    defaultMaxIdleConns,
+		idleTTL:    defaultIdleTTL,
 	}
 	for _, o := range opts {
 		o(p)
 	}
+	p.pool = newConnPool(p.maxIdle, p.idleTTL, p.dialWS)
 	return p, nil
+}
+
+// Close releases all pooled connections and stops background goroutines.
+// It is safe to call Close multiple times.
+func (p *Provider) Close() error {
+	p.pool.close()
+	return nil
 }
 
 // StartStream opens a streaming transcription session with ElevenLabs.
 // It respects cfg.SampleRate and cfg.Language.
+//
+// If a pre-warmed connection is available in the pool it is used immediately,
+// avoiding the WebSocket dial latency. After acquiring a connection the pool
+// begins warming a replacement in the background.
 func (p *Provider) StartStream(ctx context.Context, cfg stt.StreamConfig) (stt.SessionHandle, error) {
 	wsURL, err := p.buildURL(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("elevenlabs: build URL: %w", err)
 	}
 
-	headers := http.Header{}
-	headers.Set("xi-api-key", p.apiKey)
-
-	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
-		HTTPHeader: headers,
-	})
+	conn, err := p.pool.get(ctx, wsURL)
 	if err != nil {
-		return nil, fmt.Errorf("elevenlabs: dial: %w", err)
+		return nil, err
 	}
-	conn.SetReadLimit(1 << 20) // 1 MiB
 
 	sr := cfg.SampleRate
 	if sr == 0 {
@@ -135,7 +173,26 @@ func (p *Provider) StartStream(ctx context.Context, cfg stt.StreamConfig) (stt.S
 	go sess.readLoop(ctx)
 	go sess.writeLoop(ctx)
 
+	// Pre-warm the next connection so subsequent calls avoid dial latency.
+	p.pool.warm(wsURL)
+
 	return sess, nil
+}
+
+// dialWS establishes a new WebSocket connection to the ElevenLabs endpoint.
+// It is used as the dial function for the connection pool.
+func (p *Provider) dialWS(ctx context.Context, wsURL string) (*websocket.Conn, error) {
+	headers := http.Header{}
+	headers.Set("xi-api-key", p.apiKey)
+
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: headers,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("elevenlabs: dial: %w", err)
+	}
+	conn.SetReadLimit(1 << 20) // 1 MiB
+	return conn, nil
 }
 
 // buildURL constructs the ElevenLabs streaming endpoint URL for the given config.

--- a/pkg/provider/stt/elevenlabs/elevenlabs_test.go
+++ b/pkg/provider/stt/elevenlabs/elevenlabs_test.go
@@ -36,6 +36,7 @@ func TestNew(t *testing.T) {
 		if err != nil {
 			t.Fatalf("New: %v", err)
 		}
+		t.Cleanup(func() { _ = p.Close() })
 		assertEqual(t, "model", defaultModel, p.model)
 		assertEqual(t, "language", defaultLanguage, p.language)
 		if p.sampleRate != defaultSampleRate {
@@ -55,6 +56,7 @@ func TestNew(t *testing.T) {
 		if err != nil {
 			t.Fatalf("New: %v", err)
 		}
+		t.Cleanup(func() { _ = p.Close() })
 		assertEqual(t, "model", "custom-model", p.model)
 		assertEqual(t, "language", "de", p.language)
 		if p.sampleRate != 48000 {
@@ -75,6 +77,7 @@ func TestBuildURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("New: %v", err)
 		}
+		t.Cleanup(func() { _ = p.Close() })
 
 		rawURL, err := p.buildURL(stt.StreamConfig{
 			SampleRate: 16000,
@@ -103,6 +106,7 @@ func TestBuildURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("New: %v", err)
 		}
+		t.Cleanup(func() { _ = p.Close() })
 
 		rawURL, err := p.buildURL(stt.StreamConfig{Language: "fr", SampleRate: 16000})
 		if err != nil {
@@ -119,6 +123,7 @@ func TestBuildURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("New: %v", err)
 		}
+		t.Cleanup(func() { _ = p.Close() })
 
 		rawURL, err := p.buildURL(stt.StreamConfig{})
 		if err != nil {
@@ -137,6 +142,7 @@ func TestBuildURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("New: %v", err)
 		}
+		t.Cleanup(func() { _ = p.Close() })
 
 		rawURL, err := p.buildURL(stt.StreamConfig{Language: "en-US", SampleRate: 16000})
 		if err != nil {
@@ -153,6 +159,7 @@ func TestBuildURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("New: %v", err)
 		}
+		t.Cleanup(func() { _ = p.Close() })
 
 		rawURL, err := p.buildURL(stt.StreamConfig{SampleRate: 16000})
 		if err != nil {
@@ -467,6 +474,7 @@ func TestSession_CloseDoesNotTimeout(t *testing.T) {
 		if err != nil {
 			t.Fatalf("New: %v", err)
 		}
+		t.Cleanup(func() { _ = p.Close() })
 
 		sess, err := p.StartStream(context.Background(), stt.StreamConfig{
 			SampleRate: 16000,
@@ -526,6 +534,7 @@ func TestSession_CloseDoesNotTimeout(t *testing.T) {
 		if err != nil {
 			t.Fatalf("New: %v", err)
 		}
+		t.Cleanup(func() { _ = p.Close() })
 
 		sess, err := p.StartStream(context.Background(), stt.StreamConfig{
 			SampleRate: 16000,
@@ -587,6 +596,7 @@ func TestSession_CloseDoesNotTimeout(t *testing.T) {
 		if err != nil {
 			t.Fatalf("New: %v", err)
 		}
+		t.Cleanup(func() { _ = p.Close() })
 
 		sess, err := p.StartStream(context.Background(), stt.StreamConfig{
 			SampleRate: 16000,
@@ -666,6 +676,7 @@ func TestSession_DuplicateCommittedTranscriptDeduplicated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	t.Cleanup(func() { _ = p.Close() })
 
 	sess, err := p.StartStream(context.Background(), stt.StreamConfig{
 		SampleRate: 16000,

--- a/pkg/provider/stt/elevenlabs/pool.go
+++ b/pkg/provider/stt/elevenlabs/pool.go
@@ -1,0 +1,230 @@
+package elevenlabs
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+const (
+	defaultMaxIdleConns = 2
+	defaultIdleTTL      = 30 * time.Second
+	poolCleanupInterval = 10 * time.Second
+	poolWarmTimeout     = 10 * time.Second
+)
+
+// connPool maintains a set of pre-warmed WebSocket connections to reduce
+// dial latency for ElevenLabs STT sessions. Connections are keyed by their
+// full WebSocket URL (which encodes model, language, and sample rate).
+//
+// When [Provider.StartStream] takes a connection from the pool, it
+// immediately starts a background warm-up dial so the next call finds a
+// ready connection. A background goroutine periodically evicts connections
+// that have exceeded their idle TTL.
+//
+// All methods are safe for concurrent use.
+type connPool struct {
+	mu       sync.Mutex
+	idle     map[string][]poolEntry
+	warming  map[string]bool // tracks in-progress warm-up dials per URL
+	maxIdle  int
+	idleTTL  time.Duration
+	dialFunc func(ctx context.Context, wsURL string) (*websocket.Conn, error)
+	done     chan struct{}
+	closeO   sync.Once
+	wg       sync.WaitGroup
+}
+
+// poolEntry is a single idle WebSocket connection with its creation timestamp.
+type poolEntry struct {
+	conn      *websocket.Conn
+	createdAt time.Time
+}
+
+// newConnPool creates a connection pool and starts its background cleanup
+// goroutine. The dialFn is called to establish new WebSocket connections.
+func newConnPool(maxIdle int, idleTTL time.Duration, dialFn func(ctx context.Context, url string) (*websocket.Conn, error)) *connPool {
+	p := &connPool{
+		idle:     make(map[string][]poolEntry),
+		warming:  make(map[string]bool),
+		maxIdle:  maxIdle,
+		idleTTL:  idleTTL,
+		dialFunc: dialFn,
+		done:     make(chan struct{}),
+	}
+	p.wg.Add(1)
+	go p.cleanupLoop()
+	return p
+}
+
+// get returns a pre-warmed connection for the given URL, or dials a fresh one
+// if no idle connection is available.
+func (p *connPool) get(ctx context.Context, wsURL string) (*websocket.Conn, error) {
+	if conn := p.takeIdle(wsURL); conn != nil {
+		return conn, nil
+	}
+	slog.Debug("elevenlabs: pool miss, dialing fresh", "url", wsURL)
+	return p.dialFunc(ctx, wsURL)
+}
+
+// takeIdle removes and returns the freshest idle connection for the URL, or
+// nil if none are available. Stale entries (older than idleTTL) are closed
+// and discarded.
+func (p *connPool) takeIdle(wsURL string) *websocket.Conn {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	entries := p.idle[wsURL]
+	for len(entries) > 0 {
+		// LIFO: prefer the most recently warmed connection.
+		e := entries[len(entries)-1]
+		entries = entries[:len(entries)-1]
+
+		if time.Since(e.createdAt) < p.idleTTL {
+			if len(entries) == 0 {
+				delete(p.idle, wsURL)
+			} else {
+				p.idle[wsURL] = entries
+			}
+			slog.Debug("elevenlabs: pool hit", "url", wsURL)
+			return e.conn
+		}
+		// Stale — close and try the next entry.
+		e.conn.CloseNow()
+	}
+	delete(p.idle, wsURL)
+	return nil
+}
+
+// warm starts dialing a connection for the given URL in the background.
+// It is a no-op if the pool already has enough idle connections, a warm-up
+// is already in progress for this URL, or the pool has been closed.
+func (p *connPool) warm(wsURL string) {
+	p.mu.Lock()
+	select {
+	case <-p.done:
+		p.mu.Unlock()
+		return
+	default:
+	}
+	if len(p.idle[wsURL]) >= p.maxIdle || p.warming[wsURL] {
+		p.mu.Unlock()
+		return
+	}
+	p.warming[wsURL] = true
+	p.mu.Unlock()
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		defer func() {
+			p.mu.Lock()
+			delete(p.warming, wsURL)
+			p.mu.Unlock()
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), poolWarmTimeout)
+		defer cancel()
+
+		select {
+		case <-p.done:
+			return
+		default:
+		}
+
+		conn, err := p.dialFunc(ctx, wsURL)
+		if err != nil {
+			slog.Debug("elevenlabs: pool warm failed", "url", wsURL, "err", err)
+			return
+		}
+
+		p.mu.Lock()
+		defer p.mu.Unlock()
+
+		select {
+		case <-p.done:
+			conn.CloseNow()
+			return
+		default:
+		}
+
+		if len(p.idle[wsURL]) >= p.maxIdle {
+			conn.CloseNow()
+			return
+		}
+		p.idle[wsURL] = append(p.idle[wsURL], poolEntry{
+			conn:      conn,
+			createdAt: time.Now(),
+		})
+		slog.Debug("elevenlabs: pool warmed", "url", wsURL, "idle", len(p.idle[wsURL]))
+	}()
+}
+
+// close drains and closes all idle connections and stops the cleanup
+// goroutine. It is safe to call multiple times.
+func (p *connPool) close() {
+	p.closeO.Do(func() {
+		close(p.done)
+
+		p.mu.Lock()
+		for url, entries := range p.idle {
+			for i := range entries {
+				entries[i].conn.CloseNow()
+			}
+			delete(p.idle, url)
+		}
+		p.mu.Unlock()
+
+		p.wg.Wait()
+	})
+}
+
+// cleanupLoop periodically evicts idle connections that have exceeded their TTL.
+func (p *connPool) cleanupLoop() {
+	defer p.wg.Done()
+	ticker := time.NewTicker(poolCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.done:
+			return
+		case <-ticker.C:
+			p.evictStale()
+		}
+	}
+}
+
+// evictStale removes and closes connections older than idleTTL.
+func (p *connPool) evictStale() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	now := time.Now()
+	for url, entries := range p.idle {
+		alive := entries[:0]
+		for _, e := range entries {
+			if now.Sub(e.createdAt) >= p.idleTTL {
+				e.conn.CloseNow()
+			} else {
+				alive = append(alive, e)
+			}
+		}
+		if len(alive) == 0 {
+			delete(p.idle, url)
+		} else {
+			p.idle[url] = alive
+		}
+	}
+}
+
+// idleCount returns the number of idle connections for the given URL.
+// Intended for testing.
+func (p *connPool) idleCount(wsURL string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.idle[wsURL])
+}

--- a/pkg/provider/stt/elevenlabs/pool_test.go
+++ b/pkg/provider/stt/elevenlabs/pool_test.go
@@ -1,0 +1,402 @@
+package elevenlabs
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/glyphoxa/pkg/provider/stt"
+	"github.com/coder/websocket"
+)
+
+// startPoolTestServer launches a minimal WebSocket server for pool tests.
+// It accepts connections and keeps them open until the client closes.
+func startPoolTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		// Keep the connection open until the client disconnects.
+		for {
+			if _, _, err := conn.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// poolTestDialer returns a dial function that connects to the test server and
+// increments the counter on each call.
+func poolTestDialer(t *testing.T, srv *httptest.Server, counter *atomic.Int64) func(ctx context.Context, wsURL string) (*websocket.Conn, error) {
+	t.Helper()
+	return func(ctx context.Context, _ string) (*websocket.Conn, error) {
+		counter.Add(1)
+		url := "ws" + srv.URL[len("http"):]
+		conn, _, err := websocket.Dial(ctx, url, nil)
+		if err != nil {
+			return nil, err
+		}
+		conn.SetReadLimit(1 << 20)
+		return conn, nil
+	}
+}
+
+func TestConnPool_GetMiss(t *testing.T) {
+	t.Parallel()
+
+	srv := startPoolTestServer(t)
+	var dials atomic.Int64
+	p := newConnPool(2, 30*time.Second, poolTestDialer(t, srv, &dials))
+	t.Cleanup(p.close)
+
+	conn, err := p.get(context.Background(), "ws://example.com/stt")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer conn.CloseNow()
+
+	if got := dials.Load(); got != 1 {
+		t.Errorf("expected 1 dial on pool miss, got %d", got)
+	}
+}
+
+func TestConnPool_GetHit(t *testing.T) {
+	t.Parallel()
+
+	srv := startPoolTestServer(t)
+	var dials atomic.Int64
+	p := newConnPool(2, 30*time.Second, poolTestDialer(t, srv, &dials))
+	t.Cleanup(p.close)
+
+	url := "ws://example.com/stt"
+
+	// Warm a connection manually.
+	ctx := context.Background()
+	warmConn, err := p.dialFunc(ctx, url)
+	if err != nil {
+		t.Fatalf("dialFunc: %v", err)
+	}
+	p.mu.Lock()
+	p.idle[url] = append(p.idle[url], poolEntry{conn: warmConn, createdAt: time.Now()})
+	p.mu.Unlock()
+
+	dialsBefore := dials.Load()
+
+	// Get should return the warmed connection without dialing.
+	got, err := p.get(ctx, url)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer got.CloseNow()
+
+	if dials.Load() != dialsBefore {
+		t.Error("expected no new dials on pool hit")
+	}
+	if got != warmConn {
+		t.Error("expected get to return the pre-warmed connection")
+	}
+	if p.idleCount(url) != 0 {
+		t.Errorf("expected 0 idle after get, got %d", p.idleCount(url))
+	}
+}
+
+func TestConnPool_GetEvictsStale(t *testing.T) {
+	t.Parallel()
+
+	srv := startPoolTestServer(t)
+	var dials atomic.Int64
+	// Very short TTL so the pre-warmed connection is stale immediately.
+	p := newConnPool(2, 1*time.Millisecond, poolTestDialer(t, srv, &dials))
+	t.Cleanup(p.close)
+
+	url := "ws://example.com/stt"
+
+	// Add a connection that's already stale.
+	ctx := context.Background()
+	staleConn, err := p.dialFunc(ctx, url)
+	if err != nil {
+		t.Fatalf("dialFunc: %v", err)
+	}
+	p.mu.Lock()
+	p.idle[url] = append(p.idle[url], poolEntry{conn: staleConn, createdAt: time.Now().Add(-time.Second)})
+	p.mu.Unlock()
+
+	dialsBefore := dials.Load()
+
+	// get should evict the stale connection and dial fresh.
+	got, err := p.get(ctx, url)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer got.CloseNow()
+
+	if dials.Load() <= dialsBefore {
+		t.Error("expected a new dial after stale eviction")
+	}
+	if got == staleConn {
+		t.Error("expected a fresh connection, not the stale one")
+	}
+}
+
+func TestConnPool_Warm(t *testing.T) {
+	t.Parallel()
+
+	srv := startPoolTestServer(t)
+	var dials atomic.Int64
+	p := newConnPool(2, 30*time.Second, poolTestDialer(t, srv, &dials))
+	t.Cleanup(p.close)
+
+	url := "ws://example.com/stt"
+	p.warm(url)
+
+	// Wait for the warm-up goroutine to complete.
+	deadline := time.After(5 * time.Second)
+	for {
+		if p.idleCount(url) > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for warm-up to complete")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	if got := dials.Load(); got != 1 {
+		t.Errorf("expected 1 dial from warm, got %d", got)
+	}
+	if p.idleCount(url) != 1 {
+		t.Errorf("expected 1 idle after warm, got %d", p.idleCount(url))
+	}
+}
+
+func TestConnPool_WarmNoOpWhenFull(t *testing.T) {
+	t.Parallel()
+
+	srv := startPoolTestServer(t)
+	var dials atomic.Int64
+	p := newConnPool(1, 30*time.Second, poolTestDialer(t, srv, &dials))
+	t.Cleanup(p.close)
+
+	url := "ws://example.com/stt"
+
+	// Manually fill the pool to maxIdle.
+	ctx := context.Background()
+	conn, err := p.dialFunc(ctx, url)
+	if err != nil {
+		t.Fatalf("dialFunc: %v", err)
+	}
+	p.mu.Lock()
+	p.idle[url] = append(p.idle[url], poolEntry{conn: conn, createdAt: time.Now()})
+	p.mu.Unlock()
+
+	dialsBefore := dials.Load()
+
+	// warm should be a no-op.
+	p.warm(url)
+	// Give any potential goroutine a chance to run.
+	time.Sleep(50 * time.Millisecond)
+
+	if dials.Load() != dialsBefore {
+		t.Error("expected no new dials when pool is full")
+	}
+}
+
+func TestConnPool_WarmNoOpWhenInProgress(t *testing.T) {
+	t.Parallel()
+
+	srv := startPoolTestServer(t)
+	var dials atomic.Int64
+	p := newConnPool(4, 30*time.Second, poolTestDialer(t, srv, &dials))
+	t.Cleanup(p.close)
+
+	url := "ws://example.com/stt"
+
+	// Start two warm-ups concurrently; only one should dial.
+	p.warm(url)
+	p.warm(url)
+
+	// Wait for warm-up to complete.
+	deadline := time.After(5 * time.Second)
+	for {
+		if p.idleCount(url) > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for warm-up")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	if got := dials.Load(); got != 1 {
+		t.Errorf("expected exactly 1 dial (deduped), got %d", got)
+	}
+}
+
+func TestConnPool_EvictStale(t *testing.T) {
+	t.Parallel()
+
+	srv := startPoolTestServer(t)
+	var dials atomic.Int64
+	p := newConnPool(4, 50*time.Millisecond, poolTestDialer(t, srv, &dials))
+	t.Cleanup(p.close)
+
+	url := "ws://example.com/stt"
+
+	// Add two connections: one fresh, one stale.
+	ctx := context.Background()
+	freshConn, err := p.dialFunc(ctx, url)
+	if err != nil {
+		t.Fatalf("dialFunc: %v", err)
+	}
+	staleConn, err := p.dialFunc(ctx, url)
+	if err != nil {
+		t.Fatalf("dialFunc: %v", err)
+	}
+	p.mu.Lock()
+	p.idle[url] = []poolEntry{
+		{conn: staleConn, createdAt: time.Now().Add(-time.Second)}, // stale
+		{conn: freshConn, createdAt: time.Now()},                   // fresh
+	}
+	p.mu.Unlock()
+
+	p.evictStale()
+
+	if p.idleCount(url) != 1 {
+		t.Errorf("expected 1 idle after eviction, got %d", p.idleCount(url))
+	}
+}
+
+func TestConnPool_Close(t *testing.T) {
+	t.Parallel()
+
+	srv := startPoolTestServer(t)
+	var dials atomic.Int64
+	p := newConnPool(2, 30*time.Second, poolTestDialer(t, srv, &dials))
+
+	url := "ws://example.com/stt"
+	ctx := context.Background()
+	conn, err := p.dialFunc(ctx, url)
+	if err != nil {
+		t.Fatalf("dialFunc: %v", err)
+	}
+	p.mu.Lock()
+	p.idle[url] = append(p.idle[url], poolEntry{conn: conn, createdAt: time.Now()})
+	p.mu.Unlock()
+
+	// Close should not block and should clean up.
+	p.close()
+
+	if p.idleCount(url) != 0 {
+		t.Errorf("expected 0 idle after close, got %d", p.idleCount(url))
+	}
+
+	// Second close should be safe.
+	p.close()
+}
+
+func TestConnPool_WarmAfterClose(t *testing.T) {
+	t.Parallel()
+
+	srv := startPoolTestServer(t)
+	var dials atomic.Int64
+	p := newConnPool(2, 30*time.Second, poolTestDialer(t, srv, &dials))
+
+	p.close()
+
+	dialsBefore := dials.Load()
+	p.warm("ws://example.com/stt")
+	time.Sleep(50 * time.Millisecond)
+
+	if dials.Load() != dialsBefore {
+		t.Error("expected no dials after pool is closed")
+	}
+}
+
+func TestStartStream_UsesPool(t *testing.T) {
+	t.Parallel()
+
+	srv := startElevenLabsServer(t, func(conn *websocket.Conn) {
+		ctx := context.Background()
+		_ = conn.Write(ctx, websocket.MessageText,
+			[]byte(`{"message_type":"session_started"}`))
+		for {
+			_, msg, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+			var chunk audioChunkMessage
+			if err := json.Unmarshal(msg, &chunk); err != nil {
+				continue
+			}
+			if chunk.Commit {
+				resp := `{"message_type":"committed_transcript","text":"pool test","language_code":"en"}`
+				_ = conn.Write(ctx, websocket.MessageText, []byte(resp))
+				for {
+					if _, _, err := conn.Read(ctx); err != nil {
+						return
+					}
+				}
+			}
+		}
+	})
+
+	p, err := New("test-key", WithBaseURL(wsURL(srv)))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+
+	// First StartStream triggers a pool miss + a warm-up.
+	sess1, err := p.StartStream(context.Background(), stt.StreamConfig{
+		SampleRate: 16000,
+		Language:   "en",
+	})
+	if err != nil {
+		t.Fatalf("StartStream 1: %v", err)
+	}
+
+	// Wait for the warm-up connection to be established.
+	wsURLStr, _ := p.buildURL(stt.StreamConfig{SampleRate: 16000, Language: "en"})
+	deadline := time.After(5 * time.Second)
+	for {
+		if p.pool.idleCount(wsURLStr) > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for pool warm-up")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	if err := sess1.SendAudio(make([]byte, 320)); err != nil {
+		t.Fatalf("SendAudio: %v", err)
+	}
+	_ = sess1.Close()
+
+	// Second StartStream should get a pool hit (the warmed connection).
+	sess2, err := p.StartStream(context.Background(), stt.StreamConfig{
+		SampleRate: 16000,
+		Language:   "en",
+	})
+	if err != nil {
+		t.Fatalf("StartStream 2: %v", err)
+	}
+	_ = sess2.Close()
+}

--- a/pkg/provider/stt/types.go
+++ b/pkg/provider/stt/types.go
@@ -19,6 +19,11 @@ type Transcript struct {
 	// May be nil for providers that don't support word-level output.
 	Words []WordDetail
 
+	// RawText preserves the original uncorrected STT output when transcript
+	// correction is applied. Set by the audio pipeline before correction
+	// overwrites Text. Empty when no correction was applied.
+	RawText string
+
 	// SpeakerID identifies the speaker when speaker diarization is active.
 	SpeakerID string
 


### PR DESCRIPTION
## Summary
- Adds a pre-warming WebSocket connection pool to the ElevenLabs STT provider to eliminate 50-200ms dial latency per speech segment
- When `StartStream()` takes a connection from the pool, it immediately starts dialing a replacement in the background (`warm()`), so the next call finds a ready connection
- Background goroutine evicts idle connections past their TTL (default 30s) to prevent stale/server-closed connections
- New `Provider.Close()` method for clean shutdown of pooled connections
- Configurable via `WithPoolSize(n)` and `WithPoolIdleTTL(d)` options

## How it works
1. `StartStream()` calls `pool.get()` — returns a pre-warmed connection if available, otherwise dials fresh
2. After acquiring a connection, `pool.warm()` starts a background dial to replenish the pool
3. Sessions still close the WebSocket on `Close()` (no connection reuse — avoids stale server-side state)
4. Idle connections are keyed by full WebSocket URL (model + language + sample rate)

## Test plan
- [x] Pool unit tests: get miss/hit, stale eviction, warm, warm dedup, warm-after-close, close
- [x] Integration test: `TestStartStream_UsesPool` verifies pool hit on second StartStream
- [x] Existing tests updated with `Provider.Close()` cleanup
- [x] All tests pass with `-race -count=1`
- [x] `go vet` and `gofmt` clean