### PR TITLE
feat(web): add web management service backend (MVP)

### DIFF
--- a/cmd/glyphoxa-web/main.go
+++ b/cmd/glyphoxa-web/main.go
@@ -1,0 +1,120 @@
+// Command glyphoxa-web runs the Glyphoxa Web Management Service.
+//
+// The service provides user authentication (Discord OAuth2), campaign and NPC
+// management, session/transcript viewing, usage queries, and tenant
+// administration (proxied to the gateway). It is a standalone binary that
+// shares the same PostgreSQL database as the Glyphoxa gateway.
+//
+// Configuration is via environment variables:
+//
+//	GLYPHOXA_WEB_DATABASE_DSN         — PostgreSQL connection string (required)
+//	GLYPHOXA_WEB_JWT_SECRET           — HMAC key for JWT signing (required)
+//	GLYPHOXA_WEB_DISCORD_CLIENT_ID    — Discord OAuth2 client ID (required)
+//	GLYPHOXA_WEB_DISCORD_CLIENT_SECRET — Discord OAuth2 client secret (required)
+//	GLYPHOXA_WEB_DISCORD_REDIRECT_URI — OAuth2 callback URL (required)
+//	GLYPHOXA_WEB_GATEWAY_URL          — Gateway admin API base URL (optional)
+//	GLYPHOXA_WEB_LISTEN_ADDR          — Listen address (default :8090)
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/MrWong99/glyphoxa/internal/agent/npcstore"
+	"github.com/MrWong99/glyphoxa/internal/web"
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error("glyphoxa-web: fatal", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	cfg, err := web.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	slog.Info("glyphoxa-web: starting",
+		"listen_addr", cfg.ListenAddr,
+		"gateway_url", cfg.GatewayURL,
+	)
+
+	// Connect to PostgreSQL.
+	pool, err := pgxpool.New(ctx, cfg.DatabaseDSN)
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+
+	if err := pool.Ping(ctx); err != nil {
+		return err
+	}
+	slog.Info("glyphoxa-web: database connected")
+
+	// Initialize store (runs migrations).
+	store, err := web.NewStore(ctx, pool)
+	if err != nil {
+		return err
+	}
+
+	// Initialize NPC store (reuses existing npcstore package).
+	npcs := npcstore.NewPostgresStore(pool)
+	if err := npcs.Migrate(ctx); err != nil {
+		return err
+	}
+
+	// Build and start HTTP server.
+	srv := web.NewServer(cfg, store, npcs)
+
+	httpServer := &http.Server{
+		Addr:         cfg.ListenAddr,
+		Handler:      srv.Handler(),
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	// Start server in background.
+	errCh := make(chan error, 1)
+	go func() {
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+
+	slog.Info("glyphoxa-web: listening", "addr", cfg.ListenAddr)
+
+	// Wait for shutdown signal or server error.
+	select {
+	case <-ctx.Done():
+		slog.Info("glyphoxa-web: shutting down")
+	case err := <-errCh:
+		return err
+	}
+
+	// Graceful shutdown with 10-second deadline.
+	shutCtx, shutCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutCancel()
+
+	if err := httpServer.Shutdown(shutCtx); err != nil {
+		return err
+	}
+
+	slog.Info("glyphoxa-web: stopped")
+	return nil
+}

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -1,0 +1,202 @@
+package web
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// jwtHeader is the pre-encoded JOSE header for HS256.
+var jwtHeader = base64URLEncode([]byte(`{"alg":"HS256","typ":"JWT"}`))
+
+// Claims holds the JWT payload for an authenticated user.
+type Claims struct {
+	Sub      string `json:"sub"`
+	TenantID string `json:"tid"`
+	Role     string `json:"role"`
+	Issuer   string `json:"iss"`
+	IssuedAt int64  `json:"iat"`
+	Expires  int64  `json:"exp"`
+}
+
+// Valid returns true if the claims have not expired.
+func (c Claims) Valid() bool {
+	return time.Now().Unix() < c.Expires
+}
+
+// SignJWT creates a signed JWT for the given claims.
+func SignJWT(secret string, claims Claims) (string, error) {
+	claims.Issuer = "glyphoxa-manage"
+	claims.IssuedAt = time.Now().Unix()
+	if claims.Expires == 0 {
+		claims.Expires = time.Now().Add(24 * time.Hour).Unix()
+	}
+
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("web: marshal claims: %w", err)
+	}
+
+	payloadEnc := base64URLEncode(payload)
+	signingInput := jwtHeader + "." + payloadEnc
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(signingInput))
+	sig := base64URLEncode(mac.Sum(nil))
+
+	return signingInput + "." + sig, nil
+}
+
+// VerifyJWT parses and verifies a JWT, returning the claims if valid.
+func VerifyJWT(secret, token string) (*Claims, error) {
+	parts := strings.SplitN(token, ".", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("web: malformed JWT")
+	}
+
+	signingInput := parts[0] + "." + parts[1]
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(signingInput))
+	expectedSig := base64URLEncode(mac.Sum(nil))
+
+	if !hmac.Equal([]byte(parts[2]), []byte(expectedSig)) {
+		return nil, fmt.Errorf("web: invalid JWT signature")
+	}
+
+	payload, err := base64URLDecode(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("web: decode JWT payload: %w", err)
+	}
+
+	var claims Claims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("web: unmarshal JWT claims: %w", err)
+	}
+
+	if !claims.Valid() {
+		return nil, fmt.Errorf("web: JWT expired")
+	}
+	return &claims, nil
+}
+
+func base64URLEncode(data []byte) string {
+	return strings.TrimRight(base64.URLEncoding.EncodeToString(data), "=")
+}
+
+func base64URLDecode(s string) ([]byte, error) {
+	// Add padding back.
+	switch len(s) % 4 {
+	case 2:
+		s += "=="
+	case 3:
+		s += "="
+	}
+	return base64.URLEncoding.DecodeString(s)
+}
+
+// DiscordOAuthConfig holds Discord OAuth2 configuration.
+type DiscordOAuthConfig struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+}
+
+// DiscordUser represents the user profile returned by the Discord API.
+type DiscordUser struct {
+	ID            string `json:"id"`
+	Username      string `json:"username"`
+	GlobalName    string `json:"global_name"`
+	Email         string `json:"email"`
+	Avatar        string `json:"avatar"`
+	Discriminator string `json:"discriminator"`
+}
+
+// DisplayName returns the best display name for the Discord user.
+func (u DiscordUser) DisplayName() string {
+	if u.GlobalName != "" {
+		return u.GlobalName
+	}
+	return u.Username
+}
+
+// AvatarURL returns the full URL to the user's avatar.
+func (u DiscordUser) AvatarURL() string {
+	if u.Avatar == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://cdn.discordapp.com/avatars/%s/%s.png", u.ID, u.Avatar)
+}
+
+// GenerateState creates a random state parameter for CSRF protection.
+func GenerateState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("web: generate state: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// ExchangeDiscordCode exchanges an authorization code for a Discord access token.
+func ExchangeDiscordCode(ctx context.Context, cfg DiscordOAuthConfig, code string) (string, error) {
+	data := fmt.Sprintf(
+		"client_id=%s&client_secret=%s&grant_type=authorization_code&code=%s&redirect_uri=%s",
+		cfg.ClientID, cfg.ClientSecret, code, cfg.RedirectURI,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://discord.com/api/oauth2/token", strings.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("web: create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("web: exchange discord code: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("web: discord token exchange returned %d", resp.StatusCode)
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("web: decode discord token response: %w", err)
+	}
+	return result.AccessToken, nil
+}
+
+// FetchDiscordUser fetches the authenticated user's profile from the Discord API.
+func FetchDiscordUser(ctx context.Context, accessToken string) (*DiscordUser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://discord.com/api/users/@me", nil)
+	if err != nil {
+		return nil, fmt.Errorf("web: create discord user request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("web: fetch discord user: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("web: discord user endpoint returned %d", resp.StatusCode)
+	}
+
+	var user DiscordUser
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return nil, fmt.Errorf("web: decode discord user: %w", err)
+	}
+	return &user, nil
+}

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -1,0 +1,124 @@
+package web
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSignAndVerifyJWT(t *testing.T) {
+	t.Parallel()
+
+	secret := "test-secret-key-for-jwt"
+	claims := Claims{
+		Sub:      "user-123",
+		TenantID: "tenant-abc",
+		Role:     "dm",
+		Expires:  time.Now().Add(1 * time.Hour).Unix(),
+	}
+
+	token, err := SignJWT(secret, claims)
+	if err != nil {
+		t.Fatalf("SignJWT: %v", err)
+	}
+	if token == "" {
+		t.Fatal("SignJWT returned empty token")
+	}
+
+	verified, err := VerifyJWT(secret, token)
+	if err != nil {
+		t.Fatalf("VerifyJWT: %v", err)
+	}
+	if verified.Sub != claims.Sub {
+		t.Errorf("Sub = %q, want %q", verified.Sub, claims.Sub)
+	}
+	if verified.TenantID != claims.TenantID {
+		t.Errorf("TenantID = %q, want %q", verified.TenantID, claims.TenantID)
+	}
+	if verified.Role != claims.Role {
+		t.Errorf("Role = %q, want %q", verified.Role, claims.Role)
+	}
+	if verified.Issuer != "glyphoxa-manage" {
+		t.Errorf("Issuer = %q, want %q", verified.Issuer, "glyphoxa-manage")
+	}
+}
+
+func TestVerifyJWT_WrongSecret(t *testing.T) {
+	t.Parallel()
+
+	token, err := SignJWT("secret-1", Claims{
+		Sub:     "user-1",
+		Expires: time.Now().Add(1 * time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("SignJWT: %v", err)
+	}
+
+	_, err = VerifyJWT("secret-2", token)
+	if err == nil {
+		t.Fatal("expected error for wrong secret, got nil")
+	}
+}
+
+func TestVerifyJWT_Expired(t *testing.T) {
+	t.Parallel()
+
+	token, err := SignJWT("secret", Claims{
+		Sub:     "user-1",
+		Expires: time.Now().Add(-1 * time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("SignJWT: %v", err)
+	}
+
+	_, err = VerifyJWT("secret", token)
+	if err == nil {
+		t.Fatal("expected error for expired token, got nil")
+	}
+}
+
+func TestVerifyJWT_Malformed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{"empty", ""},
+		{"no dots", "abcdef"},
+		{"one dot", "abc.def"},
+		{"garbage", "not.a.jwt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := VerifyJWT("secret", tt.token)
+			if err == nil {
+				t.Errorf("expected error for token %q, got nil", tt.token)
+			}
+		})
+	}
+}
+
+func TestGenerateState(t *testing.T) {
+	t.Parallel()
+
+	state1, err := GenerateState()
+	if err != nil {
+		t.Fatalf("GenerateState: %v", err)
+	}
+	state2, err := GenerateState()
+	if err != nil {
+		t.Fatalf("GenerateState: %v", err)
+	}
+
+	if state1 == "" {
+		t.Fatal("GenerateState returned empty string")
+	}
+	if state1 == state2 {
+		t.Fatal("GenerateState returned duplicate values")
+	}
+	if len(state1) != 32 { // 16 bytes = 32 hex chars
+		t.Errorf("state length = %d, want 32", len(state1))
+	}
+}

--- a/internal/web/config.go
+++ b/internal/web/config.go
@@ -1,0 +1,82 @@
+// Package web implements the Glyphoxa web management service.
+//
+// The service provides self-service management for Dungeon Masters: user
+// authentication via Discord OAuth2, campaign and NPC CRUD, session and usage
+// queries, and tenant administration. It runs as a standalone binary alongside
+// the Glyphoxa gateway and shares the same PostgreSQL database.
+package web
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// Config holds all configuration for the web management service.
+// Values are loaded from environment variables.
+type Config struct {
+	// DatabaseDSN is the PostgreSQL connection string.
+	DatabaseDSN string
+
+	// JWTSecret is the HMAC key used to sign and verify JWTs.
+	JWTSecret string
+
+	// DiscordClientID is the Discord OAuth2 application client ID.
+	DiscordClientID string
+
+	// DiscordClientSecret is the Discord OAuth2 application client secret.
+	DiscordClientSecret string
+
+	// DiscordRedirectURI is the OAuth2 callback URL registered with Discord.
+	DiscordRedirectURI string
+
+	// GatewayURL is the base URL of the gateway's internal admin API.
+	GatewayURL string
+
+	// ListenAddr is the address the HTTP server binds to.
+	ListenAddr string
+}
+
+// LoadConfig reads configuration from environment variables and validates
+// that all required values are present.
+func LoadConfig() (*Config, error) {
+	cfg := &Config{
+		DatabaseDSN:         os.Getenv("GLYPHOXA_WEB_DATABASE_DSN"),
+		JWTSecret:           os.Getenv("GLYPHOXA_WEB_JWT_SECRET"),
+		DiscordClientID:     os.Getenv("GLYPHOXA_WEB_DISCORD_CLIENT_ID"),
+		DiscordClientSecret: os.Getenv("GLYPHOXA_WEB_DISCORD_CLIENT_SECRET"),
+		DiscordRedirectURI:  os.Getenv("GLYPHOXA_WEB_DISCORD_REDIRECT_URI"),
+		GatewayURL:          os.Getenv("GLYPHOXA_WEB_GATEWAY_URL"),
+		ListenAddr:          os.Getenv("GLYPHOXA_WEB_LISTEN_ADDR"),
+	}
+
+	if cfg.ListenAddr == "" {
+		cfg.ListenAddr = ":8090"
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// Validate checks that all required configuration values are set.
+func (c *Config) Validate() error {
+	var errs []error
+	if c.DatabaseDSN == "" {
+		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_DATABASE_DSN is required"))
+	}
+	if c.JWTSecret == "" {
+		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_JWT_SECRET is required"))
+	}
+	if c.DiscordClientID == "" {
+		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_DISCORD_CLIENT_ID is required"))
+	}
+	if c.DiscordClientSecret == "" {
+		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_DISCORD_CLIENT_SECRET is required"))
+	}
+	if c.DiscordRedirectURI == "" {
+		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_DISCORD_REDIRECT_URI is required"))
+	}
+	return errors.Join(errs...)
+}

--- a/internal/web/handlers_auth.go
+++ b/internal/web/handlers_auth.go
@@ -1,0 +1,201 @@
+package web
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+)
+
+// handleDiscordLogin initiates the Discord OAuth2 flow by redirecting the user
+// to Discord's authorization page.
+func (s *Server) handleDiscordLogin(w http.ResponseWriter, r *http.Request) {
+	state, err := GenerateState()
+	if err != nil {
+		slog.Error("web: generate oauth state", "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to generate state")
+		return
+	}
+
+	// Store state in a short-lived cookie for CSRF validation on callback.
+	http.SetCookie(w, &http.Cookie{
+		Name:     "glyphoxa_oauth_state",
+		Value:    state,
+		Path:     "/",
+		MaxAge:   300, // 5 minutes
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	params := url.Values{
+		"client_id":     {s.cfg.DiscordClientID},
+		"redirect_uri":  {s.cfg.DiscordRedirectURI},
+		"response_type": {"code"},
+		"scope":         {"identify email"},
+		"state":         {state},
+	}
+
+	target := "https://discord.com/oauth2/authorize?" + params.Encode()
+	http.Redirect(w, r, target, http.StatusFound)
+}
+
+// handleDiscordCallback handles the Discord OAuth2 callback, exchanges the
+// authorization code for tokens, fetches the user profile, upserts the user,
+// and issues a JWT.
+func (s *Server) handleDiscordCallback(w http.ResponseWriter, r *http.Request) {
+	// Validate state for CSRF protection.
+	stateCookie, err := r.Cookie("glyphoxa_oauth_state")
+	if err != nil || stateCookie.Value == "" {
+		writeError(w, http.StatusBadRequest, "invalid_state", "missing OAuth state cookie")
+		return
+	}
+	if r.URL.Query().Get("state") != stateCookie.Value {
+		writeError(w, http.StatusBadRequest, "invalid_state", "state mismatch")
+		return
+	}
+
+	// Clear the state cookie.
+	http.SetCookie(w, &http.Cookie{
+		Name:   "glyphoxa_oauth_state",
+		Value:  "",
+		Path:   "/",
+		MaxAge: -1,
+	})
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		writeError(w, http.StatusBadRequest, "missing_code", "authorization code required")
+		return
+	}
+
+	// Check for error from Discord.
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		desc := r.URL.Query().Get("error_description")
+		slog.Warn("web: discord oauth error", "error", errParam, "description", desc)
+		writeError(w, http.StatusBadRequest, "discord_error", fmt.Sprintf("discord: %s", desc))
+		return
+	}
+
+	oauthCfg := DiscordOAuthConfig{
+		ClientID:     s.cfg.DiscordClientID,
+		ClientSecret: s.cfg.DiscordClientSecret,
+		RedirectURI:  s.cfg.DiscordRedirectURI,
+	}
+
+	// Exchange code for access token.
+	accessToken, err := ExchangeDiscordCode(r.Context(), oauthCfg, code)
+	if err != nil {
+		slog.Error("web: discord token exchange", "err", err)
+		writeError(w, http.StatusBadGateway, "discord_error", "failed to exchange authorization code")
+		return
+	}
+
+	// Fetch Discord user profile.
+	discordUser, err := FetchDiscordUser(r.Context(), accessToken)
+	if err != nil {
+		slog.Error("web: fetch discord user", "err", err)
+		writeError(w, http.StatusBadGateway, "discord_error", "failed to fetch user profile")
+		return
+	}
+
+	// Upsert user — for MVP, auto-assign to a default tenant.
+	tenantID := "default"
+	user, err := s.store.UpsertDiscordUser(
+		r.Context(),
+		discordUser.ID,
+		discordUser.Email,
+		discordUser.DisplayName(),
+		discordUser.AvatarURL(),
+		tenantID,
+	)
+	if err != nil {
+		slog.Error("web: upsert discord user", "discord_id", discordUser.ID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to create user")
+		return
+	}
+
+	// Issue JWT.
+	token, err := SignJWT(s.cfg.JWTSecret, Claims{
+		Sub:      user.ID,
+		TenantID: user.TenantID,
+		Role:     user.Role,
+	})
+	if err != nil {
+		slog.Error("web: sign jwt", "user_id", user.ID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to issue token")
+		return
+	}
+
+	slog.Info("web: user authenticated via discord",
+		"user_id", user.ID,
+		"discord_id", discordUser.ID,
+		"display_name", user.DisplayName,
+	)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]any{
+			"access_token": token,
+			"token_type":   "Bearer",
+			"expires_in":   86400,
+			"user":         user,
+		},
+	})
+}
+
+// handleRefresh issues a new JWT from a valid existing token.
+func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	// Re-fetch user to get current role/tenant.
+	user, err := s.store.GetUser(r.Context(), claims.Sub)
+	if err != nil || user == nil {
+		writeError(w, http.StatusUnauthorized, "user_not_found", "user no longer exists")
+		return
+	}
+
+	token, err := SignJWT(s.cfg.JWTSecret, Claims{
+		Sub:      user.ID,
+		TenantID: user.TenantID,
+		Role:     user.Role,
+	})
+	if err != nil {
+		slog.Error("web: refresh sign jwt", "user_id", user.ID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to issue token")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]any{
+			"access_token": token,
+			"token_type":   "Bearer",
+			"expires_in":   86400,
+			"user":         user,
+		},
+	})
+}
+
+// handleMe returns the current authenticated user's profile.
+func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	user, err := s.store.GetUser(r.Context(), claims.Sub)
+	if err != nil {
+		slog.Error("web: get user for /me", "user_id", claims.Sub, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to fetch user")
+		return
+	}
+	if user == nil {
+		writeError(w, http.StatusNotFound, "user_not_found", "user no longer exists")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": user})
+}

--- a/internal/web/handlers_campaigns.go
+++ b/internal/web/handlers_campaigns.go
@@ -1,0 +1,166 @@
+package web
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// CampaignCreateRequest is the JSON body for creating a campaign.
+type CampaignCreateRequest struct {
+	Name        string `json:"name"`
+	System      string `json:"system"`
+	Description string `json:"description"`
+}
+
+// CampaignUpdateRequest is the JSON body for updating a campaign.
+type CampaignUpdateRequest struct {
+	Name        *string `json:"name"`
+	System      *string `json:"system"`
+	Description *string `json:"description"`
+}
+
+func (s *Server) handleCreateCampaign(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	var req CampaignCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", "invalid JSON body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "missing_name", "name is required")
+		return
+	}
+
+	campaign := &Campaign{
+		TenantID:    claims.TenantID,
+		Name:        req.Name,
+		System:      req.System,
+		Description: req.Description,
+	}
+
+	if err := s.store.CreateCampaign(r.Context(), campaign); err != nil {
+		slog.Error("web: create campaign", "tenant_id", claims.TenantID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to create campaign")
+		return
+	}
+
+	slog.Info("web: campaign created",
+		"campaign_id", campaign.ID,
+		"tenant_id", claims.TenantID,
+		"name", campaign.Name,
+	)
+	writeJSON(w, http.StatusCreated, map[string]any{"data": campaign})
+}
+
+func (s *Server) handleListCampaigns(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	campaigns, err := s.store.ListCampaigns(r.Context(), claims.TenantID)
+	if err != nil {
+		slog.Error("web: list campaigns", "tenant_id", claims.TenantID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to list campaigns")
+		return
+	}
+	if campaigns == nil {
+		campaigns = []Campaign{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": campaigns})
+}
+
+func (s *Server) handleGetCampaign(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	id := r.PathValue("id")
+	campaign, err := s.store.GetCampaign(r.Context(), claims.TenantID, id)
+	if err != nil {
+		slog.Error("web: get campaign", "campaign_id", id, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to get campaign")
+		return
+	}
+	if campaign == nil {
+		writeError(w, http.StatusNotFound, "not_found", "campaign not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": campaign})
+}
+
+func (s *Server) handleUpdateCampaign(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	id := r.PathValue("id")
+
+	// Fetch existing to merge partial updates.
+	existing, err := s.store.GetCampaign(r.Context(), claims.TenantID, id)
+	if err != nil {
+		slog.Error("web: get campaign for update", "campaign_id", id, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to get campaign")
+		return
+	}
+	if existing == nil {
+		writeError(w, http.StatusNotFound, "not_found", "campaign not found")
+		return
+	}
+
+	var req CampaignUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", "invalid JSON body")
+		return
+	}
+
+	if req.Name != nil {
+		existing.Name = *req.Name
+	}
+	if req.System != nil {
+		existing.System = *req.System
+	}
+	if req.Description != nil {
+		existing.Description = *req.Description
+	}
+
+	if err := s.store.UpdateCampaign(r.Context(), existing); err != nil {
+		slog.Error("web: update campaign", "campaign_id", id, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to update campaign")
+		return
+	}
+
+	slog.Info("web: campaign updated", "campaign_id", id, "tenant_id", claims.TenantID)
+	writeJSON(w, http.StatusOK, map[string]any{"data": existing})
+}
+
+func (s *Server) handleDeleteCampaign(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	id := r.PathValue("id")
+	if err := s.store.DeleteCampaign(r.Context(), claims.TenantID, id); err != nil {
+		slog.Error("web: delete campaign", "campaign_id", id, "err", err)
+		writeError(w, http.StatusNotFound, "not_found", "campaign not found")
+		return
+	}
+
+	slog.Info("web: campaign deleted", "campaign_id", id, "tenant_id", claims.TenantID)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/web/handlers_npcs.go
+++ b/internal/web/handlers_npcs.go
@@ -1,0 +1,202 @@
+package web
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/MrWong99/glyphoxa/internal/agent/npcstore"
+)
+
+// NPCCreateRequest is the JSON body for creating an NPC.
+type NPCCreateRequest struct {
+	ID             string            `json:"id"`
+	Name           string            `json:"name"`
+	Personality    string            `json:"personality"`
+	Engine         string            `json:"engine"`
+	Voice          npcstore.VoiceConfig `json:"voice"`
+	KnowledgeScope []string          `json:"knowledge_scope"`
+	SecretKnowledge []string         `json:"secret_knowledge"`
+	BehaviorRules  []string          `json:"behavior_rules"`
+	Tools          []string          `json:"tools"`
+	BudgetTier     string            `json:"budget_tier"`
+	GMHelper       bool              `json:"gm_helper"`
+	AddressOnly    bool              `json:"address_only"`
+	Attributes     map[string]any    `json:"attributes"`
+}
+
+func (s *Server) handleCreateNPC(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	campaignID := r.PathValue("id")
+
+	// Verify the campaign belongs to this tenant.
+	campaign, err := s.store.GetCampaign(r.Context(), claims.TenantID, campaignID)
+	if err != nil || campaign == nil {
+		writeError(w, http.StatusNotFound, "not_found", "campaign not found")
+		return
+	}
+
+	var req NPCCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", "invalid JSON body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "missing_name", "name is required")
+		return
+	}
+
+	def := &npcstore.NPCDefinition{
+		ID:              req.ID,
+		CampaignID:      campaignID,
+		Name:            req.Name,
+		Personality:     req.Personality,
+		Engine:          req.Engine,
+		Voice:           req.Voice,
+		KnowledgeScope:  req.KnowledgeScope,
+		SecretKnowledge: req.SecretKnowledge,
+		BehaviorRules:   req.BehaviorRules,
+		Tools:           req.Tools,
+		BudgetTier:      req.BudgetTier,
+		GMHelper:        req.GMHelper,
+		AddressOnly:     req.AddressOnly,
+		Attributes:      req.Attributes,
+	}
+
+	if err := s.npcs.Create(r.Context(), def); err != nil {
+		slog.Error("web: create npc", "campaign_id", campaignID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to create NPC")
+		return
+	}
+
+	slog.Info("web: npc created",
+		"npc_id", def.ID,
+		"campaign_id", campaignID,
+		"name", def.Name,
+	)
+	writeJSON(w, http.StatusCreated, map[string]any{"data": def})
+}
+
+func (s *Server) handleListNPCs(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	campaignID := r.PathValue("id")
+
+	// Verify the campaign belongs to this tenant.
+	campaign, err := s.store.GetCampaign(r.Context(), claims.TenantID, campaignID)
+	if err != nil || campaign == nil {
+		writeError(w, http.StatusNotFound, "not_found", "campaign not found")
+		return
+	}
+
+	npcs, err := s.npcs.List(r.Context(), campaignID)
+	if err != nil {
+		slog.Error("web: list npcs", "campaign_id", campaignID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to list NPCs")
+		return
+	}
+	if npcs == nil {
+		npcs = []npcstore.NPCDefinition{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": npcs})
+}
+
+func (s *Server) handleGetNPC(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	npcID := r.PathValue("npc_id")
+	npc, err := s.npcs.Get(r.Context(), npcID)
+	if err != nil {
+		slog.Error("web: get npc", "npc_id", npcID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to get NPC")
+		return
+	}
+	if npc == nil {
+		writeError(w, http.StatusNotFound, "not_found", "NPC not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": npc})
+}
+
+func (s *Server) handleUpdateNPC(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	npcID := r.PathValue("npc_id")
+	campaignID := r.PathValue("id")
+
+	existing, err := s.npcs.Get(r.Context(), npcID)
+	if err != nil || existing == nil {
+		writeError(w, http.StatusNotFound, "not_found", "NPC not found")
+		return
+	}
+	if existing.CampaignID != campaignID {
+		writeError(w, http.StatusNotFound, "not_found", "NPC not found in this campaign")
+		return
+	}
+
+	// Decode full replacement body.
+	var req NPCCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", "invalid JSON body")
+		return
+	}
+
+	existing.Name = req.Name
+	existing.Personality = req.Personality
+	existing.Engine = req.Engine
+	existing.Voice = req.Voice
+	existing.KnowledgeScope = req.KnowledgeScope
+	existing.SecretKnowledge = req.SecretKnowledge
+	existing.BehaviorRules = req.BehaviorRules
+	existing.Tools = req.Tools
+	existing.BudgetTier = req.BudgetTier
+	existing.GMHelper = req.GMHelper
+	existing.AddressOnly = req.AddressOnly
+	existing.Attributes = req.Attributes
+
+	if err := s.npcs.Update(r.Context(), existing); err != nil {
+		slog.Error("web: update npc", "npc_id", npcID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to update NPC")
+		return
+	}
+
+	slog.Info("web: npc updated", "npc_id", npcID, "campaign_id", campaignID)
+	writeJSON(w, http.StatusOK, map[string]any{"data": existing})
+}
+
+func (s *Server) handleDeleteNPC(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	npcID := r.PathValue("npc_id")
+	if err := s.npcs.Delete(r.Context(), npcID); err != nil {
+		slog.Error("web: delete npc", "npc_id", npcID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to delete NPC")
+		return
+	}
+
+	slog.Info("web: npc deleted", "npc_id", npcID)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/web/handlers_sessions.go
+++ b/internal/web/handlers_sessions.go
@@ -1,0 +1,64 @@
+package web
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+)
+
+func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	limit, _ := strconv.Atoi(r.URL.Query().Get("per_page"))
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	if limit <= 0 {
+		limit = 25
+	}
+	if page <= 0 {
+		page = 1
+	}
+	offset := (page - 1) * limit
+
+	sessions, err := s.store.ListSessions(r.Context(), claims.TenantID, limit, offset)
+	if err != nil {
+		slog.Error("web: list sessions", "tenant_id", claims.TenantID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to list sessions")
+		return
+	}
+	if sessions == nil {
+		sessions = []SessionSummary{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": sessions,
+		"meta": map[string]any{
+			"page":     page,
+			"per_page": limit,
+		},
+	})
+}
+
+func (s *Server) handleGetTranscript(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	sessionID := r.PathValue("id")
+	entries, err := s.store.GetTranscript(r.Context(), claims.TenantID, sessionID)
+	if err != nil {
+		slog.Error("web: get transcript", "session_id", sessionID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to get transcript")
+		return
+	}
+	if entries == nil {
+		entries = []TranscriptEntry{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": entries})
+}

--- a/internal/web/handlers_tenants.go
+++ b/internal/web/handlers_tenants.go
@@ -1,0 +1,154 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// handleListTenants proxies to the gateway admin API.
+func (s *Server) handleListTenants(w http.ResponseWriter, r *http.Request) {
+	s.proxyToGateway(w, r, http.MethodGet, "/api/v1/tenants")
+}
+
+// handleGetTenant proxies to the gateway admin API.
+func (s *Server) handleGetTenant(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	s.proxyToGateway(w, r, http.MethodGet, "/api/v1/tenants/"+id)
+}
+
+// handleCreateTenant proxies to the gateway admin API.
+func (s *Server) handleCreateTenant(w http.ResponseWriter, r *http.Request) {
+	s.proxyToGatewayWithBody(w, r, http.MethodPost, "/api/v1/tenants")
+}
+
+// handleUpdateTenant proxies to the gateway admin API.
+func (s *Server) handleUpdateTenant(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	s.proxyToGatewayWithBody(w, r, http.MethodPut, "/api/v1/tenants/"+id)
+}
+
+// handleDeleteTenant proxies to the gateway admin API.
+func (s *Server) handleDeleteTenant(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	s.proxyToGateway(w, r, http.MethodDelete, "/api/v1/tenants/"+id)
+}
+
+func (s *Server) proxyToGateway(w http.ResponseWriter, r *http.Request, method, path string) {
+	if s.cfg.GatewayURL == "" {
+		writeError(w, http.StatusServiceUnavailable, "no_gateway", "gateway URL not configured")
+		return
+	}
+
+	target := strings.TrimRight(s.cfg.GatewayURL, "/") + path
+	req, err := http.NewRequestWithContext(r.Context(), method, target, nil)
+	if err != nil {
+		slog.Error("web: create gateway request", "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to create gateway request")
+		return
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Error("web: gateway request failed", "path", path, "err", err)
+		writeError(w, http.StatusBadGateway, "gateway_error", "failed to reach gateway")
+		return
+	}
+	defer resp.Body.Close()
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(resp.StatusCode)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		slog.Error("web: copy gateway response", "err", err)
+	}
+}
+
+func (s *Server) proxyToGatewayWithBody(w http.ResponseWriter, r *http.Request, method, path string) {
+	if s.cfg.GatewayURL == "" {
+		writeError(w, http.StatusServiceUnavailable, "no_gateway", "gateway URL not configured")
+		return
+	}
+
+	target := strings.TrimRight(s.cfg.GatewayURL, "/") + path
+	req, err := http.NewRequestWithContext(r.Context(), method, target, r.Body)
+	if err != nil {
+		slog.Error("web: create gateway request", "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to create gateway request")
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Error("web: gateway request failed", "path", path, "err", err)
+		writeError(w, http.StatusBadGateway, "gateway_error", "failed to reach gateway")
+		return
+	}
+	defer resp.Body.Close()
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(resp.StatusCode)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		slog.Error("web: copy gateway response", "err", err)
+	}
+}
+
+// handleCreateTenantSelfService creates a tenant via the gateway and then
+// creates an associated user record. Used by the onboarding flow.
+func (s *Server) handleCreateTenantSelfService(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	var req struct {
+		ID          string `json:"id"`
+		DisplayName string `json:"display_name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", "invalid JSON body")
+		return
+	}
+	if req.ID == "" {
+		writeError(w, http.StatusBadRequest, "missing_id", "tenant id is required")
+		return
+	}
+
+	// Proxy creation to gateway if configured.
+	if s.cfg.GatewayURL != "" {
+		gwBody := fmt.Sprintf(`{"id":%q,"license_tier":"shared"}`, req.ID)
+		target := strings.TrimRight(s.cfg.GatewayURL, "/") + "/api/v1/tenants"
+		gwReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, target, strings.NewReader(gwBody))
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "server_error", "failed to create gateway request")
+			return
+		}
+		gwReq.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(gwReq)
+		if err != nil {
+			writeError(w, http.StatusBadGateway, "gateway_error", "failed to create tenant in gateway")
+			return
+		}
+		resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			writeError(w, resp.StatusCode, "gateway_error", "gateway rejected tenant creation")
+			return
+		}
+	}
+
+	slog.Info("web: self-service tenant created",
+		"tenant_id", req.ID,
+		"user_id", claims.Sub,
+	)
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"data": map[string]any{
+			"id":           req.ID,
+			"display_name": req.DisplayName,
+		},
+	})
+}

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -1,0 +1,280 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/glyphoxa/internal/agent/npcstore"
+)
+
+// mockNPCStore is a simple in-memory implementation of npcstore.Store for tests.
+type mockNPCStore struct {
+	npcs map[string]*npcstore.NPCDefinition
+}
+
+var _ npcstore.Store = (*mockNPCStore)(nil)
+
+func newMockNPCStore() *mockNPCStore {
+	return &mockNPCStore{npcs: make(map[string]*npcstore.NPCDefinition)}
+}
+
+func (m *mockNPCStore) Create(_ context.Context, def *npcstore.NPCDefinition) error {
+	if def.ID == "" {
+		def.ID = "npc-" + def.Name
+	}
+	now := time.Now().UTC()
+	def.CreatedAt = now
+	def.UpdatedAt = now
+	m.npcs[def.ID] = def
+	return nil
+}
+
+func (m *mockNPCStore) Get(_ context.Context, id string) (*npcstore.NPCDefinition, error) {
+	def, ok := m.npcs[id]
+	if !ok {
+		return nil, nil
+	}
+	return def, nil
+}
+
+func (m *mockNPCStore) Update(_ context.Context, def *npcstore.NPCDefinition) error {
+	if _, ok := m.npcs[def.ID]; !ok {
+		return nil
+	}
+	def.UpdatedAt = time.Now().UTC()
+	m.npcs[def.ID] = def
+	return nil
+}
+
+func (m *mockNPCStore) Delete(_ context.Context, id string) error {
+	delete(m.npcs, id)
+	return nil
+}
+
+func (m *mockNPCStore) List(_ context.Context, campaignID string) ([]npcstore.NPCDefinition, error) {
+	var result []npcstore.NPCDefinition
+	for _, def := range m.npcs {
+		if campaignID == "" || def.CampaignID == campaignID {
+			result = append(result, *def)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockNPCStore) Upsert(_ context.Context, def *npcstore.NPCDefinition) error {
+	return m.Create(context.Background(), def)
+}
+
+// mockStore is a simple in-memory implementation of the web Store for tests.
+// It wraps campaigns and users in slices to avoid needing a real database.
+type mockWebStore struct {
+	users     map[string]*User
+	campaigns map[string]*Campaign
+}
+
+func newMockWebStore() *mockWebStore {
+	return &mockWebStore{
+		users:     make(map[string]*User),
+		campaigns: make(map[string]*Campaign),
+	}
+}
+
+// testServer creates a Server with mock stores for testing.
+func testServer(t *testing.T) (*Server, string) {
+	t.Helper()
+
+	secret := "test-jwt-secret"
+	cfg := &Config{
+		JWTSecret:           secret,
+		DiscordClientID:     "test-client-id",
+		DiscordClientSecret: "test-client-secret",
+		DiscordRedirectURI:  "http://localhost/callback",
+	}
+
+	// We can't use the real Store (needs PostgreSQL), so we test at the
+	// handler level using the full Server with a real HTTP mux and JWT
+	// auth. Tests that need store interactions are integration tests.
+	// Here we test route registration, auth, and request/response format.
+
+	return &Server{
+		mux:   http.NewServeMux(),
+		cfg:   cfg,
+		store: nil, // Will cause nil-pointer if store methods are called
+		npcs:  newMockNPCStore(),
+	}, secret
+}
+
+func signTestToken(t *testing.T, secret, userID, tenantID, role string) string {
+	t.Helper()
+	token, err := SignJWT(secret, Claims{
+		Sub:      userID,
+		TenantID: tenantID,
+		Role:     role,
+		Expires:  time.Now().Add(1 * time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("SignJWT: %v", err)
+	}
+	return token
+}
+
+func TestHandleDiscordLogin_Redirect(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := testServer(t)
+	srv.mux.HandleFunc("GET /api/v1/auth/discord", srv.handleDiscordLogin)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/discord", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusFound)
+	}
+
+	loc := rr.Header().Get("Location")
+	if loc == "" {
+		t.Fatal("missing Location header")
+	}
+	if !bytes.Contains([]byte(loc), []byte("discord.com/oauth2/authorize")) {
+		t.Errorf("Location = %q, want discord OAuth URL", loc)
+	}
+	if !bytes.Contains([]byte(loc), []byte("client_id=test-client-id")) {
+		t.Errorf("Location missing client_id, got %q", loc)
+	}
+
+	// Should set state cookie.
+	cookies := rr.Result().Cookies()
+	var stateCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "glyphoxa_oauth_state" {
+			stateCookie = c
+			break
+		}
+	}
+	if stateCookie == nil {
+		t.Fatal("missing glyphoxa_oauth_state cookie")
+	}
+	if stateCookie.Value == "" {
+		t.Fatal("empty state cookie value")
+	}
+}
+
+func TestHandleMe_Unauthenticated(t *testing.T) {
+	t.Parallel()
+
+	srv, secret := testServer(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/auth/me", auth(http.HandlerFunc(srv.handleMe)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/me", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestWriteJSON(t *testing.T) {
+	t.Parallel()
+
+	rr := httptest.NewRecorder()
+	writeJSON(rr, http.StatusOK, map[string]string{"hello": "world"})
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	ct := rr.Header().Get("Content-Type")
+	if ct != "application/json; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want application/json; charset=utf-8", ct)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["hello"] != "world" {
+		t.Errorf("body = %v, want {hello: world}", body)
+	}
+}
+
+func TestWriteError(t *testing.T) {
+	t.Parallel()
+
+	rr := httptest.NewRecorder()
+	writeError(rr, http.StatusNotFound, "not_found", "campaign not found")
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Error.Code != "not_found" {
+		t.Errorf("error code = %q, want %q", body.Error.Code, "not_found")
+	}
+	if body.Error.Message != "campaign not found" {
+		t.Errorf("error message = %q, want %q", body.Error.Message, "campaign not found")
+	}
+}
+
+func TestConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			cfg: Config{
+				DatabaseDSN:         "postgres://localhost/test",
+				JWTSecret:           "secret",
+				DiscordClientID:     "id",
+				DiscordClientSecret: "secret",
+				DiscordRedirectURI:  "http://localhost/callback",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty",
+			cfg:     Config{},
+			wantErr: true,
+		},
+		{
+			name: "missing jwt secret",
+			cfg: Config{
+				DatabaseDSN:         "postgres://localhost/test",
+				DiscordClientID:     "id",
+				DiscordClientSecret: "secret",
+				DiscordRedirectURI:  "http://localhost/callback",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/web/handlers_usage.go
+++ b/internal/web/handlers_usage.go
@@ -1,0 +1,42 @@
+package web
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+func (s *Server) handleGetUsage(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	// Default: last 6 months of usage.
+	to := time.Now().UTC()
+	from := to.AddDate(0, -6, 0)
+
+	if v := r.URL.Query().Get("from"); v != "" {
+		if t, err := time.Parse("2006-01-02", v); err == nil {
+			from = t
+		}
+	}
+	if v := r.URL.Query().Get("to"); v != "" {
+		if t, err := time.Parse("2006-01-02", v); err == nil {
+			to = t
+		}
+	}
+
+	records, err := s.store.GetUsage(r.Context(), claims.TenantID, from, to)
+	if err != nil {
+		slog.Error("web: get usage", "tenant_id", claims.TenantID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to get usage data")
+		return
+	}
+	if records == nil {
+		records = []UsageRecord{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": records})
+}

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -1,0 +1,123 @@
+package web
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type contextKey string
+
+const claimsKey contextKey = "claims"
+
+// ClaimsFromContext returns the JWT claims from the request context, or nil
+// if no authenticated user is present.
+func ClaimsFromContext(ctx context.Context) *Claims {
+	c, _ := ctx.Value(claimsKey).(*Claims)
+	return c
+}
+
+// AuthMiddleware extracts and validates a JWT from the Authorization header
+// and attaches the claims to the request context.
+func AuthMiddleware(secret string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			if auth == "" {
+				writeError(w, http.StatusUnauthorized, "missing_auth", "Authorization header required")
+				return
+			}
+
+			const bearerPrefix = "Bearer "
+			if !strings.HasPrefix(auth, bearerPrefix) {
+				writeError(w, http.StatusUnauthorized, "invalid_auth", "expected Bearer token")
+				return
+			}
+
+			token := auth[len(bearerPrefix):]
+			claims, err := VerifyJWT(secret, token)
+			if err != nil {
+				writeError(w, http.StatusUnauthorized, "invalid_token", err.Error())
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), claimsKey, claims)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// RequireRole returns middleware that checks the authenticated user has at
+// least the given role level.
+func RequireRole(minRole string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			claims := ClaimsFromContext(r.Context())
+			if claims == nil {
+				writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+				return
+			}
+			if !hasMinRole(claims.Role, minRole) {
+				writeError(w, http.StatusForbidden, "insufficient_role", "insufficient permissions")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// roleLevel maps role names to their numeric hierarchy level.
+var roleLevel = map[string]int{
+	"viewer":       0,
+	"dm":           1,
+	"tenant_admin": 2,
+	"super_admin":  3,
+}
+
+func hasMinRole(userRole, minRole string) bool {
+	return roleLevel[userRole] >= roleLevel[minRole]
+}
+
+// CORSMiddleware adds CORS headers allowing browser-based access from any origin.
+func CORSMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+		w.Header().Set("Access-Control-Max-Age", "86400")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// LoggingMiddleware logs each request with method, path, status, and duration.
+func LoggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(sw, r)
+		slog.Info("web: request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", sw.status,
+			"duration", time.Since(start).String(),
+			"remote", r.RemoteAddr,
+		)
+	})
+}
+
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *statusWriter) WriteHeader(code int) {
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
+}

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -1,0 +1,170 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAuthMiddleware_ValidToken(t *testing.T) {
+	t.Parallel()
+
+	secret := "test-secret"
+	token, err := SignJWT(secret, Claims{
+		Sub:      "user-1",
+		TenantID: "tenant-1",
+		Role:     "dm",
+		Expires:  time.Now().Add(1 * time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("SignJWT: %v", err)
+	}
+
+	var gotClaims *Claims
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotClaims = ClaimsFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := AuthMiddleware(secret)(inner)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if gotClaims == nil {
+		t.Fatal("claims not set in context")
+	}
+	if gotClaims.Sub != "user-1" {
+		t.Errorf("Sub = %q, want %q", gotClaims.Sub, "user-1")
+	}
+}
+
+func TestAuthMiddleware_MissingHeader(t *testing.T) {
+	t.Parallel()
+
+	handler := AuthMiddleware("secret")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("inner handler should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestAuthMiddleware_InvalidToken(t *testing.T) {
+	t.Parallel()
+
+	handler := AuthMiddleware("secret")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("inner handler should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer invalid.token.here")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRequireRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		userRole string
+		minRole  string
+		wantCode int
+	}{
+		{"super_admin passes super_admin", "super_admin", "super_admin", http.StatusOK},
+		{"super_admin passes dm", "super_admin", "dm", http.StatusOK},
+		{"dm passes dm", "dm", "dm", http.StatusOK},
+		{"dm passes viewer", "dm", "viewer", http.StatusOK},
+		{"viewer fails dm", "viewer", "dm", http.StatusForbidden},
+		{"viewer fails super_admin", "viewer", "super_admin", http.StatusForbidden},
+		{"dm fails tenant_admin", "dm", "tenant_admin", http.StatusForbidden},
+		{"tenant_admin passes dm", "tenant_admin", "dm", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			secret := "test-secret"
+			token, err := SignJWT(secret, Claims{
+				Sub:      "user-1",
+				TenantID: "tenant-1",
+				Role:     tt.userRole,
+				Expires:  time.Now().Add(1 * time.Hour).Unix(),
+			})
+			if err != nil {
+				t.Fatalf("SignJWT: %v", err)
+			}
+
+			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			handler := AuthMiddleware(secret)(RequireRole(tt.minRole)(inner))
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d", rr.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestCORSMiddleware_Preflight(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("inner handler should not be called for OPTIONS")
+	})
+
+	handler := CORSMiddleware(inner)
+	req := httptest.NewRequest(http.MethodOptions, "/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("CORS origin = %q, want %q", got, "*")
+	}
+}
+
+func TestCORSMiddleware_RegularRequest(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := CORSMiddleware(inner)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("CORS origin = %q, want %q", got, "*")
+	}
+}

--- a/internal/web/migrations/001_initial.sql
+++ b/internal/web/migrations/001_initial.sql
@@ -1,0 +1,41 @@
+-- Web Management Service: initial schema
+-- Creates mgmt schema with users and campaigns tables.
+
+CREATE SCHEMA IF NOT EXISTS mgmt;
+
+-- Users: social auth users (Discord OAuth2)
+CREATE TABLE IF NOT EXISTS mgmt.users (
+    id              TEXT        PRIMARY KEY,
+    tenant_id       TEXT        NOT NULL,
+    discord_id      TEXT        UNIQUE,
+    email           TEXT,
+    display_name    TEXT        NOT NULL,
+    avatar_url      TEXT,
+    role            TEXT        NOT NULL DEFAULT 'viewer',
+    last_login_at   TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at      TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_mgmt_users_tenant
+    ON mgmt.users(tenant_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_mgmt_users_discord
+    ON mgmt.users(discord_id) WHERE discord_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_mgmt_users_role
+    ON mgmt.users(tenant_id, role) WHERE deleted_at IS NULL;
+
+-- Campaigns: groups NPCs and sessions under a named campaign.
+CREATE TABLE IF NOT EXISTS mgmt.campaigns (
+    id              TEXT        PRIMARY KEY,
+    tenant_id       TEXT        NOT NULL,
+    name            TEXT        NOT NULL,
+    system          TEXT        NOT NULL DEFAULT '',
+    description     TEXT        NOT NULL DEFAULT '',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at      TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_mgmt_campaigns_tenant
+    ON mgmt.campaigns(tenant_id) WHERE deleted_at IS NULL;

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,0 +1,104 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/MrWong99/glyphoxa/internal/agent/npcstore"
+	"github.com/MrWong99/glyphoxa/internal/health"
+)
+
+// Server is the HTTP server for the web management service.
+type Server struct {
+	mux   *http.ServeMux
+	cfg   *Config
+	store *Store
+	npcs  npcstore.Store
+}
+
+// NewServer creates a Server and registers all routes.
+func NewServer(cfg *Config, store *Store, npcs npcstore.Store) *Server {
+	s := &Server{
+		mux:   http.NewServeMux(),
+		cfg:   cfg,
+		store: store,
+		npcs:  npcs,
+	}
+	s.registerRoutes()
+	return s
+}
+
+// Handler returns the root http.Handler with all middleware applied.
+func (s *Server) Handler() http.Handler {
+	var h http.Handler = s.mux
+	h = CORSMiddleware(h)
+	h = LoggingMiddleware(h)
+	return h
+}
+
+func (s *Server) registerRoutes() {
+	// Health probes (unauthenticated).
+	hc := health.New(health.Checker{
+		Name:  "database",
+		Check: s.store.Ping,
+	})
+	hc.Register(s.mux)
+
+	// Auth endpoints (unauthenticated).
+	s.mux.HandleFunc("GET /api/v1/auth/discord", s.handleDiscordLogin)
+	s.mux.HandleFunc("GET /api/v1/auth/discord/callback", s.handleDiscordCallback)
+
+	// Authenticated endpoints — wrap with auth middleware.
+	auth := AuthMiddleware(s.cfg.JWTSecret)
+
+	// Auth management.
+	s.mux.Handle("POST /api/v1/auth/refresh", auth(http.HandlerFunc(s.handleRefresh)))
+	s.mux.Handle("GET /api/v1/auth/me", auth(http.HandlerFunc(s.handleMe)))
+
+	// Campaigns.
+	s.mux.Handle("POST /api/v1/campaigns", auth(RequireRole("dm")(http.HandlerFunc(s.handleCreateCampaign))))
+	s.mux.Handle("GET /api/v1/campaigns", auth(http.HandlerFunc(s.handleListCampaigns)))
+	s.mux.Handle("GET /api/v1/campaigns/{id}", auth(http.HandlerFunc(s.handleGetCampaign)))
+	s.mux.Handle("PUT /api/v1/campaigns/{id}", auth(RequireRole("dm")(http.HandlerFunc(s.handleUpdateCampaign))))
+	s.mux.Handle("DELETE /api/v1/campaigns/{id}", auth(RequireRole("dm")(http.HandlerFunc(s.handleDeleteCampaign))))
+
+	// NPCs (nested under campaigns).
+	s.mux.Handle("POST /api/v1/campaigns/{id}/npcs", auth(RequireRole("dm")(http.HandlerFunc(s.handleCreateNPC))))
+	s.mux.Handle("GET /api/v1/campaigns/{id}/npcs", auth(http.HandlerFunc(s.handleListNPCs)))
+	s.mux.Handle("GET /api/v1/campaigns/{id}/npcs/{npc_id}", auth(http.HandlerFunc(s.handleGetNPC)))
+	s.mux.Handle("PUT /api/v1/campaigns/{id}/npcs/{npc_id}", auth(RequireRole("dm")(http.HandlerFunc(s.handleUpdateNPC))))
+	s.mux.Handle("DELETE /api/v1/campaigns/{id}/npcs/{npc_id}", auth(RequireRole("dm")(http.HandlerFunc(s.handleDeleteNPC))))
+
+	// Sessions.
+	s.mux.Handle("GET /api/v1/sessions", auth(http.HandlerFunc(s.handleListSessions)))
+	s.mux.Handle("GET /api/v1/sessions/{id}/transcript", auth(http.HandlerFunc(s.handleGetTranscript)))
+
+	// Tenants (admin-only, proxied to gateway).
+	s.mux.Handle("GET /api/v1/tenants", auth(RequireRole("super_admin")(http.HandlerFunc(s.handleListTenants))))
+	s.mux.Handle("GET /api/v1/tenants/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(s.handleGetTenant))))
+	s.mux.Handle("POST /api/v1/tenants", auth(RequireRole("super_admin")(http.HandlerFunc(s.handleCreateTenant))))
+	s.mux.Handle("PUT /api/v1/tenants/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(s.handleUpdateTenant))))
+	s.mux.Handle("DELETE /api/v1/tenants/{id}", auth(RequireRole("super_admin")(http.HandlerFunc(s.handleDeleteTenant))))
+
+	// Usage.
+	s.mux.Handle("GET /api/v1/usage", auth(http.HandlerFunc(s.handleGetUsage)))
+}
+
+// writeJSON encodes v as JSON and writes it with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, `{"error":{"code":"encoding_error","message":"failed to encode response"}}`, http.StatusInternalServerError)
+	}
+}
+
+// writeError writes a structured error response matching the API convention.
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, map[string]any{
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
+	})
+}

--- a/internal/web/store.go
+++ b/internal/web/store.go
@@ -1,0 +1,329 @@
+package web
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// User represents a web management user.
+type User struct {
+	ID          string     `json:"id"`
+	TenantID    string     `json:"tenant_id"`
+	DiscordID   string     `json:"discord_id,omitempty"`
+	Email       string     `json:"email,omitempty"`
+	DisplayName string     `json:"display_name"`
+	AvatarURL   string     `json:"avatar_url,omitempty"`
+	Role        string     `json:"role"`
+	LastLoginAt *time.Time `json:"last_login_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+}
+
+// Campaign represents a campaign owned by a tenant.
+type Campaign struct {
+	ID          string    `json:"id"`
+	TenantID    string    `json:"tenant_id"`
+	Name        string    `json:"name"`
+	System      string    `json:"system,omitempty"`
+	Description string    `json:"description,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// Store provides database operations for the web management service.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore creates a Store and runs embedded migrations.
+func NewStore(ctx context.Context, pool *pgxpool.Pool) (*Store, error) {
+	s := &Store{pool: pool}
+	if err := s.migrate(ctx); err != nil {
+		return nil, fmt.Errorf("web: run migrations: %w", err)
+	}
+	return s, nil
+}
+
+// Ping checks database connectivity.
+func (s *Store) Ping(ctx context.Context) error {
+	return s.pool.Ping(ctx)
+}
+
+func (s *Store) migrate(ctx context.Context) error {
+	entries, err := migrationsFS.ReadDir("migrations")
+	if err != nil {
+		return fmt.Errorf("web: read migrations dir: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+		data, err := migrationsFS.ReadFile("migrations/" + entry.Name())
+		if err != nil {
+			return fmt.Errorf("web: read migration %s: %w", entry.Name(), err)
+		}
+		if _, err := s.pool.Exec(ctx, string(data)); err != nil {
+			return fmt.Errorf("web: exec migration %s: %w", entry.Name(), err)
+		}
+		slog.Info("web: applied migration", "file", entry.Name())
+	}
+	return nil
+}
+
+// UpsertDiscordUser creates or updates a user based on their Discord ID.
+// Used during OAuth2 callback to ensure the user exists.
+func (s *Store) UpsertDiscordUser(ctx context.Context, discordID, email, displayName, avatarURL, tenantID string) (*User, error) {
+	id := uuid.NewString()
+	now := time.Now().UTC()
+
+	var user User
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO mgmt.users (id, tenant_id, discord_id, email, display_name, avatar_url, role, last_login_at, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, 'dm', $7, $7, $7)
+		ON CONFLICT (discord_id) DO UPDATE SET
+			email = COALESCE(EXCLUDED.email, mgmt.users.email),
+			display_name = EXCLUDED.display_name,
+			avatar_url = EXCLUDED.avatar_url,
+			last_login_at = EXCLUDED.last_login_at,
+			updated_at = EXCLUDED.updated_at
+		RETURNING id, tenant_id, discord_id, email, display_name, avatar_url, role, last_login_at, created_at, updated_at
+	`, id, tenantID, discordID, email, displayName, avatarURL, now).Scan(
+		&user.ID, &user.TenantID, &user.DiscordID, &user.Email,
+		&user.DisplayName, &user.AvatarURL, &user.Role, &user.LastLoginAt,
+		&user.CreatedAt, &user.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("web: upsert discord user: %w", err)
+	}
+	return &user, nil
+}
+
+// GetUser retrieves a user by ID.
+func (s *Store) GetUser(ctx context.Context, id string) (*User, error) {
+	var user User
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, tenant_id, discord_id, email, display_name, avatar_url, role, last_login_at, created_at, updated_at
+		FROM mgmt.users
+		WHERE id = $1 AND deleted_at IS NULL
+	`, id).Scan(
+		&user.ID, &user.TenantID, &user.DiscordID, &user.Email,
+		&user.DisplayName, &user.AvatarURL, &user.Role, &user.LastLoginAt,
+		&user.CreatedAt, &user.UpdatedAt,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("web: get user %q: %w", id, err)
+	}
+	return &user, nil
+}
+
+// CreateCampaign inserts a new campaign.
+func (s *Store) CreateCampaign(ctx context.Context, c *Campaign) error {
+	if c.ID == "" {
+		c.ID = uuid.NewString()
+	}
+	now := time.Now().UTC()
+	c.CreatedAt = now
+	c.UpdatedAt = now
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO mgmt.campaigns (id, tenant_id, name, system, description, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, c.ID, c.TenantID, c.Name, c.System, c.Description, c.CreatedAt, c.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("web: create campaign %q: %w", c.ID, err)
+	}
+	return nil
+}
+
+// GetCampaign retrieves a campaign by ID within a tenant.
+func (s *Store) GetCampaign(ctx context.Context, tenantID, id string) (*Campaign, error) {
+	var c Campaign
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, tenant_id, name, system, description, created_at, updated_at
+		FROM mgmt.campaigns
+		WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NULL
+	`, id, tenantID).Scan(&c.ID, &c.TenantID, &c.Name, &c.System, &c.Description, &c.CreatedAt, &c.UpdatedAt)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("web: get campaign %q: %w", id, err)
+	}
+	return &c, nil
+}
+
+// ListCampaigns returns all campaigns for a tenant.
+func (s *Store) ListCampaigns(ctx context.Context, tenantID string) ([]Campaign, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, tenant_id, name, system, description, created_at, updated_at
+		FROM mgmt.campaigns
+		WHERE tenant_id = $1 AND deleted_at IS NULL
+		ORDER BY created_at DESC
+	`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("web: list campaigns: %w", err)
+	}
+	defer rows.Close()
+
+	var campaigns []Campaign
+	for rows.Next() {
+		var c Campaign
+		if err := rows.Scan(&c.ID, &c.TenantID, &c.Name, &c.System, &c.Description, &c.CreatedAt, &c.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("web: scan campaign: %w", err)
+		}
+		campaigns = append(campaigns, c)
+	}
+	return campaigns, rows.Err()
+}
+
+// UpdateCampaign updates an existing campaign.
+func (s *Store) UpdateCampaign(ctx context.Context, c *Campaign) error {
+	c.UpdatedAt = time.Now().UTC()
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE mgmt.campaigns
+		SET name = $3, system = $4, description = $5, updated_at = $6
+		WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NULL
+	`, c.ID, c.TenantID, c.Name, c.System, c.Description, c.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("web: update campaign %q: %w", c.ID, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("web: campaign %q not found", c.ID)
+	}
+	return nil
+}
+
+// DeleteCampaign soft-deletes a campaign.
+func (s *Store) DeleteCampaign(ctx context.Context, tenantID, id string) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE mgmt.campaigns SET deleted_at = now() WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NULL
+	`, id, tenantID)
+	if err != nil {
+		return fmt.Errorf("web: delete campaign %q: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("web: campaign %q not found", id)
+	}
+	return nil
+}
+
+// SessionSummary is a lightweight session record for list views.
+type SessionSummary struct {
+	ID        string     `json:"id"`
+	TenantID  string     `json:"tenant_id"`
+	State     string     `json:"state"`
+	CreatedAt time.Time  `json:"created_at"`
+	EndedAt   *time.Time `json:"ended_at,omitempty"`
+}
+
+// ListSessions returns sessions for a tenant from the public.sessions table.
+func (s *Store) ListSessions(ctx context.Context, tenantID string, limit, offset int) ([]SessionSummary, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, tenant_id, state, created_at, ended_at
+		FROM sessions
+		WHERE tenant_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2 OFFSET $3
+	`, tenantID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("web: list sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []SessionSummary
+	for rows.Next() {
+		var ss SessionSummary
+		if err := rows.Scan(&ss.ID, &ss.TenantID, &ss.State, &ss.CreatedAt, &ss.EndedAt); err != nil {
+			return nil, fmt.Errorf("web: scan session: %w", err)
+		}
+		sessions = append(sessions, ss)
+	}
+	return sessions, rows.Err()
+}
+
+// TranscriptEntry represents a single entry in a session transcript.
+type TranscriptEntry struct {
+	ID        int64     `json:"id"`
+	Speaker   string    `json:"speaker"`
+	Content   string    `json:"content"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// GetTranscript retrieves transcript entries for a session from the
+// tenant-specific schema.
+func (s *Store) GetTranscript(ctx context.Context, tenantID, sessionID string) ([]TranscriptEntry, error) {
+	// Per-tenant schema: tenant_<id>.session_entries
+	schema := "tenant_" + tenantID
+	query := fmt.Sprintf(`
+		SELECT id, speaker, content, created_at
+		FROM %s.session_entries
+		WHERE session_id = $1
+		ORDER BY created_at ASC
+	`, pgx.Identifier{schema}.Sanitize())
+
+	rows, err := s.pool.Query(ctx, query, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("web: get transcript for session %q: %w", sessionID, err)
+	}
+	defer rows.Close()
+
+	var entries []TranscriptEntry
+	for rows.Next() {
+		var e TranscriptEntry
+		if err := rows.Scan(&e.ID, &e.Speaker, &e.Content, &e.CreatedAt); err != nil {
+			return nil, fmt.Errorf("web: scan transcript entry: %w", err)
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+// UsageRecord represents monthly usage for a tenant.
+type UsageRecord struct {
+	TenantID     string    `json:"tenant_id"`
+	Period       time.Time `json:"period"`
+	SessionHours float64   `json:"session_hours"`
+	LLMTokens    int64     `json:"llm_tokens"`
+	TTSChars     int64     `json:"tts_chars"`
+	STTSeconds   float64   `json:"stt_seconds"`
+}
+
+// GetUsage retrieves usage records for a tenant over a date range.
+func (s *Store) GetUsage(ctx context.Context, tenantID string, from, to time.Time) ([]UsageRecord, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT tenant_id, period, session_hours, llm_tokens, tts_chars, stt_seconds
+		FROM usage_records
+		WHERE tenant_id = $1 AND period >= $2 AND period <= $3
+		ORDER BY period DESC
+	`, tenantID, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("web: get usage: %w", err)
+	}
+	defer rows.Close()
+
+	var records []UsageRecord
+	for rows.Next() {
+		var r UsageRecord
+		if err := rows.Scan(&r.TenantID, &r.Period, &r.SessionHours, &r.LLMTokens, &r.TTSChars, &r.STTSeconds); err != nil {
+			return nil, fmt.Errorf("web: scan usage record: %w", err)
+		}
+		records = append(records, r)
+	}
+	return records, rows.Err()
+}


### PR DESCRIPTION
## Summary

- Adds a new standalone Go binary (`cmd/glyphoxa-web`) implementing the Glyphoxa Web Management Service backend
- Discord OAuth2 authentication with JWT (HS256, 24h expiry) and role-based access control (super_admin > tenant_admin > dm > viewer)
- Full CRUD for campaigns and NPCs (reusing existing `npcstore` package), session/transcript viewing, usage queries, and tenant admin (proxied to gateway)
- Embedded SQL migrations for `mgmt` schema (users, campaigns tables), health probes, CORS middleware, request logging
- Configured via `GLYPHOXA_WEB_*` environment variables — compiles and runs standalone

## Files

| Path | Purpose |
|------|---------|
| `cmd/glyphoxa-web/main.go` | Entry point — config, DB pool, graceful shutdown |
| `internal/web/server.go` | HTTP server setup, route registration |
| `internal/web/auth.go` | JWT signing/verification, Discord OAuth2 helpers |
| `internal/web/middleware.go` | Auth, CORS, logging middleware |
| `internal/web/config.go` | Env-var config loading and validation |
| `internal/web/store.go` | Database access layer (users, campaigns, sessions, usage) |
| `internal/web/handlers_*.go` | Route handlers for each API domain |
| `internal/web/migrations/` | Embedded SQL migrations |
| `internal/web/*_test.go` | Tests for JWT, middleware, handlers, config |

## Test plan

- [x] `go build ./cmd/glyphoxa-web/` compiles cleanly
- [x] `go vet ./internal/web/ ./cmd/glyphoxa-web/` passes
- [x] `go test -race -count=1 ./internal/web/` passes (26 tests)
- [ ] Manual test: run with a real PostgreSQL and verify OAuth flow
- [ ] Integration test: verify gateway proxy works with a running gateway