### PR TITLE
ci(web): integrate web management service into CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,5 +335,37 @@ jobs:
       - name: Install C++ runtime
         run: sudo apt-get update && sudo apt-get install -y g++
 
-      - name: Build
+      - name: Build glyphoxa
         run: go build -ldflags='-s -w' ./cmd/glyphoxa
+
+      - name: Build glyphoxa-web
+        run: go build -ldflags='-s -w' ./cmd/glyphoxa-web
+
+  # ---------------------------------------------------------------------------
+  # Web frontend: lint and build
+  # ---------------------------------------------------------------------------
+  web-frontend:
+    name: Web Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,8 +10,11 @@ permissions:
   packages: write
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Glyphoxa voice engine (main binary)
+  # ---------------------------------------------------------------------------
   docker:
-    name: Build and push
+    name: Build and push (glyphoxa)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,5 +54,53 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ---------------------------------------------------------------------------
+  # Glyphoxa web management service (Next.js frontend + Go API backend)
+  # ---------------------------------------------------------------------------
+  docker-web:
+    name: Build and push (glyphoxa-web)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta-web
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/mrwong99/glyphoxa-web
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.web
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-web.outputs.tags }}
+          labels: ${{ steps.meta-web.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,66 @@
+# =============================================================================
+# Multi-stage build for Glyphoxa Web Management Service
+# =============================================================================
+#
+# Combines the Next.js frontend (standalone mode) with the Go API backend
+# in a single image. Next.js serves the frontend on port 3000 and proxies
+# /api/* requests to the Go backend on port 8090 (via next.config.ts rewrites).
+#
+# Both processes are managed by a lightweight entrypoint script.
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage 1: Build Next.js frontend (standalone output)
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS frontend-build
+
+WORKDIR /app
+
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+
+COPY web/ ./
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage 2: Build Go backend (no CGO required)
+# ---------------------------------------------------------------------------
+FROM golang:1.26 AS backend-build
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 go build \
+    -o /out/glyphoxa-web \
+    -ldflags='-s -w' \
+    ./cmd/glyphoxa-web
+
+# ---------------------------------------------------------------------------
+# Stage 3: Final runtime image
+# ---------------------------------------------------------------------------
+FROM node:22-slim
+
+RUN groupadd -r glyphoxa && useradd -r -g glyphoxa -m glyphoxa
+
+# Copy Go backend binary.
+COPY --from=backend-build /out/glyphoxa-web /usr/local/bin/glyphoxa-web
+
+# Copy Next.js standalone server and static assets.
+COPY --from=frontend-build /app/.next/standalone /app
+COPY --from=frontend-build /app/.next/static /app/.next/static
+
+# Next.js standalone defaults to port 3000, Go backend to 8090.
+ENV HOSTNAME="0.0.0.0"
+ENV PORT=3000
+
+USER glyphoxa
+WORKDIR /app
+
+EXPOSE 3000 8090
+
+# Start Go API backend in background, Next.js frontend in foreground.
+CMD /usr/local/bin/glyphoxa-web & exec node server.js

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,15 @@
 
 export CGO_ENABLED := 1
 
-.PHONY: build test lint vet fmt check clean whisper-libs dave-libs onnx-libs install-lint proto proto-check proto-lint
+.PHONY: build build-web test lint vet fmt check clean whisper-libs dave-libs onnx-libs install-lint proto proto-check proto-lint web-install web-dev web-build web-lint
 
-# Build
+# Build voice engine
 build:
 	go build -o bin/glyphoxa ./cmd/glyphoxa
+
+# Build web management service (no CGO required)
+build-web:
+	CGO_ENABLED=0 go build -o bin/glyphoxa-web ./cmd/glyphoxa-web
 
 # Run all tests with race detector
 test:
@@ -141,6 +145,26 @@ proto-check:
 # Lint protobuf definitions.
 proto-lint:
 	buf lint
+
+# ---------------------------------------------------------------------------
+# Web frontend (Next.js)
+# ---------------------------------------------------------------------------
+
+# Install web frontend dependencies
+web-install:
+	cd web && npm ci
+
+# Run web frontend dev server
+web-dev:
+	cd web && npm run dev
+
+# Build web frontend for production
+web-build:
+	cd web && npm run build
+
+# Lint web frontend
+web-lint:
+	cd web && npm run lint
 
 # Clean build artifacts
 clean:


### PR DESCRIPTION
## Summary
- **CI workflow**: Added `web-frontend` job (Node.js 22, `npm ci`, `npm run lint`, `npm run build`) and `glyphoxa-web` Go build check alongside existing `glyphoxa` build
- **Docker workflow**: Added `docker-web` job that builds and pushes `ghcr.io/mrwong99/glyphoxa-web` multi-arch image (amd64/arm64)
- **Dockerfile.web**: Multi-stage build combining Next.js standalone frontend + Go API backend in a single image. Next.js on port 3000 proxies `/api/*` to Go backend on port 8090
- **Makefile**: Added `build-web`, `web-install`, `web-dev`, `web-build`, `web-lint` targets

## Test plan
- [ ] CI passes: Go build for `cmd/glyphoxa-web`, web frontend lint + build
- [ ] Existing CI jobs (lint, test, build for glyphoxa) still pass unmodified
- [ ] Docker image `ghcr.io/mrwong99/glyphoxa-web` builds and pushes on main merge
- [ ] `make build-web` produces `bin/glyphoxa-web` locally
- [ ] `make web-build` runs Next.js production build