### PR TITLE
docs: update documentation for Gateway Audio Bridge architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ go test -race -count=1 -run TestFunctionName ./path/to/package/...
 
 ### Package Layout
 
-- **`cmd/glyphoxa/`** — Entry point. Parses config, registers provider factories, wires `app.New()`, handles graceful shutdown (SIGINT/SIGTERM).
+- **`cmd/glyphoxa/`** — Entry point. Parses config, registers provider factories, wires `app.New()`, handles graceful shutdown (SIGINT/SIGTERM). `cmd/glyphoxa-web/` is the web management service entry point.
+- **`internal/web/`** — Web management service. Authentication (Discord OAuth2 + API key), tenant/campaign/NPC/session CRUD handlers, PostgreSQL store, middleware.
 - **`internal/`** — Application-private packages (not importable externally).
 - **`pkg/`** — Public API packages (external code may import).
 
@@ -55,12 +56,12 @@ Player speaks → **VAD** (voice activity detection) → **STT** (speech-to-text
 - **`internal/config/`** — YAML config loader with provider registry and hot-reload support.
 - **`internal/hotctx/`** — Concurrent assembly of NPC identity, recent transcript, and scene context in <50ms.
 - **`internal/mcp/`** — MCP host and tool registry with budget tiers (instant/fast/standard).
-- **`internal/gateway/`** — Multi-tenant gateway. `AdminAPI` serves tenant CRUD over HTTP. `BotManager` manages per-tenant Discord bots. `sessionorch/` orchestrates session lifecycle with PostgreSQL-backed state and license constraint enforcement. `usage/` tracks session hours and enforces quotas. `grpctransport/` implements the gateway↔worker gRPC contract; `local/` provides in-process equivalents for `--mode=full`.
+- **`internal/gateway/`** — Multi-tenant gateway. `AdminAPI` serves tenant CRUD over HTTP. `BotManager` manages per-tenant Discord bots. `sessionorch/` orchestrates session lifecycle with PostgreSQL-backed state and license constraint enforcement. `usage/` tracks session hours and enforces quotas. `audiobridge/` bridges per-session Discord voice audio to workers over gRPC. `dispatch/` creates K8s Jobs for worker pods. `grpctransport/` implements the gateway↔worker gRPC contract; `local/` provides in-process equivalents for `--mode=full`.
 - **`internal/session/`** — Voice pipeline lifecycle. `Runtime` owns the full pipeline (VAD→STT→LLM→TTS→Mixer) for a single session. `WorkerHandler` receives gRPC commands from the gateway and manages `Runtime` instances. Shared by `--mode=full` and `--mode=worker`.
 - **`internal/observe/`** — Observability. Prometheus metrics, OTel distributed traces, structured logging via `slog`. Per-tenant labels (`tenant_id`, `campaign_id`) on all telemetry. HTTP middleware for automatic instrumentation.
 - **`internal/health/`** — Health probes. `/healthz` (liveness) and `/readyz` (readiness with pluggable checkers).
 - **`internal/resilience/`** — Resilience patterns. `CircuitBreaker` (closed→open→half-open) wraps gRPC clients and provider calls.
-- **`pkg/audio/`** — `Platform`/`Connection` interfaces. Adapters: `discord/`, `webrtc/`. `mixer/` handles priority queue with barge-in detection.
+- **`pkg/audio/`** — `Platform`/`Connection` interfaces. Adapters: `discord/`, `webrtc/`, `grpcbridge/` (worker-side gRPC audio connection for distributed mode). `mixer/` handles priority queue with barge-in detection.
 - **`pkg/memory/`** — 3-layer memory: L1 (session log), L2 (semantic/vector via pgvector), L3 (knowledge graph with recursive CTEs). Backend: PostgreSQL + pgvector.
 - **`pkg/provider/`** — Provider interfaces and implementations for `llm/`, `stt/`, `tts/`, `s2s/`, `vad/`, `embeddings/`. Each has a `mock/` subdirectory.
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Glyphoxa runs in four modes via `--mode`:
 | Mode | Description |
 |------|-------------|
 | `full` (default) | Single-process, self-hosted. No admin API, config from YAML. |
-| `gateway` | Multi-tenant orchestrator. Admin API, bot management, session routing via gRPC. |
-| `worker` | Voice pipeline executor. Receives sessions from gateway, connects to Discord voice. |
+| `gateway` | Multi-tenant orchestrator. Admin API, bot management, Discord voice ownership, audio streaming to workers via gRPC AudioBridge. |
+| `worker` | Voice pipeline executor. Receives audio from gateway via gRPC, runs VAD→STT→LLM→TTS pipeline, streams NPC audio back. |
 | `mcp-gateway` | Shared MCP tool server for workers. Stateless tools over HTTP. |
 
 ## 🏗️ Architecture
@@ -103,7 +103,7 @@ make check
 
 | Component | Providers |
 |-----------|-----------|
-| **STT** | Deepgram Nova-3, whisper.cpp (local) |
+| **STT** | ElevenLabs, Deepgram Nova-3, whisper.cpp (local) |
 | **LLM** | OpenAI, Anthropic, Google Gemini, Ollama (local) — via [any-llm-go](https://github.com/mozilla-ai/any-llm-go) |
 | **TTS** | ElevenLabs, Coqui XTTS (local) |
 | **S2S** | Gemini Live, OpenAI Realtime |
@@ -167,6 +167,7 @@ Comprehensive guides for developers and contributors — see the [full documenta
 | [Audio Pipeline](docs/audio-pipeline.md) | Audio flow, VAD, engine types |
 | [Commands](docs/commands.md) | Discord slash and voice commands |
 | [Deployment](docs/deployment.md) | Docker Compose, Kubernetes / Helm, production setup |
+| [Distributed Mode](docs/distributed-mode.md) | Gateway Audio Bridge, gRPC audio streaming, K8s deployment |
 | [Multi-Tenant](docs/multi-tenant.md) | Gateway, admin API, tenant model, usage tracking |
 | [Observability](docs/observability.md) | Metrics, Grafana, health endpoints |
 | [Testing](docs/testing.md) | Test conventions and patterns |

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ New to Glyphoxa? Follow this path:
 |----------|-------------|
 | [Commands](commands.md) | Discord slash commands, voice commands, puppet mode, dashboard |
 | [Deployment](deployment.md) | Docker Compose, Kubernetes / Helm, binary modes, production checklist |
+| [Distributed Mode](distributed-mode.md) | Gateway Audio Bridge architecture, gRPC audio streaming, K8s deployment, gotchas |
 | [Multi-Tenant](multi-tenant.md) | Gateway, admin API, tenant model, session orchestration, usage tracking |
 | [Observability](observability.md) | Metrics, Prometheus, Grafana dashboards, per-tenant labels, health endpoints, alerting |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,25 +64,30 @@ Written in Go for native concurrency, every pipeline stage runs as a goroutine c
 
 ### Distributed Topology (`--mode=gateway` + `--mode=worker`)
 
-In multi-tenant deployments, the system splits into separate processes:
+In multi-tenant deployments, the system splits into separate processes connected by the **Gateway Audio Bridge**:
 
 ```
-┌─────────────────────────────────┐     ┌──────────────────────────────────┐
-│           Gateway               │     │            Worker                │
-│                                 │     │                                  │
-│  Admin API (tenant CRUD)        │     │  VAD → STT → LLM → TTS → Mixer  │
-│  Bot Manager (per-tenant bots)  │ gRPC│  Session Runtime                 │
-│  Session Orchestrator     ──────┼─────┤  Discord Voice (direct)          │
-│  Usage / Quota Tracking         │     │  MCP Tool Calls                  │
-│  Health + Metrics               │     │  Health + Metrics                │
-└─────────────────────────────────┘     └──────────────────────────────────┘
+┌──────────────────────────────────┐     ┌──────────────────────────────────┐
+│            Gateway               │     │            Worker                │
+│                                  │     │                                  │
+│  Admin API (tenant CRUD)         │     │  VAD → STT → LLM → TTS → Mixer  │
+│  Bot Manager (per-tenant bots)   │     │  Session Runtime                 │
+│  Discord Voice (VoiceManager)    │     │  grpcbridge.Connection           │
+│  Audio Bridge Server ────────────┼─────┤  (audio.Connection over gRPC)    │
+│  Session Orchestrator            │gRPC │  MCP Tool Calls                  │
+│  K8s Job Dispatcher              │     │  Health + Metrics                │
+│  Usage / Quota Tracking          │     │                                  │
+│  Health + Metrics                │     │                                  │
+└──────────────────────────────────┘     └──────────────────────────────────┘
          │                                          │
          └──── PostgreSQL (session state) ──────────┘
 ```
 
-The gateway manages tenant lifecycle and session orchestration. Workers run the voice pipeline and connect directly to Discord voice channels — audio never flows through the gateway. Control signals (start/stop/heartbeat) use gRPC. In `--mode=full`, both roles run in-process with direct function calls instead of gRPC.
+The gateway owns the Discord voice connection via disgo's `VoiceManager` and streams raw opus frames to/from workers over the `AudioBridgeService` gRPC bidirectional stream. Workers never connect to Discord directly — they receive audio through a `grpcbridge.Connection` that implements the same `audio.Connection` interface used by direct Discord connections. Control signals (start/stop/heartbeat) flow over separate `SessionWorkerService` and `SessionGatewayService` RPCs.
 
-See [Multi-Tenant Architecture](multi-tenant.md) for details.
+In `--mode=full`, both roles run in-process with direct function calls instead of gRPC, and the worker opens its own Discord voice connection.
+
+See [Multi-Tenant Architecture](multi-tenant.md) and [Distributed Mode](distributed-mode.md) for details.
 
 ---
 
@@ -213,10 +218,10 @@ The `var _ Interface = (*Impl)(nil)` line ensures the compiler checks that `*Imp
 | Interface | Package | Implementations |
 |-----------|---------|-----------------|
 | `audio.Platform` | `pkg/audio` | `discord.Platform`, `webrtc.Platform` |
-| `audio.Connection` | `pkg/audio` | `discord.Connection`, `webrtc.Connection` |
+| `audio.Connection` | `pkg/audio` | `discord.Connection`, `webrtc.Connection`, `grpcbridge.Connection` |
 | `engine.VoiceEngine` | `internal/engine` | `cascade.Engine`, `s2s.Engine`, `mock.VoiceEngine` |
 | `llm.Provider` | `pkg/provider/llm` | `anyllm.Provider`, `resilience.LLMFallback`, `mock.Provider` |
-| `stt.Provider` | `pkg/provider/stt` | `deepgram.Provider`, `whisper.Provider`, `whisper.NativeProvider`, `resilience.STTFallback`, `mock.Provider` |
+| `stt.Provider` | `pkg/provider/stt` | `elevenlabs.Provider`, `deepgram.Provider`, `whisper.Provider`, `whisper.NativeProvider`, `resilience.STTFallback`, `mock.Provider` |
 | `tts.Provider` | `pkg/provider/tts` | `elevenlabs.Provider`, `coqui.Provider`, `resilience.TTSFallback`, `mock.Provider` |
 | `s2s.Provider` | `pkg/provider/s2s` | `gemini.Provider`, `openai.Provider`, `mock.Provider` |
 | `vad.Engine` | `pkg/provider/vad` | `mock.Engine` (Silero via silero-vad-go) |

--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -180,17 +180,34 @@ providers:
 
 **When to use:** Custom web UIs, browser-based TTRPG tools, or environments where Discord is not available. Currently in alpha -- the `PeerTransport` interface abstracts the pion/webrtc integration so it can be developed independently.
 
+### 🔗 gRPC Audio Bridge Transport (`pkg/audio/grpcbridge/`)
+
+The gRPC bridge transport is used by workers in **distributed mode** (`--mode=worker`). Instead of connecting to Discord directly, the worker receives and sends opus audio frames via the gateway's `AudioBridgeService` gRPC bidirectional stream.
+
+**How it works:**
+
+| Stage | Detail |
+|---|---|
+| **Inbound** | The gateway forwards raw opus frames from its Discord voice connection over gRPC. The `grpcbridge.Connection` decodes them to PCM using per-user `gopus.Decoder` instances and demuxes by `user_id` into per-participant input channels. New participants are detected lazily as frames arrive. |
+| **Outbound** | PCM `AudioFrame` values from the mixer are converted to 48 kHz stereo, buffered to full 20ms opus frames, encoded via `gopus.Encoder`, and sent back to the gateway over the same gRPC stream. The gateway then sends them to Discord. |
+| **Handshake** | On connection, the worker sends an initial frame containing only `session_id` so the gateway can route the stream to the correct `SessionBridge`. |
+| **Flush (barge-in)** | When the mixer interrupts playback (player barge-in or mute), `Flush()` drains the local output buffer and sends a `flush` control frame to the gateway, which discards its own buffered frames. This ensures stale NPC audio stops immediately on both sides. |
+| **Lifecycle** | `Disconnect()` closes the gRPC send direction; the recv loop exits when the stream ends, closing all input channels. Safe to call multiple times. |
+
+**When to use:** This transport is used automatically in distributed mode when the worker receives a `GLYPHOXA_AUDIO_BRIDGE_ADDR` environment variable. It is transparent to the rest of the pipeline — the `grpcbridge.Connection` implements the same `audio.Connection` interface as the Discord and WebRTC transports.
+
 ### Transport Comparison
 
-| Feature | Discord | WebRTC |
-|---|---|---|
-| Provider name | `discord` | `webrtc` |
-| Codec | Opus (48 kHz stereo) | Configurable (default 48 kHz) |
-| Client | Discord app | Any WebRTC browser |
-| Config | `api_key` + `options.guild_id` | `options.stun_servers` + `options.sample_rate` |
-| Maturity | Production | Alpha |
-| Participant tracking | VoiceStateUpdate events | Explicit AddPeer/RemovePeer |
-| Multi-room | One connection per channel | One connection per room |
+| Feature | Discord | WebRTC | gRPC Audio Bridge |
+|---|---|---|---|
+| Provider name | `discord` | `webrtc` | (automatic in distributed mode) |
+| Codec | Opus (48 kHz stereo) | Configurable (default 48 kHz) | Opus (48 kHz stereo, via gateway) |
+| Client | Discord app | Any WebRTC browser | Gateway (proxies Discord) |
+| Config | `api_key` + `options.guild_id` | `options.stun_servers` + `options.sample_rate` | `GLYPHOXA_AUDIO_BRIDGE_ADDR` env var |
+| Maturity | Production | Alpha | Production |
+| Participant tracking | VoiceStateUpdate events | Explicit AddPeer/RemovePeer | Lazy via user_id in frames |
+| Multi-room | One connection per channel | One connection per room | One stream per session |
+| Barge-in support | Direct | Direct | Flush frames over gRPC |
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -86,8 +86,8 @@ The Glyphoxa binary supports four modes:
 | Mode | Flag | Description |
 |------|------|-------------|
 | Full | `--mode=full` | Single-process (default). Self-hosted, no admin API. |
-| Gateway | `--mode=gateway` | Session orchestrator with admin API. Manages bots and routes sessions. |
-| Worker | `--mode=worker` | Voice pipeline executor. Created as Kubernetes Jobs by the gateway. |
+| Gateway | `--mode=gateway` | Session orchestrator with admin API. Owns Discord voice connections and streams audio to workers via gRPC AudioBridge. Dispatches workers as K8s Jobs. |
+| Worker | `--mode=worker` | Voice pipeline executor. Receives audio from gateway via gRPC AudioBridge, runs VAD→STT→LLM→TTS→Mixer, and streams NPC audio back. Never connects to Discord directly. |
 | MCP Gateway | `--mode=mcp-gateway` | Shared tool server for all workers. |
 
 ### Quick Start (Shared Topology)
@@ -139,6 +139,7 @@ Gateway and worker pods use these environment variables (set automatically by th
 | `GLYPHOXA_GRPC_ADDR` | gateway, worker | gRPC listen address |
 | `GLYPHOXA_GATEWAY_ADDR` | worker | Gateway gRPC address for callbacks |
 | `GLYPHOXA_DATABASE_DSN` | gateway, worker | PostgreSQL connection string |
+| `GLYPHOXA_AUDIO_BRIDGE_ADDR` | worker | Gateway's AudioBridge gRPC address (enables distributed audio mode) |
 | `GLYPHOXA_MCP_GATEWAY_URL` | worker | MCP gateway HTTP URL |
 
 ### Tier-Aware Node Scheduling

--- a/docs/distributed-mode.md
+++ b/docs/distributed-mode.md
@@ -1,0 +1,403 @@
+---
+nav_order: 12
+---
+
+# Distributed Mode — Gateway Audio Bridge Architecture
+
+Glyphoxa's distributed mode splits the system into a **gateway** and one or more **workers** that communicate over gRPC. This document covers the architecture, audio flow, session lifecycle, configuration, deployment, and known gotchas.
+
+For single-process deployments, see [Deployment](deployment.md) — `--mode=full` requires no distributed configuration.
+
+---
+
+## Architecture Overview
+
+In distributed mode, three gRPC services connect the gateway and worker:
+
+```
+┌──────────────────────────────────────────────┐
+│                  Gateway                      │
+│                                               │
+│   Discord Bot (VoiceManager)                  │
+│      │                                        │
+│      ├─ joins voice channel                   │
+│      ├─ receives opus from players            │
+│      └─ sends opus to players                 │
+│      │                                        │
+│   AudioBridge Server                          │
+│      │  per-session SessionBridge             │
+│      │  toWorker chan ←── Discord audio        │
+│      │  fromWorker chan ──→ Discord audio      │
+│      │                                        │
+│   Session Orchestrator (PostgreSQL)           │
+│   K8s Job Dispatcher                          │
+│   Admin API (:8081)                           │
+│   Slash Command Handlers                      │
+└────────┬────────────┬────────────────────────┘
+         │            │
+    gRPC │     gRPC   │ AudioBridgeService
+   control│    (bidi   │ (opus stream)
+   plane  │    stream) │
+         │            │
+┌────────┴────────────┴────────────────────────┐
+│                  Worker                       │
+│                                               │
+│   grpcbridge.Connection                       │
+│      │  implements audio.Connection           │
+│      │  opus decode → PCM (per-user)          │
+│      │  PCM → opus encode (NPC output)        │
+│      │                                        │
+│   Voice Pipeline                              │
+│      VAD (Silero) → STT → LLM → TTS → Mixer  │
+│                                               │
+│   Session Runtime                             │
+│   Heartbeat Reporter                          │
+└───────────────────────────────────────────────┘
+```
+
+### Why Audio Bridge?
+
+An earlier design ("Voice State Proxy") had the gateway capture Discord voice credentials and pass them to the worker, which would then connect to Discord voice directly. This approach was abandoned because:
+
+1. **Complexity** — capturing voice credentials from Discord gateway events required intercepting `VOICE_STATE_UPDATE` and `VOICE_SERVER_UPDATE` at the right time, with fragile race conditions
+2. **Suspend/resume** — the gateway had to suspend its own voice connection before the worker could take over (causing 60-second hangs)
+3. **Slash commands** — with the worker owning voice, the gateway couldn't easily handle Discord slash commands for the same session
+
+The Audio Bridge approach is simpler: the gateway keeps the Discord voice connection permanently and transparently proxies opus frames. The worker is completely Discord-unaware — it receives PCM audio and sends PCM audio through the standard `audio.Connection` interface.
+
+---
+
+## How Voice Works
+
+### Audio Flow: Player → NPC
+
+```
+Player speaks in Discord
+    │
+    ▼
+Discord sends opus packets to gateway's VoiceManager
+    │
+    ▼
+Gateway: opus packet → SessionBridge.toWorker channel
+    │
+    ▼ (gRPC AudioBridgeService.StreamAudio)
+    │
+Worker: grpcbridge.Connection.recvLoop()
+    ├─ opus decode → PCM (per-user gopus.Decoder)
+    ├─ demux by user_id into per-participant input channels
+    ▼
+Voice Pipeline: VAD → STT → LLM → TTS → Mixer
+    │
+    ▼
+Worker: grpcbridge.Connection.sendLoop()
+    ├─ PCM → opus encode (48 kHz stereo, 20ms frames)
+    ▼ (gRPC AudioBridgeService.StreamAudio, return direction)
+    │
+Gateway: SessionBridge.fromWorker channel → Discord OpusSend
+    │
+    ▼
+All players hear the NPC
+```
+
+### Handshake
+
+When a worker starts a session, it connects to the gateway's `AudioBridgeService.StreamAudio` RPC and sends an initial frame containing only the `session_id`. The gateway has 10 seconds to receive this handshake before closing the stream. The `session_id` routes the stream to the correct `SessionBridge` that was pre-created when the gateway dispatched the session.
+
+### Barge-In and Flush
+
+When a player starts speaking while an NPC is outputting audio:
+
+1. The worker's VAD detects player speech
+2. The mixer interrupts the current NPC segment and clears the queue
+3. `grpcbridge.Connection.Flush()` drains the local output buffer
+4. A `flush` control frame is sent to the gateway over the gRPC stream
+5. The gateway's `SessionBridge.Flush()` drains all buffered frames from `fromWorker`
+6. Stale NPC audio stops playing immediately on both sides
+
+### Buffer Sizes
+
+| Buffer | Size | Purpose |
+|--------|------|---------|
+| `toWorker` | 128 frames (~2.5s) | Discord→worker, realtime pace (50 fps) |
+| `fromWorker` | 1500 frames (~30s) | Worker→Discord, handles TTS bursts (faster-than-realtime generation) |
+| Per-participant input | 64 frames | Worker-side, per-user PCM |
+| Output | 64 frames | Worker-side, NPC audio from mixer |
+
+---
+
+## How Sessions Work
+
+### Session Lifecycle
+
+```
+1. Player runs /session start in Discord
+       │
+2. Gateway slash command handler → SessionOrchestrator.ValidateAndCreate()
+   ├─ checks concurrent session limit (license tier)
+   ├─ checks monthly quota (QuotaGuard)
+   └─ creates session record in PostgreSQL (state: pending)
+       │
+3. Gateway → K8s Job Dispatcher
+   ├─ creates K8s Job from template
+   ├─ polls until pod is Ready
+   └─ returns worker pod IP + gRPC port
+       │
+4. Gateway → AudioBridge.NewSessionBridge(sessionID)
+   (pre-creates the channel pair for the gRPC stream)
+       │
+5. Gateway → VoiceManager.JoinVoiceChannel()
+   (connects bot to the player's voice channel)
+       │
+6. Gateway → Worker (gRPC): StartSession(req)
+   ├─ worker builds voice pipeline (RuntimeFactory)
+   ├─ worker connects to AudioBridgeService.StreamAudio
+   ├─ worker sends handshake frame with session_id
+   └─ worker starts VAD→STT→LLM→TTS→Mixer loop
+       │
+7. Worker → Gateway (gRPC): ReportState(session_id, ACTIVE)
+       │
+8. Audio flows bidirectionally via AudioBridgeService
+       │
+9. Player runs /session stop (or session times out)
+       │
+10. Gateway → Worker (gRPC): StopSession(session_id)
+    ├─ worker stops pipeline, disconnects audio
+    └─ worker reports state ENDED
+       │
+11. Gateway cleans up: remove bridge, disconnect voice, update DB
+```
+
+### Worker Dispatch (K8s Jobs)
+
+The `dispatch.Dispatcher` (`internal/gateway/dispatch/`) creates Kubernetes Jobs for each voice session:
+
+- **Template**: A pre-configured `batchv1.Job` with environment variables for the worker
+- **Pod readiness**: Polls until the worker pod is Running and Ready (default timeout: 120s)
+- **Address resolution**: Uses the pod IP + gRPC port (default: 50051) as the worker address
+- **Cleanup**: Gateway deletes the K8s Job when the session ends
+
+Key environment variables injected into worker pods:
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `GLYPHOXA_GRPC_ADDR` | `:50051` | Worker gRPC listen address |
+| `GLYPHOXA_GATEWAY_ADDR` | `<gateway-service>:50051` | Gateway gRPC address for callbacks |
+| `GLYPHOXA_AUDIO_BRIDGE_ADDR` | `<gateway-service>:50051` | Gateway AudioBridge address |
+| `GLYPHOXA_DATABASE_DSN` | `postgres://...` | PostgreSQL connection string |
+| `GLYPHOXA_MCP_GATEWAY_URL` | `http://...` | MCP gateway URL (optional) |
+
+### Heartbeat and Failure Detection
+
+Workers send periodic heartbeats to the gateway via `SessionGatewayService.Heartbeat`. If the heartbeat stops:
+
+- **Audio stream disconnect**: The `AudioBridgeService` detects stream closure immediately and fires `OnStreamDetach`, triggering cleanup without waiting for heartbeat timeout
+- **Heartbeat timeout**: `CleanupZombies(timeout)` transitions sessions with no heartbeat for >90 seconds to `ended` state
+- **Combined**: The audio stream detach provides fast detection; the heartbeat timeout is a safety net
+
+---
+
+## Configuration
+
+### Gateway Configuration
+
+The gateway is configured primarily through environment variables and the admin API:
+
+```yaml
+# Gateway mode
+--mode=gateway
+
+# Required environment variables:
+GLYPHOXA_ADMIN_KEY=your-secret-key      # Admin API authentication
+GLYPHOXA_GRPC_ADDR=:50051               # gRPC listen address
+GLYPHOXA_DATABASE_DSN=postgres://...     # PostgreSQL with pgvector
+```
+
+### Worker Configuration
+
+Workers receive their configuration via the `StartSessionRequest` gRPC message, which includes tenant ID, campaign ID, NPC configs, and bot token. Provider configuration (which STT/LLM/TTS to use) comes from a ConfigMap mounted into the worker pod.
+
+Example worker config (mounted as ConfigMap):
+
+```yaml
+providers:
+  vad:
+    name: silero
+    options:
+      frame_size_ms: 32   # Must be 32 for Silero with 16kHz input
+
+  stt:
+    name: elevenlabs
+    api_key: ${ELEVENLABS_API_KEY}
+    options:
+      language: de          # Must be set explicitly for non-English
+
+  llm:
+    name: gemini
+    api_key: ${GEMINI_API_KEY}
+    model: gemini-2.0-flash
+
+  tts:
+    name: elevenlabs
+    api_key: ${ELEVENLABS_API_KEY}
+
+memory:
+  postgres_dsn: ${GLYPHOXA_DATABASE_DSN}
+  embedding_dimensions: 768
+
+  embeddings:
+    name: gemini
+    api_key: ${GEMINI_API_KEY}
+    model: gemini-embedding-001
+```
+
+### NPC Configuration Format
+
+NPCs are defined in the `StartSessionRequest` and stored in PostgreSQL (`npc_definitions` table). Key fields:
+
+```yaml
+npcs:
+  - name: Heinrich
+    personality: "A gruff dwarven blacksmith..."
+    engine: cascaded          # Must be "cascaded" (not "cascade")
+    voice:
+      voice_id: "abc123..."  # voice is a struct, not a plain string
+    knowledge_scope:
+      - blacksmithing
+      - local_gossip
+    budget_tier: standard
+    gm_helper: false
+    address_only: false
+```
+
+**Common mistakes:**
+- `engine` must be `cascaded` (not `cascade`)
+- `voice` is a struct `{voice_id: "..."}`, not a plain string
+- `voice_id` must match a voice in your TTS provider (e.g., ElevenLabs voice ID)
+
+---
+
+## Known Gotchas
+
+### gRPC Context Kills Long-Lived Resources
+
+**Problem**: Using the gRPC RPC context for resources that outlive the RPC causes silent cancellation.
+
+**Solution**: Always use `context.Background()` for long-lived pipeline components (VAD sessions, STT connections, TTS streams). Only use the RPC context for the RPC call itself.
+
+```go
+// Wrong: pipeline dies when StartSession RPC returns
+pipeline := newPipeline(rpcCtx)
+
+// Right: pipeline lives until explicitly stopped
+pipeline := newPipeline(context.Background())
+```
+
+### DAVE E2EE Voice Encryption
+
+Discord's DAVE (Discord Audio Video Encryption) is mandatory since 2026-03-01. The gateway must use `safedave.NewSession` (a thread-safe wrapper around `golibdave`) when joining voice:
+
+```go
+voice.WithDaveSessionCreateFunc(safedave.NewSession)
+```
+
+Without this, the gateway will connect to voice but receive/send encrypted frames that the pipeline can't process. The symptom is silence in both directions.
+
+### VAD Frame Size Must Be 32ms
+
+Silero VAD with 16 kHz input requires `frame_size_ms: 32`. Using 30ms (the default documented elsewhere) causes a dimension mismatch in the ONNX model and panics at runtime.
+
+### STT Language Must Be Set Explicitly
+
+For non-English sessions, the STT provider's `language` option must be set explicitly:
+
+```yaml
+stt:
+  options:
+    language: de  # German
+```
+
+Without this, STT defaults to English and produces garbled transcriptions of non-English speech.
+
+### German NPC Routing: Short Word False Matches
+
+The NPC address detection router matches keywords in player speech. German articles like "der", "die", "das" can falsely match NPC names containing those substrings. Fixed by requiring a minimum 4-rune keyword length. If you define German NPCs, avoid very short names.
+
+### zhi Re-Render Drops Manual ConfigMap Edits
+
+If you deploy with `zhi` and manually edit the ConfigMap (e.g., to add NPCs), running `zhi apply` will re-render the template and overwrite your changes. Solution: add NPCs to the zhi workspace template, not the live ConfigMap.
+
+### Worker Pod DNS Resolution
+
+Worker pods dispatched as K8s Jobs may not have DNS resolution for the gateway service if the DNS entry hasn't propagated. The dispatcher uses pod IP + port directly to avoid this issue.
+
+---
+
+## Deployment on K3s
+
+This section covers the actual deployment topology used on the Glyphoxa home server (K3s at `192.168.178.44`).
+
+### Cluster Layout
+
+```
+K3s Node (192.168.178.44)
+├── glyphoxa namespace
+│   ├── Deployment: glyphoxa-gateway (1 replica)
+│   │   ├── Discord bot (VoiceManager)
+│   │   ├── Admin API (:8081)
+│   │   ├── gRPC server (:50051)
+│   │   └── AudioBridge server (same gRPC port)
+│   ├── Deployment: glyphoxa-postgres (1 replica)
+│   │   └── PostgreSQL + pgvector
+│   ├── Job: glyphoxa-session-<id> (per-session, created dynamically)
+│   │   └── Worker pod (voice pipeline)
+│   └── Service: glyphoxa-gateway (ClusterIP)
+│       ├── port 8081 → admin API
+│       └── port 50051 → gRPC (control + audio)
+```
+
+### zhi Workspace
+
+The deployment is managed by `zhi` at `~/zhi-deploy/glyphoxa-k8s`:
+
+```
+glyphoxa-k8s/
+├── workspace.yaml          # zhi workspace definition
+├── templates/
+│   ├── gateway-deployment.yaml
+│   ├── gateway-service.yaml
+│   ├── postgres-deployment.yaml
+│   ├── postgres-service.yaml
+│   ├── worker-job-template.yaml
+│   ├── configmap.yaml      # Provider config (STT, LLM, TTS, etc.)
+│   └── secrets.yaml        # API keys (sealed)
+```
+
+### Worker Job Template
+
+The gateway uses a pre-configured Job template to dispatch workers. Key aspects:
+
+- **Image**: Same image as the gateway (`ghcr.io/mrwong99/glyphoxa`)
+- **Command**: `--mode=worker`
+- **Resources**: CPU/memory limits appropriate for the voice pipeline
+- **activeDeadlineSeconds**: 14400 (4 hours max session)
+- **Environment**: Gateway address, audio bridge address, database DSN, API keys
+- **ConfigMap mount**: Provider configuration (STT language, models, etc.)
+
+---
+
+## Comparison: Full Mode vs Distributed Mode
+
+| Aspect | Full Mode (`--mode=full`) | Distributed Mode (`--mode=gateway` + `--mode=worker`) |
+|--------|--------------------------|-------------------------------------------------------|
+| Processes | Single binary | Gateway + worker(s) as separate pods |
+| Discord voice | Worker connects directly via `VoiceOnlyPlatform` | Gateway owns connection, proxies via AudioBridge |
+| audio.Connection | `discord.Connection` | `grpcbridge.Connection` |
+| Session control | `local.Client` (direct function calls) | `grpctransport.Client` (gRPC with circuit breaker) |
+| State callbacks | `local.Callback` (direct function calls) | gRPC `SessionGatewayService` |
+| Worker lifecycle | In-process | K8s Jobs (created/deleted per session) |
+| Multi-tenant | No (single config) | Yes (admin API, per-tenant bots, quota) |
+| Scaling | Vertical only | Horizontal (one worker per session) |
+
+---
+
+**See also:** [Architecture](architecture.md) · [Multi-Tenant](multi-tenant.md) · [Audio Pipeline](audio-pipeline.md) · [Deployment](deployment.md) · [Configuration](configuration.md)

--- a/docs/multi-tenant.md
+++ b/docs/multi-tenant.md
@@ -17,8 +17,8 @@ The Glyphoxa binary supports four modes via the `--mode` flag:
 | Mode | Description | Use case |
 |------|-------------|----------|
 | `full` (default) | Single-process. Gateway and worker in one binary. No admin API. Config from YAML. | Self-hosted, open-source |
-| `gateway` | Session orchestrator. Manages Discord bots, routes sessions to workers via gRPC. Serves admin API. | SaaS control plane |
-| `worker` | Voice pipeline executor. Receives session commands from gateway. Connects directly to Discord voice. | SaaS data plane |
+| `gateway` | Session orchestrator. Manages Discord bots, owns Discord voice connections, streams audio to workers via gRPC AudioBridge. Serves admin API. Dispatches K8s Jobs for workers. | SaaS control plane |
+| `worker` | Voice pipeline executor. Receives audio from gateway via gRPC AudioBridge, runs the full voice pipeline (VAD→STT→LLM→TTS→Mixer), streams NPC audio back. Never connects to Discord directly. | SaaS data plane |
 | `mcp-gateway` | Shared MCP tool server. Hosts stateless tools (dice, rules) and proxies external MCP servers over HTTP. | SaaS tool layer |
 
 In `--mode=full`, the gateway and worker contracts are satisfied by in-process function calls (`internal/gateway/local/`), so the full pipeline runs identically to distributed mode without network overhead.
@@ -147,7 +147,7 @@ The `usage.Store` tracks per-tenant resource consumption per billing period (mon
 
 ## gRPC Contract
 
-Gateway and worker communicate via two gRPC services defined in `proto/glyphoxa/v1/session.proto`:
+Gateway and worker communicate via three gRPC services defined in `proto/glyphoxa/v1/session.proto`:
 
 ### SessionWorkerService (worker exposes, gateway calls)
 
@@ -156,6 +156,20 @@ Gateway and worker communicate via two gRPC services defined in `proto/glyphoxa/
 | `StartSession` | gateway → worker | Launch voice pipeline for a session |
 | `StopSession` | gateway → worker | Tear down a running session |
 | `GetStatus` | gateway → worker | Query active session statuses |
+| `ListNPCs` | gateway → worker | List NPCs in a running session |
+| `MuteNPC` / `UnmuteNPC` | gateway → worker | Mute/unmute a specific NPC |
+| `MuteAllNPCs` / `UnmuteAllNPCs` | gateway → worker | Mute/unmute all NPCs in a session |
+| `SpeakNPC` | gateway → worker | Force an NPC to speak pre-written text |
+
+### AudioBridgeService (gateway exposes, worker calls)
+
+| RPC | Direction | Purpose |
+|-----|-----------|---------|
+| `StreamAudio` | bidirectional | Opus audio frames between gateway's Discord voice connection and worker's audio pipeline |
+
+The gateway joins Discord voice via disgo's `VoiceManager` and creates a per-session `SessionBridge` (`internal/gateway/audiobridge/`). When a worker starts, it opens a bidirectional gRPC stream to `StreamAudio`, sends a handshake frame with the `session_id`, and then receives Discord audio (gateway→worker) and sends NPC audio (worker→gateway) over the same stream. The worker uses `grpcbridge.Connection` (`pkg/audio/grpcbridge/`) which implements `audio.Connection`, so the rest of the voice pipeline is identical to direct Discord mode.
+
+Audio frames include `flush` signals for barge-in: when a player interrupts an NPC, the worker sends a flush frame and the gateway discards all buffered outgoing audio.
 
 ### SessionGatewayService (gateway exposes, worker calls)
 
@@ -166,7 +180,7 @@ Gateway and worker communicate via two gRPC services defined in `proto/glyphoxa/
 
 The gRPC client (`grpctransport.Client`) wraps all calls with a circuit breaker to prevent cascading failures when a worker becomes unreachable.
 
-In `--mode=full`, these contracts are satisfied by `local.Client` and `local.Callback` which make direct function calls with no serialisation overhead.
+In `--mode=full`, the `SessionWorkerService` and `SessionGatewayService` contracts are satisfied by `local.Client` and `local.Callback` which make direct function calls with no serialisation overhead. The AudioBridge is not used in full mode — the worker opens its own Discord voice connection directly.
 
 ---
 
@@ -217,18 +231,22 @@ L2 semantic chunks (vector embeddings) are included only for Dedicated tier expo
 | File | Description |
 |------|-------------|
 | `cmd/glyphoxa/main.go` | Mode flag parsing and dispatch |
+| `cmd/glyphoxa/worker_factory.go` | RuntimeFactory — builds voice pipeline, connects AudioBridge or direct Discord |
 | `internal/gateway/admin.go` | Admin API HTTP handlers |
 | `internal/gateway/botmanager.go` | Per-tenant bot lifecycle |
-| `internal/gateway/contract.go` | WorkerClient and GatewayCallback interfaces |
+| `internal/gateway/contract.go` | WorkerClient, NPCController, and GatewayCallback interfaces |
+| `internal/gateway/audiobridge/bridge.go` | Per-session audio bridge server (gateway-side, Discord↔gRPC) |
+| `internal/gateway/dispatch/dispatcher.go` | K8s Job dispatcher for worker pods |
 | `internal/gateway/sessionorch/orchestrator.go` | Session lifecycle and constraints |
 | `internal/gateway/usage/quota_guard.go` | Quota enforcement wrapper |
 | `internal/gateway/grpctransport/client.go` | gRPC WorkerClient with circuit breaker |
-| `internal/gateway/local/client.go` | In-process WorkerClient for full mode |
+| `internal/gateway/local/local.go` | In-process WorkerClient for full mode |
 | `internal/session/runtime.go` | Voice pipeline lifecycle |
 | `internal/session/worker_handler.go` | gRPC handler managing Runtime instances |
+| `pkg/audio/grpcbridge/connection.go` | Worker-side gRPC audio connection (implements audio.Connection) |
 | `pkg/memory/export/` | Campaign archive read/write |
 | `proto/glyphoxa/v1/session.proto` | gRPC service and message definitions |
 
 ---
 
-**See also:** [Architecture](architecture.md) · [Deployment](deployment.md) · [Observability](observability.md) · [Configuration](configuration.md)
+**See also:** [Architecture](architecture.md) · [Distributed Mode](distributed-mode.md) · [Deployment](deployment.md) · [Observability](observability.md) · [Configuration](configuration.md)

--- a/docs/plans/web-management/00-overview.md
+++ b/docs/plans/web-management/00-overview.md
@@ -1,0 +1,53 @@
+---
+title: "Web Management Service — Plan Index"
+type: overview
+status: draft
+date: 2026-03-24
+supersedes: docs/plans/2026-03-23-admin-web-ui-plan.md
+---
+
+# Web Management Service — Plan Overview
+
+This folder contains the design plans for the **Glyphoxa Web Management Service** — a separate, independently deployable service that provides self-service management for Dungeon Masters, tenant administration, NPC configuration, billing, and observability.
+
+The web management service supersedes the earlier "embedded admin web UI" plan (`docs/plans/2026-03-23-admin-web-ui-plan.md`). The key decision was to build a **separate service** rather than embedding a web UI in the gateway.
+
+---
+
+## Plan Documents
+
+| # | Document | Description |
+|---|----------|-------------|
+| 01 | [Architecture & Tech Stack](01-architecture.md) | Service architecture, tech stack (Go backend, Next.js frontend), deployment model, security boundaries. Defines the separation between web service and gateway. |
+| 02 | [API Design](02-api-design.md) | REST API endpoints, authentication flows (Discord OAuth2, API key), request/response schemas, error handling. Wraps and extends the gateway's existing Admin API. |
+| 03 | [Database Schema](03-database-schema.md) | PostgreSQL schema design in a dedicated `mgmt` schema. Tables for users, subscriptions, sessions, audit logs. Same PostgreSQL instance as gateway, cross-schema foreign keys. |
+| 04 | [Frontend Design](04-frontend-design.md) | Next.js frontend architecture, page designs, component hierarchy, interaction patterns. Self-service portal for non-technical DMs — no YAML, no CLI. |
+| 05 | [Billing & Pricing](05-billing-pricing.md) | Subscription tiers, Stripe integration, quota enforcement, self-hosted vs SaaS billing model. |
+
+## Supporting Research
+
+| Document | Description |
+|----------|-------------|
+| [Pricing Models](pricing-models.md) | Market research on TTRPG AI tool pricing ($5-15/month expected range). |
+| [Pricing Models Assessment](pricing-models-assessment.md) | Detailed assessment of pricing model options for Glyphoxa. |
+
+---
+
+## Key Design Decisions
+
+1. **Separate service, not embedded** — The web management service runs as its own binary (`cmd/glyphoxa-web/`) with its own deployment. This avoids coupling the web UI lifecycle to the gateway and allows independent scaling.
+
+2. **Same database, separate schema** — Uses the `mgmt` schema in the same PostgreSQL instance as the gateway. Cross-schema foreign keys maintain referential integrity without a second database.
+
+3. **Discord OAuth2 for DM login** — DMs authenticate via Discord OAuth2. The web service maps Discord user IDs to tenants and campaigns.
+
+4. **Gateway Admin API as backend** — The web service wraps the gateway's existing Admin API for tenant/session operations, adding authentication, rate limiting, and a user-friendly interface on top.
+
+---
+
+## Implementation Status
+
+- **Backend MVP**: `cmd/glyphoxa-web/` and `internal/web/` — initial implementation merged (auth, tenant/campaign/NPC/session handlers, PostgreSQL store)
+- **Frontend MVP**: `glyphoxa-web/` — Next.js with shadcn/ui and TanStack Query (initial scaffold)
+- **Billing**: Not yet implemented
+- **Deployment**: Not yet deployed to K3s


### PR DESCRIPTION
## Summary

- **Updated 7 existing docs** to replace outdated references to workers connecting directly to Discord voice with the current Gateway Audio Bridge architecture
- **New `docs/distributed-mode.md`** — comprehensive guide covering architecture, audio flow (with diagrams), session lifecycle, configuration examples, known gotchas, and K3s deployment
- **New `docs/plans/web-management/00-overview.md`** — index for the 5 web management plan documents + 2 research docs

## Files Changed

### Updated docs (outdated → current):
- `CLAUDE.md` — added `audiobridge/`, `dispatch/`, `grpcbridge/`, `internal/web/` to key subsystems
- `docs/architecture.md` — rewrote distributed topology diagram, added `grpcbridge.Connection` to interface table, added ElevenLabs STT
- `docs/multi-tenant.md` — updated mode descriptions, added `AudioBridgeService` to gRPC contract section, expanded key source files
- `docs/deployment.md` — updated mode descriptions, added `GLYPHOXA_AUDIO_BRIDGE_ADDR` env var
- `docs/audio-pipeline.md` — added gRPC Audio Bridge transport section with full comparison table
- `README.md` — updated mode descriptions, added ElevenLabs STT provider, added distributed mode doc link
- `docs/README.md` — added distributed mode to documentation index

### New docs:
- `docs/distributed-mode.md` — full distributed mode guide
- `docs/plans/web-management/00-overview.md` — web management plans index

## Test plan
- [ ] Verify all internal doc links resolve correctly
- [ ] Review distributed-mode.md for accuracy against source code
- [ ] Check no remaining references to "Voice State Proxy" or "connects directly to Discord voice" in updated docs