### PR TITLE
fix(web): security audit — tenant isolation, cookie security, body limits

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -146,12 +147,15 @@ func GenerateState() (string, error) {
 
 // ExchangeDiscordCode exchanges an authorization code for a Discord access token.
 func ExchangeDiscordCode(ctx context.Context, cfg DiscordOAuthConfig, code string) (string, error) {
-	data := fmt.Sprintf(
-		"client_id=%s&client_secret=%s&grant_type=authorization_code&code=%s&redirect_uri=%s",
-		cfg.ClientID, cfg.ClientSecret, code, cfg.RedirectURI,
-	)
+	data := url.Values{
+		"client_id":     {cfg.ClientID},
+		"client_secret": {cfg.ClientSecret},
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {cfg.RedirectURI},
+	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://discord.com/api/oauth2/token", strings.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://discord.com/api/oauth2/token", strings.NewReader(data.Encode()))
 	if err != nil {
 		return "", fmt.Errorf("web: create token request: %w", err)
 	}

--- a/internal/web/config.go
+++ b/internal/web/config.go
@@ -68,6 +68,8 @@ func (c *Config) Validate() error {
 	}
 	if c.JWTSecret == "" {
 		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_JWT_SECRET is required"))
+	} else if len(c.JWTSecret) < 32 {
+		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_JWT_SECRET must be at least 32 characters"))
 	}
 	if c.DiscordClientID == "" {
 		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_DISCORD_CLIENT_ID is required"))

--- a/internal/web/handlers_auth.go
+++ b/internal/web/handlers_auth.go
@@ -24,6 +24,7 @@ func (s *Server) handleDiscordLogin(w http.ResponseWriter, r *http.Request) {
 		Path:     "/",
 		MaxAge:   300, // 5 minutes
 		HttpOnly: true,
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
 

--- a/internal/web/handlers_npcs.go
+++ b/internal/web/handlers_npcs.go
@@ -10,19 +10,19 @@ import (
 
 // NPCCreateRequest is the JSON body for creating an NPC.
 type NPCCreateRequest struct {
-	ID             string            `json:"id"`
-	Name           string            `json:"name"`
-	Personality    string            `json:"personality"`
-	Engine         string            `json:"engine"`
-	Voice          npcstore.VoiceConfig `json:"voice"`
-	KnowledgeScope []string          `json:"knowledge_scope"`
-	SecretKnowledge []string         `json:"secret_knowledge"`
-	BehaviorRules  []string          `json:"behavior_rules"`
-	Tools          []string          `json:"tools"`
-	BudgetTier     string            `json:"budget_tier"`
-	GMHelper       bool              `json:"gm_helper"`
-	AddressOnly    bool              `json:"address_only"`
-	Attributes     map[string]any    `json:"attributes"`
+	ID              string               `json:"id"`
+	Name            string               `json:"name"`
+	Personality     string               `json:"personality"`
+	Engine          string               `json:"engine"`
+	Voice           npcstore.VoiceConfig `json:"voice"`
+	KnowledgeScope  []string             `json:"knowledge_scope"`
+	SecretKnowledge []string             `json:"secret_knowledge"`
+	BehaviorRules   []string             `json:"behavior_rules"`
+	Tools           []string             `json:"tools"`
+	BudgetTier      string               `json:"budget_tier"`
+	GMHelper        bool                 `json:"gm_helper"`
+	AddressOnly     bool                 `json:"address_only"`
+	Attributes      map[string]any       `json:"attributes"`
 }
 
 func (s *Server) handleCreateNPC(w http.ResponseWriter, r *http.Request) {
@@ -118,6 +118,15 @@ func (s *Server) handleGetNPC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	campaignID := r.PathValue("id")
+
+	// Verify the campaign belongs to this tenant.
+	campaign, err := s.store.GetCampaign(r.Context(), claims.TenantID, campaignID)
+	if err != nil || campaign == nil {
+		writeError(w, http.StatusNotFound, "not_found", "campaign not found")
+		return
+	}
+
 	npcID := r.PathValue("npc_id")
 	npc, err := s.npcs.Get(r.Context(), npcID)
 	if err != nil {
@@ -125,7 +134,7 @@ func (s *Server) handleGetNPC(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to get NPC")
 		return
 	}
-	if npc == nil {
+	if npc == nil || npc.CampaignID != campaignID {
 		writeError(w, http.StatusNotFound, "not_found", "NPC not found")
 		return
 	}
@@ -140,9 +149,16 @@ func (s *Server) handleUpdateNPC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	npcID := r.PathValue("npc_id")
 	campaignID := r.PathValue("id")
 
+	// Verify the campaign belongs to this tenant.
+	campaign, err := s.store.GetCampaign(r.Context(), claims.TenantID, campaignID)
+	if err != nil || campaign == nil {
+		writeError(w, http.StatusNotFound, "not_found", "campaign not found")
+		return
+	}
+
+	npcID := r.PathValue("npc_id")
 	existing, err := s.npcs.Get(r.Context(), npcID)
 	if err != nil || existing == nil {
 		writeError(w, http.StatusNotFound, "not_found", "NPC not found")
@@ -190,13 +206,30 @@ func (s *Server) handleDeleteNPC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	campaignID := r.PathValue("id")
+
+	// Verify the campaign belongs to this tenant.
+	campaign, err := s.store.GetCampaign(r.Context(), claims.TenantID, campaignID)
+	if err != nil || campaign == nil {
+		writeError(w, http.StatusNotFound, "not_found", "campaign not found")
+		return
+	}
+
 	npcID := r.PathValue("npc_id")
+
+	// Verify the NPC belongs to this campaign before deleting.
+	existing, err := s.npcs.Get(r.Context(), npcID)
+	if err != nil || existing == nil || existing.CampaignID != campaignID {
+		writeError(w, http.StatusNotFound, "not_found", "NPC not found")
+		return
+	}
+
 	if err := s.npcs.Delete(r.Context(), npcID); err != nil {
 		slog.Error("web: delete npc", "npc_id", npcID, "err", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to delete NPC")
 		return
 	}
 
-	slog.Info("web: npc deleted", "npc_id", npcID)
+	slog.Info("web: npc deleted", "npc_id", npcID, "campaign_id", campaignID)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/web/handlers_tenants.go
+++ b/internal/web/handlers_tenants.go
@@ -15,8 +15,14 @@ func (s *Server) handleListTenants(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleGetTenant proxies to the gateway admin API.
+// tenant_admin can only access their own tenant; super_admin can access any.
 func (s *Server) handleGetTenant(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
 	id := r.PathValue("id")
+	if claims != nil && claims.Role != "super_admin" && claims.TenantID != id {
+		writeError(w, http.StatusForbidden, "forbidden", "cannot access another tenant")
+		return
+	}
 	s.proxyToGateway(w, r, http.MethodGet, "/api/v1/tenants/"+id)
 }
 
@@ -26,8 +32,14 @@ func (s *Server) handleCreateTenant(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleUpdateTenant proxies to the gateway admin API.
+// tenant_admin can only update their own tenant; super_admin can update any.
 func (s *Server) handleUpdateTenant(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
 	id := r.PathValue("id")
+	if claims != nil && claims.Role != "super_admin" && claims.TenantID != id {
+		writeError(w, http.StatusForbidden, "forbidden", "cannot modify another tenant")
+		return
+	}
 	s.proxyToGatewayWithBody(w, r, http.MethodPut, "/api/v1/tenants/"+id)
 }
 

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -163,6 +163,9 @@ func TestHandleDiscordLogin_Redirect(t *testing.T) {
 	if stateCookie.Value == "" {
 		t.Fatal("empty state cookie value")
 	}
+	if !stateCookie.Secure {
+		t.Error("state cookie should have Secure flag set")
+	}
 }
 
 func TestHandleMe_Unauthenticated(t *testing.T) {
@@ -244,12 +247,23 @@ func TestConfigValidation(t *testing.T) {
 			name: "valid",
 			cfg: Config{
 				DatabaseDSN:         "postgres://localhost/test",
-				JWTSecret:           "secret",
+				JWTSecret:           "a-very-long-jwt-secret-that-is-at-least-32-chars",
 				DiscordClientID:     "id",
 				DiscordClientSecret: "secret",
 				DiscordRedirectURI:  "http://localhost/callback",
 			},
 			wantErr: false,
+		},
+		{
+			name: "jwt secret too short",
+			cfg: Config{
+				DatabaseDSN:         "postgres://localhost/test",
+				JWTSecret:           "short",
+				DiscordClientID:     "id",
+				DiscordClientSecret: "secret",
+				DiscordRedirectURI:  "http://localhost/callback",
+			},
+			wantErr: true,
 		},
 		{
 			name:    "empty",

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -96,6 +96,17 @@ func CORSMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// maxRequestBodyBytes is the maximum allowed request body size (1 MiB).
+const maxRequestBodyBytes = 1 << 20
+
+// MaxBytesMiddleware limits request body size to prevent memory exhaustion.
+func MaxBytesMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+		next.ServeHTTP(w, r)
+	})
+}
+
 // LoggingMiddleware logs each request with method, path, status, and duration.
 func LoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -31,6 +31,7 @@ func NewServer(cfg *Config, store *Store, npcs npcstore.Store) *Server {
 // Handler returns the root http.Handler with all middleware applied.
 func (s *Server) Handler() http.Handler {
 	var h http.Handler = s.mux
+	h = MaxBytesMiddleware(h)
 	h = CORSMiddleware(h)
 	h = LoggingMiddleware(h)
 	return h


### PR DESCRIPTION
## Summary

Security audit of the web management service backend (PR #95). Found and fixed 6 vulnerabilities:

**CRITICAL:**
- **NPC tenant isolation bypass** — `handleGetNPC`, `handleUpdateNPC`, `handleDeleteNPC` had no tenant verification. Any authenticated user could read/modify/delete NPCs from any tenant by knowing the UUID. Now all three handlers verify the campaign belongs to the caller's tenant before allowing NPC access.

**HIGH:**
- **OAuth state cookie missing `Secure` flag** — Cookie could be intercepted over HTTP during MITM. Added `Secure: true`.
- **No request body size limit** — Attacker could send multi-GB POST bodies to exhaust server memory. Added `MaxBytesMiddleware` (1 MiB limit).
- **Tenant endpoint authorization bypass** — `tenant_admin` role could access/modify any tenant's data via GET/PUT `/tenants/{id}`. Now restricted to own tenant (super_admin bypasses).
- **OAuth form data parameter injection** — `ExchangeDiscordCode` used `fmt.Sprintf` for form-encoded data without URL-encoding values. Replaced with `url.Values.Encode()`.

**MEDIUM:**
- **JWT secret no minimum length** — Config now rejects secrets < 32 characters to prevent brute-force attacks.

**Not fixed (MVP-acceptable):**
- CORS `Access-Control-Allow-Origin: *` — acceptable with Bearer token auth (not a CSRF vector)
- No rate limiting on auth endpoints
- No token revocation mechanism

## Test plan
- [x] All existing web package tests pass (16/16)
- [x] New test case for JWT secret minimum length validation
- [x] New assertion for Secure flag on OAuth state cookie
- [x] `go vet` clean
- [x] `gofmt` clean