### PR TITLE
fix(web): architectural hardening — CORS, timeouts, validation, testability

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -103,6 +103,13 @@ func base64URLDecode(s string) ([]byte, error) {
 	return base64.URLEncoding.DecodeString(s)
 }
 
+// discordHTTPClient is used for all outbound requests to the Discord API.
+// It enforces a 10-second timeout to prevent slow upstream responses from
+// blocking the web service indefinitely.
+var discordHTTPClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
+
 // DiscordOAuthConfig holds Discord OAuth2 configuration.
 type DiscordOAuthConfig struct {
 	ClientID     string
@@ -161,7 +168,7 @@ func ExchangeDiscordCode(ctx context.Context, cfg DiscordOAuthConfig, code strin
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := discordHTTPClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("web: exchange discord code: %w", err)
 	}
@@ -188,7 +195,7 @@ func FetchDiscordUser(ctx context.Context, accessToken string) (*DiscordUser, er
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := discordHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("web: fetch discord user: %w", err)
 	}

--- a/internal/web/config.go
+++ b/internal/web/config.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 )
 
 // Config holds all configuration for the web management service.
@@ -33,6 +34,11 @@ type Config struct {
 	// GatewayURL is the base URL of the gateway's internal admin API.
 	GatewayURL string
 
+	// AllowedOrigins is the list of origins permitted by CORS. An empty list
+	// defaults to ["*"] (allow all), which is acceptable for development but
+	// should be restricted in production.
+	AllowedOrigins []string
+
 	// ListenAddr is the address the HTTP server binds to.
 	ListenAddr string
 }
@@ -48,6 +54,15 @@ func LoadConfig() (*Config, error) {
 		DiscordRedirectURI:  os.Getenv("GLYPHOXA_WEB_DISCORD_REDIRECT_URI"),
 		GatewayURL:          os.Getenv("GLYPHOXA_WEB_GATEWAY_URL"),
 		ListenAddr:          os.Getenv("GLYPHOXA_WEB_LISTEN_ADDR"),
+	}
+
+	if origins := os.Getenv("GLYPHOXA_WEB_ALLOWED_ORIGINS"); origins != "" {
+		for _, o := range strings.Split(origins, ",") {
+			o = strings.TrimSpace(o)
+			if o != "" {
+				cfg.AllowedOrigins = append(cfg.AllowedOrigins, o)
+			}
+		}
 	}
 
 	if cfg.ListenAddr == "" {

--- a/internal/web/handlers_campaigns.go
+++ b/internal/web/handlers_campaigns.go
@@ -36,6 +36,14 @@ func (s *Server) handleCreateCampaign(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "missing_name", "name is required")
 		return
 	}
+	if len(req.Name) > 255 {
+		writeError(w, http.StatusBadRequest, "name_too_long", "name must be 255 characters or fewer")
+		return
+	}
+	if len(req.Description) > 4096 {
+		writeError(w, http.StatusBadRequest, "description_too_long", "description must be 4096 characters or fewer")
+		return
+	}
 
 	campaign := &Campaign{
 		TenantID:    claims.TenantID,

--- a/internal/web/handlers_npcs.go
+++ b/internal/web/handlers_npcs.go
@@ -50,6 +50,10 @@ func (s *Server) handleCreateNPC(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "missing_name", "name is required")
 		return
 	}
+	if len(req.Name) > 255 {
+		writeError(w, http.StatusBadRequest, "name_too_long", "name must be 255 characters or fewer")
+		return
+	}
 
 	def := &npcstore.NPCDefinition{
 		ID:              req.ID,

--- a/internal/web/handlers_tenants.go
+++ b/internal/web/handlers_tenants.go
@@ -63,7 +63,7 @@ func (s *Server) proxyToGateway(w http.ResponseWriter, r *http.Request, method, 
 		return
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := s.gatewayHC.Do(req)
 	if err != nil {
 		slog.Error("web: gateway request failed", "path", path, "err", err)
 		writeError(w, http.StatusBadGateway, "gateway_error", "failed to reach gateway")
@@ -93,7 +93,7 @@ func (s *Server) proxyToGatewayWithBody(w http.ResponseWriter, r *http.Request, 
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := s.gatewayHC.Do(req)
 	if err != nil {
 		slog.Error("web: gateway request failed", "path", path, "err", err)
 		writeError(w, http.StatusBadGateway, "gateway_error", "failed to reach gateway")

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/MrWong99/glyphoxa/internal/agent/npcstore"
 )
 
+// Compile-time assertion.
+var _ WebStore = (*mockWebStore)(nil)
+
 // mockNPCStore is a simple in-memory implementation of npcstore.Store for tests.
 type mockNPCStore struct {
 	npcs map[string]*npcstore.NPCDefinition
@@ -70,8 +73,7 @@ func (m *mockNPCStore) Upsert(_ context.Context, def *npcstore.NPCDefinition) er
 	return m.Create(context.Background(), def)
 }
 
-// mockStore is a simple in-memory implementation of the web Store for tests.
-// It wraps campaigns and users in slices to avoid needing a real database.
+// mockWebStore is a simple in-memory implementation of WebStore for tests.
 type mockWebStore struct {
 	users     map[string]*User
 	campaigns map[string]*Campaign
@@ -82,6 +84,71 @@ func newMockWebStore() *mockWebStore {
 		users:     make(map[string]*User),
 		campaigns: make(map[string]*Campaign),
 	}
+}
+
+func (m *mockWebStore) Ping(_ context.Context) error { return nil }
+
+func (m *mockWebStore) UpsertDiscordUser(_ context.Context, discordID, email, displayName, avatarURL, tenantID string) (*User, error) {
+	id := "user-" + discordID
+	u := &User{ID: id, TenantID: tenantID, DiscordID: discordID, Email: email, DisplayName: displayName, AvatarURL: avatarURL, Role: "dm"}
+	m.users[id] = u
+	return u, nil
+}
+
+func (m *mockWebStore) GetUser(_ context.Context, id string) (*User, error) {
+	u, ok := m.users[id]
+	if !ok {
+		return nil, nil
+	}
+	return u, nil
+}
+
+func (m *mockWebStore) CreateCampaign(_ context.Context, c *Campaign) error {
+	if c.ID == "" {
+		c.ID = "camp-" + c.Name
+	}
+	m.campaigns[c.ID] = c
+	return nil
+}
+
+func (m *mockWebStore) GetCampaign(_ context.Context, tenantID, id string) (*Campaign, error) {
+	c, ok := m.campaigns[id]
+	if !ok || c.TenantID != tenantID {
+		return nil, nil
+	}
+	return c, nil
+}
+
+func (m *mockWebStore) ListCampaigns(_ context.Context, tenantID string) ([]Campaign, error) {
+	var result []Campaign
+	for _, c := range m.campaigns {
+		if c.TenantID == tenantID {
+			result = append(result, *c)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockWebStore) UpdateCampaign(_ context.Context, c *Campaign) error {
+	m.campaigns[c.ID] = c
+	return nil
+}
+
+func (m *mockWebStore) DeleteCampaign(_ context.Context, tenantID, id string) error {
+	delete(m.campaigns, id)
+	return nil
+}
+
+func (m *mockWebStore) ListSessions(_ context.Context, _ string, _, _ int) ([]SessionSummary, error) {
+	return nil, nil
+}
+
+func (m *mockWebStore) GetTranscript(_ context.Context, _, _ string) ([]TranscriptEntry, error) {
+	return nil, nil
+}
+
+func (m *mockWebStore) GetUsage(_ context.Context, _ string, _, _ time.Time) ([]UsageRecord, error) {
+	return nil, nil
 }
 
 // testServer creates a Server with mock stores for testing.
@@ -96,16 +163,12 @@ func testServer(t *testing.T) (*Server, string) {
 		DiscordRedirectURI:  "http://localhost/callback",
 	}
 
-	// We can't use the real Store (needs PostgreSQL), so we test at the
-	// handler level using the full Server with a real HTTP mux and JWT
-	// auth. Tests that need store interactions are integration tests.
-	// Here we test route registration, auth, and request/response format.
-
 	return &Server{
-		mux:   http.NewServeMux(),
-		cfg:   cfg,
-		store: nil, // Will cause nil-pointer if store methods are called
-		npcs:  newMockNPCStore(),
+		mux:       http.NewServeMux(),
+		cfg:       cfg,
+		store:     newMockWebStore(),
+		npcs:      newMockNPCStore(),
+		gatewayHC: &http.Client{Timeout: 5 * time.Second},
 	}, secret
 }
 

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -77,23 +77,49 @@ var roleLevel = map[string]int{
 }
 
 func hasMinRole(userRole, minRole string) bool {
-	return roleLevel[userRole] >= roleLevel[minRole]
+	uLevel, uOK := roleLevel[userRole]
+	mLevel, mOK := roleLevel[minRole]
+	if !uOK || !mOK {
+		return false
+	}
+	return uLevel >= mLevel
 }
 
-// CORSMiddleware adds CORS headers allowing browser-based access from any origin.
-func CORSMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
-		w.Header().Set("Access-Control-Max-Age", "86400")
-
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return
+// CORSMiddleware adds CORS headers. When allowedOrigins is empty or contains
+// "*", all origins are permitted. Otherwise only listed origins receive the
+// Access-Control-Allow-Origin header and credentials are allowed.
+func CORSMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
+	allowed := make(map[string]struct{}, len(allowedOrigins))
+	allowAll := len(allowedOrigins) == 0
+	for _, o := range allowedOrigins {
+		if o == "*" {
+			allowAll = true
 		}
-		next.ServeHTTP(w, r)
-	})
+		allowed[o] = struct{}{}
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			if allowAll {
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+			} else if _, ok := allowed[origin]; ok {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+				w.Header().Set("Vary", "Origin")
+			}
+
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+			w.Header().Set("Access-Control-Max-Age", "86400")
+
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 // maxRequestBodyBytes is the maximum allowed request body size (1 MiB).

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -136,7 +136,7 @@ func TestCORSMiddleware_Preflight(t *testing.T) {
 		t.Error("inner handler should not be called for OPTIONS")
 	})
 
-	handler := CORSMiddleware(inner)
+	handler := CORSMiddleware(nil)(inner) // nil = allow all
 	req := httptest.NewRequest(http.MethodOptions, "/test", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -156,7 +156,7 @@ func TestCORSMiddleware_RegularRequest(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := CORSMiddleware(inner)
+	handler := CORSMiddleware(nil)(inner) // nil = allow all
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -166,5 +166,38 @@ func TestCORSMiddleware_RegularRequest(t *testing.T) {
 	}
 	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "*" {
 		t.Errorf("CORS origin = %q, want %q", got, "*")
+	}
+}
+
+func TestCORSMiddleware_RestrictedOrigin(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := CORSMiddleware([]string{"https://app.example.com"})(inner)
+
+	// Allowed origin.
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "https://app.example.com" {
+		t.Errorf("CORS origin = %q, want %q", got, "https://app.example.com")
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Errorf("Allow-Credentials = %q, want %q", got, "true")
+	}
+
+	// Disallowed origin.
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req2.Header.Set("Origin", "https://evil.example.com")
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, req2)
+
+	if got := rr2.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("CORS origin for disallowed = %q, want empty", got)
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -3,6 +3,7 @@ package web
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/MrWong99/glyphoxa/internal/agent/npcstore"
 	"github.com/MrWong99/glyphoxa/internal/health"
@@ -10,19 +11,23 @@ import (
 
 // Server is the HTTP server for the web management service.
 type Server struct {
-	mux   *http.ServeMux
-	cfg   *Config
-	store *Store
-	npcs  npcstore.Store
+	mux       *http.ServeMux
+	cfg       *Config
+	store     WebStore
+	npcs      npcstore.Store
+	gatewayHC *http.Client // HTTP client for gateway proxy requests.
 }
 
 // NewServer creates a Server and registers all routes.
-func NewServer(cfg *Config, store *Store, npcs npcstore.Store) *Server {
+func NewServer(cfg *Config, store WebStore, npcs npcstore.Store) *Server {
 	s := &Server{
 		mux:   http.NewServeMux(),
 		cfg:   cfg,
 		store: store,
 		npcs:  npcs,
+		gatewayHC: &http.Client{
+			Timeout: 10 * time.Second,
+		},
 	}
 	s.registerRoutes()
 	return s
@@ -32,7 +37,7 @@ func NewServer(cfg *Config, store *Store, npcs npcstore.Store) *Server {
 func (s *Server) Handler() http.Handler {
 	var h http.Handler = s.mux
 	h = MaxBytesMiddleware(h)
-	h = CORSMiddleware(h)
+	h = CORSMiddleware(s.cfg.AllowedOrigins)(h)
 	h = LoggingMiddleware(h)
 	return h
 }

--- a/internal/web/store.go
+++ b/internal/web/store.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
@@ -12,6 +13,10 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// validTenantID matches lowercase alphanumeric IDs with optional hyphens/
+// underscores — the characters safe for use in a PostgreSQL schema name.
+var validTenantID = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$`)
 
 //go:embed migrations/*.sql
 var migrationsFS embed.FS
@@ -40,6 +45,25 @@ type Campaign struct {
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 }
+
+// WebStore defines the data operations required by the web management handlers.
+// Implementations must be safe for concurrent use.
+type WebStore interface {
+	Ping(ctx context.Context) error
+	UpsertDiscordUser(ctx context.Context, discordID, email, displayName, avatarURL, tenantID string) (*User, error)
+	GetUser(ctx context.Context, id string) (*User, error)
+	CreateCampaign(ctx context.Context, c *Campaign) error
+	GetCampaign(ctx context.Context, tenantID, id string) (*Campaign, error)
+	ListCampaigns(ctx context.Context, tenantID string) ([]Campaign, error)
+	UpdateCampaign(ctx context.Context, c *Campaign) error
+	DeleteCampaign(ctx context.Context, tenantID, id string) error
+	ListSessions(ctx context.Context, tenantID string, limit, offset int) ([]SessionSummary, error)
+	GetTranscript(ctx context.Context, tenantID, sessionID string) ([]TranscriptEntry, error)
+	GetUsage(ctx context.Context, tenantID string, from, to time.Time) ([]UsageRecord, error)
+}
+
+// Compile-time assertion that *Store implements WebStore.
+var _ WebStore = (*Store)(nil)
 
 // Store provides database operations for the web management service.
 type Store struct {
@@ -268,6 +292,9 @@ type TranscriptEntry struct {
 // GetTranscript retrieves transcript entries for a session from the
 // tenant-specific schema.
 func (s *Store) GetTranscript(ctx context.Context, tenantID, sessionID string) ([]TranscriptEntry, error) {
+	if !validTenantID.MatchString(tenantID) {
+		return nil, fmt.Errorf("web: invalid tenant ID %q", tenantID)
+	}
 	// Per-tenant schema: tenant_<id>.session_entries
 	schema := "tenant_" + tenantID
 	query := fmt.Sprintf(`


### PR DESCRIPTION
## Summary

Architectural review of the web management service with direct fixes for the most impactful issues found.

### Fixes included

- **CORS origin restriction**: `Access-Control-Allow-Origin: *` replaced with configurable allowlist via `GLYPHOXA_WEB_ALLOWED_ORIGINS` env var. Restricted origins get `Credentials: true` and `Vary: Origin` headers.
- **HTTP client timeouts**: Discord API and gateway proxy calls now use dedicated `*http.Client` with 10s timeout instead of `http.DefaultClient` (which has no timeout, risking indefinite hangs).
- **Tenant ID validation**: Regex guard on tenant ID before constructing dynamic PostgreSQL schema names in `GetTranscript` — defense-in-depth alongside `pgx.Identifier.Sanitize()`.
- **Role check hardening**: `hasMinRole` now rejects unknown role strings instead of silently mapping them to level 0 (which would grant viewer-level access to invalid roles).
- **WebStore interface**: Extracted `WebStore` interface from concrete `*Store` struct so handlers are testable with mocks. Added full mock implementation in tests.
- **Input length validation**: Campaign names (255 chars), NPC names (255 chars), campaign descriptions (4096 chars).

### Larger architectural recommendations (not addressed in this PR)

1. **DB connection pool sizing** — Default pgxpool MaxConns is 4; needs explicit tuning for >100 concurrent users. Configure via DSN or `pgxpool.Config`.
2. **Rate limiting** — No per-IP/per-endpoint rate limiting; auth endpoints are DoS-able. Consider `golang.org/x/time/rate` middleware.
3. **NPC update is full-replacement** — `handleUpdateNPC` uses `NPCCreateRequest` and overwrites all fields. Should use pointer-based partial update like campaigns do.
4. **Migration versioning** — No tracking of which migrations have run; all re-execute on startup. Consider a `schema_migrations` table.
5. **Frontend: no client-side validation** — Forms have no zod/yup schema validation; NPC editor has heavy state duplication between new/edit pages.
6. **Frontend: no error UI** — Failed queries show nothing; no toast notifications for mutation results.
7. **Frontend: no pagination** — Campaign/NPC lists load everything at once; transcript renders all entries.
8. **Offset pagination** — `LIMIT/OFFSET` becomes slow at scale; consider cursor-based pagination for sessions.
9. **Observability** — No Prometheus metrics exported from the web service (unlike the gateway).

## Test plan

- [x] `go test -race -count=1 ./internal/web/...` passes
- [x] `go vet` clean
- [x] `gofmt` clean
- [ ] Verify CORS with `GLYPHOXA_WEB_ALLOWED_ORIGINS=https://app.example.com` rejects other origins
- [ ] Verify gateway proxy requests time out after 10s if gateway is unreachable