### PR TITLE
test(web): comprehensive tests for web management service

### DIFF
--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -100,6 +100,140 @@ func TestVerifyJWT_Malformed(t *testing.T) {
 	}
 }
 
+func TestClaimsValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		expires int64
+		want    bool
+	}{
+		{"future expiry", time.Now().Add(1 * time.Hour).Unix(), true},
+		{"past expiry", time.Now().Add(-1 * time.Hour).Unix(), false},
+		{"zero expiry", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := Claims{Sub: "user-1", Expires: tt.expires}
+			if got := c.Valid(); got != tt.want {
+				t.Errorf("Valid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscordUser_DisplayName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		user       DiscordUser
+		wantName   string
+	}{
+		{
+			name:     "prefers global name",
+			user:     DiscordUser{Username: "user123", GlobalName: "Cool User"},
+			wantName: "Cool User",
+		},
+		{
+			name:     "falls back to username",
+			user:     DiscordUser{Username: "user123", GlobalName: ""},
+			wantName: "user123",
+		},
+		{
+			name:     "both empty",
+			user:     DiscordUser{Username: "", GlobalName: ""},
+			wantName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.user.DisplayName(); got != tt.wantName {
+				t.Errorf("DisplayName() = %q, want %q", got, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestDiscordUser_AvatarURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		user    DiscordUser
+		wantURL string
+	}{
+		{
+			name:    "with avatar",
+			user:    DiscordUser{ID: "123456", Avatar: "abc123"},
+			wantURL: "https://cdn.discordapp.com/avatars/123456/abc123.png",
+		},
+		{
+			name:    "no avatar",
+			user:    DiscordUser{ID: "123456", Avatar: ""},
+			wantURL: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.user.AvatarURL(); got != tt.wantURL {
+				t.Errorf("AvatarURL() = %q, want %q", got, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestSignJWT_DefaultExpiration(t *testing.T) {
+	t.Parallel()
+
+	// When Expires is 0, SignJWT should set a default (24h).
+	token, err := SignJWT("secret", Claims{Sub: "user-1"})
+	if err != nil {
+		t.Fatalf("SignJWT: %v", err)
+	}
+
+	claims, err := VerifyJWT("secret", token)
+	if err != nil {
+		t.Fatalf("VerifyJWT: %v", err)
+	}
+
+	// Expires should be roughly 24h from now.
+	expectedMin := time.Now().Add(23 * time.Hour).Unix()
+	expectedMax := time.Now().Add(25 * time.Hour).Unix()
+	if claims.Expires < expectedMin || claims.Expires > expectedMax {
+		t.Errorf("Expires = %d, want within 24h from now", claims.Expires)
+	}
+}
+
+func TestSignJWT_SetsIssuerAndIssuedAt(t *testing.T) {
+	t.Parallel()
+
+	before := time.Now().Unix()
+	token, err := SignJWT("secret", Claims{Sub: "user-1", Expires: time.Now().Add(time.Hour).Unix()})
+	if err != nil {
+		t.Fatalf("SignJWT: %v", err)
+	}
+	after := time.Now().Unix()
+
+	claims, err := VerifyJWT("secret", token)
+	if err != nil {
+		t.Fatalf("VerifyJWT: %v", err)
+	}
+
+	if claims.Issuer != "glyphoxa-manage" {
+		t.Errorf("Issuer = %q, want %q", claims.Issuer, "glyphoxa-manage")
+	}
+	if claims.IssuedAt < before || claims.IssuedAt > after {
+		t.Errorf("IssuedAt = %d, want between %d and %d", claims.IssuedAt, before, after)
+	}
+}
+
 func TestGenerateState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/handlers_auth_test.go
+++ b/internal/web/handlers_auth_test.go
@@ -1,0 +1,221 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleMe_Authenticated(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/auth/me", auth(http.HandlerFunc(srv.handleMe)))
+
+	// Seed user.
+	ws.users["user-1"] = &User{
+		ID:          "user-1",
+		TenantID:    "tenant-1",
+		DiscordID:   "discord-1",
+		DisplayName: "TestUser",
+		Role:        "dm",
+	}
+
+	req := authReq(t, http.MethodGet, "/api/v1/auth/me", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data User `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data.ID != "user-1" {
+		t.Errorf("user ID = %q, want %q", body.Data.ID, "user-1")
+	}
+	if body.Data.DisplayName != "TestUser" {
+		t.Errorf("display_name = %q, want %q", body.Data.DisplayName, "TestUser")
+	}
+}
+
+func TestHandleMe_UserNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/auth/me", auth(http.HandlerFunc(srv.handleMe)))
+
+	// No user seeded — token references a nonexistent user.
+	req := authReq(t, http.MethodGet, "/api/v1/auth/me", nil, secret, "nonexistent", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleRefresh_Authenticated(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("POST /api/v1/auth/refresh", auth(http.HandlerFunc(srv.handleRefresh)))
+
+	ws.users["user-1"] = &User{
+		ID:       "user-1",
+		TenantID: "tenant-1",
+		Role:     "tenant_admin",
+	}
+
+	req := authReq(t, http.MethodPost, "/api/v1/auth/refresh", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data struct {
+			AccessToken string `json:"access_token"`
+			TokenType   string `json:"token_type"`
+			ExpiresIn   int    `json:"expires_in"`
+			User        User   `json:"user"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data.AccessToken == "" {
+		t.Error("expected non-empty access_token")
+	}
+	if body.Data.TokenType != "Bearer" {
+		t.Errorf("token_type = %q, want %q", body.Data.TokenType, "Bearer")
+	}
+	if body.Data.ExpiresIn != 86400 {
+		t.Errorf("expires_in = %d, want %d", body.Data.ExpiresIn, 86400)
+	}
+	// The refreshed token should use current DB role (tenant_admin), not the old role (dm).
+	if body.Data.User.Role != "tenant_admin" {
+		t.Errorf("refreshed user role = %q, want %q", body.Data.User.Role, "tenant_admin")
+	}
+}
+
+func TestHandleRefresh_UserNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("POST /api/v1/auth/refresh", auth(http.HandlerFunc(srv.handleRefresh)))
+
+	// No user in store.
+	req := authReq(t, http.MethodPost, "/api/v1/auth/refresh", nil, secret, "gone-user", "t1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestHandleRefresh_Unauthenticated(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("POST /api/v1/auth/refresh", auth(http.HandlerFunc(srv.handleRefresh)))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestHandleDiscordCallback_MissingState(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := testServer(t)
+	srv.mux.HandleFunc("GET /api/v1/auth/discord/callback", srv.handleDiscordCallback)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/discord/callback?code=test&state=abc", nil)
+	// No state cookie set.
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleDiscordCallback_StateMismatch(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := testServer(t)
+	srv.mux.HandleFunc("GET /api/v1/auth/discord/callback", srv.handleDiscordCallback)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/discord/callback?code=test&state=abc", nil)
+	req.AddCookie(&http.Cookie{Name: "glyphoxa_oauth_state", Value: "xyz"})
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleDiscordCallback_MissingCode(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := testServer(t)
+	srv.mux.HandleFunc("GET /api/v1/auth/discord/callback", srv.handleDiscordCallback)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/discord/callback?state=abc", nil)
+	req.AddCookie(&http.Cookie{Name: "glyphoxa_oauth_state", Value: "abc"})
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleDiscordCallback_DiscordError(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := testServer(t)
+	srv.mux.HandleFunc("GET /api/v1/auth/discord/callback", srv.handleDiscordCallback)
+
+	// The handler checks code before error, so include a code param to reach the error branch.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/discord/callback?state=abc&code=test&error=access_denied&error_description=user+denied", nil)
+	req.AddCookie(&http.Cookie{Name: "glyphoxa_oauth_state", Value: "abc"})
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error.Code != "discord_error" {
+		t.Errorf("error code = %q, want %q", body.Error.Code, "discord_error")
+	}
+}

--- a/internal/web/handlers_campaigns_test.go
+++ b/internal/web/handlers_campaigns_test.go
@@ -1,0 +1,357 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleCreateCampaign(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		body     string
+		role     string
+		wantCode int
+	}{
+		{
+			name:     "valid campaign",
+			body:     `{"name":"Rabenheim","system":"D&D 5e","description":"A dark fantasy campaign"}`,
+			role:     "dm",
+			wantCode: http.StatusCreated,
+		},
+		{
+			name:     "missing name",
+			body:     `{"system":"D&D 5e"}`,
+			role:     "dm",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "name too long",
+			body:     `{"name":"` + strings.Repeat("x", 256) + `"}`,
+			role:     "dm",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "description too long",
+			body:     `{"name":"Test","description":"` + strings.Repeat("x", 4097) + `"}`,
+			role:     "dm",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid json",
+			body:     `{not json`,
+			role:     "dm",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "minimal valid",
+			body:     `{"name":"Minimal"}`,
+			role:     "dm",
+			wantCode: http.StatusCreated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, _, _, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("POST /api/v1/campaigns", auth(RequireRole("dm")(http.HandlerFunc(srv.handleCreateCampaign))))
+
+			req := authReq(t, http.MethodPost, "/api/v1/campaigns", bytes.NewBufferString(tt.body), secret, "user-1", "tenant-1", tt.role)
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+
+			if tt.wantCode == http.StatusCreated {
+				var body struct {
+					Data Campaign `json:"data"`
+				}
+				if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if body.Data.ID == "" {
+					t.Error("expected non-empty campaign ID")
+				}
+				if body.Data.TenantID != "tenant-1" {
+					t.Errorf("tenant_id = %q, want %q", body.Data.TenantID, "tenant-1")
+				}
+			}
+		})
+	}
+}
+
+func TestHandleCreateCampaign_InsufficientRole(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("POST /api/v1/campaigns", auth(RequireRole("dm")(http.HandlerFunc(srv.handleCreateCampaign))))
+
+	req := authReq(t, http.MethodPost, "/api/v1/campaigns",
+		bytes.NewBufferString(`{"name":"Test"}`),
+		secret, "user-1", "tenant-1", "viewer")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+}
+
+func TestHandleListCampaigns(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/campaigns", auth(http.HandlerFunc(srv.handleListCampaigns)))
+
+	// Seed campaigns for two tenants.
+	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Campaign A"}
+	ws.campaigns["c2"] = &Campaign{ID: "c2", TenantID: "tenant-1", Name: "Campaign B"}
+	ws.campaigns["c3"] = &Campaign{ID: "c3", TenantID: "tenant-2", Name: "Other Tenant"}
+
+	req := authReq(t, http.MethodGet, "/api/v1/campaigns", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data []Campaign `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data) != 2 {
+		t.Errorf("got %d campaigns, want 2", len(body.Data))
+	}
+	for _, c := range body.Data {
+		if c.TenantID != "tenant-1" {
+			t.Errorf("campaign %q has tenant_id %q, want %q", c.ID, c.TenantID, "tenant-1")
+		}
+	}
+}
+
+func TestHandleListCampaigns_Empty(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/campaigns", auth(http.HandlerFunc(srv.handleListCampaigns)))
+
+	req := authReq(t, http.MethodGet, "/api/v1/campaigns", nil, secret, "user-1", "tenant-1", "viewer")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data []Campaign `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data == nil {
+		t.Error("data should be empty array, not null")
+	}
+	if len(body.Data) != 0 {
+		t.Errorf("got %d campaigns, want 0", len(body.Data))
+	}
+}
+
+func TestHandleGetCampaign(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		id       string
+		tenantID string
+		wantCode int
+	}{
+		{"found", "c1", "tenant-1", http.StatusOK},
+		{"not found", "c999", "tenant-1", http.StatusNotFound},
+		{"wrong tenant", "c1", "tenant-2", http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, ws, _, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("GET /api/v1/campaigns/{id}", auth(http.HandlerFunc(srv.handleGetCampaign)))
+			ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Found"}
+
+			req := authReq(t, http.MethodGet, "/api/v1/campaigns/"+tt.id, nil, secret, "user-1", tt.tenantID, "dm")
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d", rr.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestHandleUpdateCampaign(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		id       string
+		body     string
+		wantCode int
+		wantName string
+	}{
+		{
+			name:     "partial update name only",
+			id:       "c1",
+			body:     `{"name":"Updated"}`,
+			wantCode: http.StatusOK,
+			wantName: "Updated",
+		},
+		{
+			name:     "not found",
+			id:       "c999",
+			body:     `{"name":"X"}`,
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "invalid json",
+			id:       "c1",
+			body:     `{bad}`,
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, ws, _, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("PUT /api/v1/campaigns/{id}", auth(RequireRole("dm")(http.HandlerFunc(srv.handleUpdateCampaign))))
+
+			ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Original", System: "D&D 5e", Description: "Original desc"}
+
+			req := authReq(t, http.MethodPut, "/api/v1/campaigns/"+tt.id,
+				bytes.NewBufferString(tt.body), secret, "user-1", "tenant-1", "dm")
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+
+			if tt.wantCode == http.StatusOK && tt.wantName != "" {
+				var body struct {
+					Data Campaign `json:"data"`
+				}
+				if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if body.Data.Name != tt.wantName {
+					t.Errorf("name = %q, want %q", body.Data.Name, tt.wantName)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleUpdateCampaign_PartialFieldPreservation(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("PUT /api/v1/campaigns/{id}", auth(RequireRole("dm")(http.HandlerFunc(srv.handleUpdateCampaign))))
+
+	ws.campaigns["c1"] = &Campaign{
+		ID:          "c1",
+		TenantID:    "tenant-1",
+		Name:        "Original",
+		System:      "D&D 5e",
+		Description: "Keep this",
+	}
+
+	// Only update system, name and description should remain.
+	body := `{"system":"Pathfinder 2e"}`
+	req := authReq(t, http.MethodPut, "/api/v1/campaigns/c1",
+		bytes.NewBufferString(body), secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var resp struct {
+		Data Campaign `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Data.Name != "Original" {
+		t.Errorf("name = %q, want %q (should be preserved)", resp.Data.Name, "Original")
+	}
+	if resp.Data.System != "Pathfinder 2e" {
+		t.Errorf("system = %q, want %q", resp.Data.System, "Pathfinder 2e")
+	}
+	if resp.Data.Description != "Keep this" {
+		t.Errorf("description = %q, want %q (should be preserved)", resp.Data.Description, "Keep this")
+	}
+}
+
+func TestHandleDeleteCampaign(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("DELETE /api/v1/campaigns/{id}", auth(RequireRole("dm")(http.HandlerFunc(srv.handleDeleteCampaign))))
+
+	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "ToDelete"}
+
+	req := authReq(t, http.MethodDelete, "/api/v1/campaigns/c1", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+
+	// Verify it's gone from the store.
+	if _, ok := ws.campaigns["c1"]; ok {
+		t.Error("campaign should have been deleted from store")
+	}
+}
+
+func TestHandleDeleteCampaign_InsufficientRole(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("DELETE /api/v1/campaigns/{id}", auth(RequireRole("dm")(http.HandlerFunc(srv.handleDeleteCampaign))))
+
+	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Protected"}
+
+	req := authReq(t, http.MethodDelete, "/api/v1/campaigns/c1", nil, secret, "user-1", "tenant-1", "viewer")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+}

--- a/internal/web/handlers_npcs_test.go
+++ b/internal/web/handlers_npcs_test.go
@@ -1,0 +1,394 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/glyphoxa/internal/agent/npcstore"
+)
+
+func TestHandleCreateNPC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		body     string
+		wantCode int
+	}{
+		{
+			name:     "valid NPC",
+			body:     `{"name":"Greymantle","personality":"wise sage","engine":"cascaded"}`,
+			wantCode: http.StatusCreated,
+		},
+		{
+			name:     "missing name",
+			body:     `{"personality":"mysterious"}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "name too long",
+			body:     `{"name":"` + strings.Repeat("x", 256) + `"}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid json",
+			body:     `{bad`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "minimal valid",
+			body:     `{"name":"MinNPC"}`,
+			wantCode: http.StatusCreated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, ws, _, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("POST /api/v1/campaigns/{id}/npcs", auth(RequireRole("dm")(http.HandlerFunc(srv.handleCreateNPC))))
+
+			// Seed a campaign.
+			ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
+
+			req := authReq(t, http.MethodPost, "/api/v1/campaigns/c1/npcs",
+				bytes.NewBufferString(tt.body), secret, "user-1", "tenant-1", "dm")
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+
+			if tt.wantCode == http.StatusCreated {
+				var body struct {
+					Data npcstore.NPCDefinition `json:"data"`
+				}
+				if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if body.Data.ID == "" {
+					t.Error("expected non-empty NPC ID")
+				}
+				if body.Data.CampaignID != "c1" {
+					t.Errorf("campaign_id = %q, want %q", body.Data.CampaignID, "c1")
+				}
+			}
+		})
+	}
+}
+
+func TestHandleCreateNPC_CampaignNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("POST /api/v1/campaigns/{id}/npcs", auth(RequireRole("dm")(http.HandlerFunc(srv.handleCreateNPC))))
+
+	// No campaign seeded.
+	req := authReq(t, http.MethodPost, "/api/v1/campaigns/nonexistent/npcs",
+		bytes.NewBufferString(`{"name":"Ghost"}`), secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleCreateNPC_WrongTenant(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("POST /api/v1/campaigns/{id}/npcs", auth(RequireRole("dm")(http.HandlerFunc(srv.handleCreateNPC))))
+
+	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
+
+	// Authenticate as tenant-2.
+	req := authReq(t, http.MethodPost, "/api/v1/campaigns/c1/npcs",
+		bytes.NewBufferString(`{"name":"Intruder"}`), secret, "user-2", "tenant-2", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (campaign belongs to different tenant)", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleListNPCs(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, ns, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/campaigns/{id}/npcs", auth(http.HandlerFunc(srv.handleListNPCs)))
+
+	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
+
+	// Seed NPCs.
+	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c1", Name: "Heinrich"}
+	ns.npcs["npc-2"] = &npcstore.NPCDefinition{ID: "npc-2", CampaignID: "c1", Name: "Mathilde"}
+	ns.npcs["npc-3"] = &npcstore.NPCDefinition{ID: "npc-3", CampaignID: "c2", Name: "OtherCampaign"}
+
+	req := authReq(t, http.MethodGet, "/api/v1/campaigns/c1/npcs", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data []npcstore.NPCDefinition `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data) != 2 {
+		t.Errorf("got %d NPCs, want 2", len(body.Data))
+	}
+}
+
+func TestHandleListNPCs_EmptyReturnsArray(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/campaigns/{id}/npcs", auth(http.HandlerFunc(srv.handleListNPCs)))
+
+	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Empty"}
+
+	req := authReq(t, http.MethodGet, "/api/v1/campaigns/c1/npcs", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data []npcstore.NPCDefinition `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data == nil {
+		t.Error("data should be empty array, not null")
+	}
+}
+
+func TestHandleGetNPC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		npcID    string
+		wantCode int
+	}{
+		{"found", "npc-1", http.StatusOK},
+		{"not found", "npc-999", http.StatusNotFound},
+		{"wrong campaign", "npc-other", http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, ws, ns, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("GET /api/v1/campaigns/{id}/npcs/{npc_id}", auth(http.HandlerFunc(srv.handleGetNPC)))
+
+			ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
+			ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c1", Name: "Heinrich"}
+			ns.npcs["npc-other"] = &npcstore.NPCDefinition{ID: "npc-other", CampaignID: "c2", Name: "WrongCampaign"}
+
+			req := authReq(t, http.MethodGet, "/api/v1/campaigns/c1/npcs/"+tt.npcID, nil, secret, "user-1", "tenant-1", "dm")
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d", rr.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestHandleUpdateNPC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		npcID    string
+		body     string
+		seedNPC  bool
+		wantCode int
+	}{
+		{
+			name:     "valid update",
+			npcID:    "npc-1",
+			body:     `{"name":"NewName","personality":"Cunning"}`,
+			seedNPC:  true,
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "not found",
+			npcID:    "npc-999",
+			body:     `{"name":"X"}`,
+			seedNPC:  true,
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "invalid json",
+			npcID:    "npc-1",
+			body:     `{bad`,
+			seedNPC:  true,
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, ws, ns, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("PUT /api/v1/campaigns/{id}/npcs/{npc_id}", auth(RequireRole("dm")(http.HandlerFunc(srv.handleUpdateNPC))))
+
+			ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
+			if tt.seedNPC {
+				ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c1", Name: "OldName", Personality: "Wise"}
+			}
+
+			req := authReq(t, http.MethodPut, "/api/v1/campaigns/c1/npcs/"+tt.npcID,
+				bytes.NewBufferString(tt.body), secret, "user-1", "tenant-1", "dm")
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+
+			if tt.wantCode == http.StatusOK {
+				var body struct {
+					Data npcstore.NPCDefinition `json:"data"`
+				}
+				if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if body.Data.Name != "NewName" {
+					t.Errorf("name = %q, want %q", body.Data.Name, "NewName")
+				}
+			}
+		})
+	}
+}
+
+func TestHandleUpdateNPC_WrongCampaign(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, ns, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("PUT /api/v1/campaigns/{id}/npcs/{npc_id}", auth(RequireRole("dm")(http.HandlerFunc(srv.handleUpdateNPC))))
+
+	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Campaign1"}
+	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c2", Name: "WrongCampaign"}
+
+	req := authReq(t, http.MethodPut, "/api/v1/campaigns/c1/npcs/npc-1",
+		bytes.NewBufferString(`{"name":"Hack"}`), secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (NPC belongs to different campaign)", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleDeleteNPC(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, ns, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("DELETE /api/v1/campaigns/{id}/npcs/{npc_id}", auth(RequireRole("dm")(http.HandlerFunc(srv.handleDeleteNPC))))
+
+	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Campaign"}
+	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c1", Name: "ToDelete"}
+
+	req := authReq(t, http.MethodDelete, "/api/v1/campaigns/c1/npcs/npc-1", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+
+	if _, ok := ns.npcs["npc-1"]; ok {
+		t.Error("NPC should have been deleted from store")
+	}
+}
+
+func TestHandleDeleteNPC_NotFound(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("DELETE /api/v1/campaigns/{id}/npcs/{npc_id}", auth(RequireRole("dm")(http.HandlerFunc(srv.handleDeleteNPC))))
+
+	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Campaign"}
+
+	req := authReq(t, http.MethodDelete, "/api/v1/campaigns/c1/npcs/npc-999", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleDeleteNPC_WrongCampaign(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, ns, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("DELETE /api/v1/campaigns/{id}/npcs/{npc_id}", auth(RequireRole("dm")(http.HandlerFunc(srv.handleDeleteNPC))))
+
+	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Campaign"}
+	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c-other", Name: "WrongCampaign"}
+
+	req := authReq(t, http.MethodDelete, "/api/v1/campaigns/c1/npcs/npc-1", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+
+	// NPC should NOT have been deleted.
+	if _, ok := ns.npcs["npc-1"]; !ok {
+		t.Error("NPC should not have been deleted (wrong campaign)")
+	}
+}
+
+func TestHandleCreateNPC_InsufficientRole(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("POST /api/v1/campaigns/{id}/npcs", auth(RequireRole("dm")(http.HandlerFunc(srv.handleCreateNPC))))
+
+	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Campaign"}
+
+	req := authReq(t, http.MethodPost, "/api/v1/campaigns/c1/npcs",
+		bytes.NewBufferString(`{"name":"Blocked"}`), secret, "user-1", "tenant-1", "viewer")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+}

--- a/internal/web/handlers_sessions_test.go
+++ b/internal/web/handlers_sessions_test.go
@@ -1,0 +1,235 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHandleListSessions(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/sessions", auth(http.HandlerFunc(srv.handleListSessions)))
+
+	now := time.Now().UTC()
+	ws.sessions = []SessionSummary{
+		{ID: "s1", TenantID: "tenant-1", State: "active", CreatedAt: now},
+		{ID: "s2", TenantID: "tenant-1", State: "ended", CreatedAt: now.Add(-time.Hour)},
+		{ID: "s3", TenantID: "tenant-2", State: "active", CreatedAt: now},
+	}
+
+	req := authReq(t, http.MethodGet, "/api/v1/sessions", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data []SessionSummary `json:"data"`
+		Meta struct {
+			Page    int `json:"page"`
+			PerPage int `json:"per_page"`
+		} `json:"meta"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data) != 2 {
+		t.Errorf("got %d sessions, want 2 (tenant-1 only)", len(body.Data))
+	}
+	if body.Meta.Page != 1 {
+		t.Errorf("page = %d, want 1", body.Meta.Page)
+	}
+	if body.Meta.PerPage != 25 {
+		t.Errorf("per_page = %d, want 25 (default)", body.Meta.PerPage)
+	}
+}
+
+func TestHandleListSessions_Pagination(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/sessions", auth(http.HandlerFunc(srv.handleListSessions)))
+
+	now := time.Now().UTC()
+	for i := range 5 {
+		ws.sessions = append(ws.sessions, SessionSummary{
+			ID:        "s" + string(rune('1'+i)),
+			TenantID:  "tenant-1",
+			State:     "ended",
+			CreatedAt: now.Add(-time.Duration(i) * time.Hour),
+		})
+	}
+
+	// Page 1, 2 per page.
+	req := authReq(t, http.MethodGet, "/api/v1/sessions?per_page=2&page=1", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data []SessionSummary `json:"data"`
+		Meta struct {
+			Page    int `json:"page"`
+			PerPage int `json:"per_page"`
+		} `json:"meta"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data) != 2 {
+		t.Errorf("got %d sessions, want 2", len(body.Data))
+	}
+	if body.Meta.PerPage != 2 {
+		t.Errorf("per_page = %d, want 2", body.Meta.PerPage)
+	}
+
+	// Page 3, 2 per page — should get 1 result.
+	req2 := authReq(t, http.MethodGet, "/api/v1/sessions?per_page=2&page=3", nil, secret, "user-1", "tenant-1", "dm")
+	rr2 := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr2, req2)
+
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr2.Code, http.StatusOK)
+	}
+
+	var body2 struct {
+		Data []SessionSummary `json:"data"`
+	}
+	if err := json.NewDecoder(rr2.Body).Decode(&body2); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body2.Data) != 1 {
+		t.Errorf("got %d sessions on page 3, want 1", len(body2.Data))
+	}
+}
+
+func TestHandleListSessions_Empty(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/sessions", auth(http.HandlerFunc(srv.handleListSessions)))
+
+	req := authReq(t, http.MethodGet, "/api/v1/sessions", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data []SessionSummary `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data == nil {
+		t.Error("data should be empty array, not null")
+	}
+}
+
+func TestHandleListSessions_DefaultPagination(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/sessions", auth(http.HandlerFunc(srv.handleListSessions)))
+
+	// Invalid pagination values should use defaults.
+	req := authReq(t, http.MethodGet, "/api/v1/sessions?per_page=-1&page=0", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Meta struct {
+			Page    int `json:"page"`
+			PerPage int `json:"per_page"`
+		} `json:"meta"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Meta.Page != 1 {
+		t.Errorf("page = %d, want 1 (default)", body.Meta.Page)
+	}
+	if body.Meta.PerPage != 25 {
+		t.Errorf("per_page = %d, want 25 (default)", body.Meta.PerPage)
+	}
+}
+
+func TestHandleGetTranscript(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/sessions/{id}/transcript", auth(http.HandlerFunc(srv.handleGetTranscript)))
+
+	now := time.Now().UTC()
+	ws.transcripts["session-1"] = []TranscriptEntry{
+		{ID: 1, Speaker: "Heinrich", Content: "Willkommen!", CreatedAt: now},
+		{ID: 2, Speaker: "Player", Content: "Hello there", CreatedAt: now.Add(time.Second)},
+	}
+
+	req := authReq(t, http.MethodGet, "/api/v1/sessions/session-1/transcript", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data []TranscriptEntry `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data) != 2 {
+		t.Errorf("got %d entries, want 2", len(body.Data))
+	}
+	if body.Data[0].Speaker != "Heinrich" {
+		t.Errorf("first speaker = %q, want %q", body.Data[0].Speaker, "Heinrich")
+	}
+}
+
+func TestHandleGetTranscript_Empty(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/sessions/{id}/transcript", auth(http.HandlerFunc(srv.handleGetTranscript)))
+
+	req := authReq(t, http.MethodGet, "/api/v1/sessions/no-session/transcript", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data []TranscriptEntry `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data == nil {
+		t.Error("data should be empty array, not null")
+	}
+}

--- a/internal/web/handlers_tenants_test.go
+++ b/internal/web/handlers_tenants_test.go
@@ -1,0 +1,355 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestTenantHandlers_NoGateway(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"list tenants", http.MethodGet, "/api/v1/tenants", ""},
+		{"get tenant", http.MethodGet, "/api/v1/tenants/t1", ""},
+		{"create tenant", http.MethodPost, "/api/v1/tenants", `{"id":"t1"}`},
+		{"update tenant", http.MethodPut, "/api/v1/tenants/t1", `{"display_name":"New"}`},
+		{"delete tenant", http.MethodDelete, "/api/v1/tenants/t1", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, _, _, secret := testServerWithStores(t)
+			// No GatewayURL configured.
+			auth := AuthMiddleware(secret)
+
+			// Register all tenant routes.
+			srv.mux.Handle("GET /api/v1/tenants", auth(RequireRole("super_admin")(http.HandlerFunc(srv.handleListTenants))))
+			srv.mux.Handle("GET /api/v1/tenants/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(srv.handleGetTenant))))
+			srv.mux.Handle("POST /api/v1/tenants", auth(RequireRole("super_admin")(http.HandlerFunc(srv.handleCreateTenant))))
+			srv.mux.Handle("PUT /api/v1/tenants/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(srv.handleUpdateTenant))))
+			srv.mux.Handle("DELETE /api/v1/tenants/{id}", auth(RequireRole("super_admin")(http.HandlerFunc(srv.handleDeleteTenant))))
+
+			var body io.Reader
+			if tt.body != "" {
+				body = bytes.NewBufferString(tt.body)
+			}
+			req := httptest.NewRequest(tt.method, tt.path, body)
+			token := signTestToken(t, secret, "user-1", "t1", "super_admin")
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusServiceUnavailable {
+				t.Errorf("status = %d, want %d (no gateway configured)", rr.Code, http.StatusServiceUnavailable)
+			}
+		})
+	}
+}
+
+func TestTenantHandlers_ProxyToGateway(t *testing.T) {
+	t.Parallel()
+
+	// Start a fake gateway server. Use t.Cleanup so it stays alive for parallel subtests.
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/tenants":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{{"id": "t1"}}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/tenants/t1":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]string{"id": "t1"}})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/tenants":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]string{"id": "new-t"}})
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v1/tenants/t1":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]string{"id": "t1"}})
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/tenants/t1":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(gateway.Close)
+
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		body     string
+		wantCode int
+	}{
+		{"list tenants", http.MethodGet, "/api/v1/tenants", "", http.StatusOK},
+		{"get tenant", http.MethodGet, "/api/v1/tenants/t1", "", http.StatusOK},
+		{"create tenant", http.MethodPost, "/api/v1/tenants", `{"id":"new-t"}`, http.StatusCreated},
+		{"update tenant", http.MethodPut, "/api/v1/tenants/t1", `{"display_name":"Upd"}`, http.StatusOK},
+		{"delete tenant", http.MethodDelete, "/api/v1/tenants/t1", "", http.StatusNoContent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, _, _, secret := testServerWithStores(t)
+			srv.cfg.GatewayURL = gateway.URL
+			srv.gatewayHC = &http.Client{Timeout: 5 * time.Second}
+
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("GET /api/v1/tenants", auth(RequireRole("super_admin")(http.HandlerFunc(srv.handleListTenants))))
+			srv.mux.Handle("GET /api/v1/tenants/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(srv.handleGetTenant))))
+			srv.mux.Handle("POST /api/v1/tenants", auth(RequireRole("super_admin")(http.HandlerFunc(srv.handleCreateTenant))))
+			srv.mux.Handle("PUT /api/v1/tenants/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(srv.handleUpdateTenant))))
+			srv.mux.Handle("DELETE /api/v1/tenants/{id}", auth(RequireRole("super_admin")(http.HandlerFunc(srv.handleDeleteTenant))))
+
+			var body io.Reader
+			if tt.body != "" {
+				body = bytes.NewBufferString(tt.body)
+			}
+			req := httptest.NewRequest(tt.method, tt.path, body)
+			token := signTestToken(t, secret, "user-1", "t1", "super_admin")
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleGetTenant_TenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{"data": map[string]string{"id": "t1"}})
+	}))
+	t.Cleanup(gateway.Close)
+
+	tests := []struct {
+		name     string
+		userTID  string
+		role     string
+		targetID string
+		wantCode int
+	}{
+		{"tenant_admin own tenant", "t1", "tenant_admin", "t1", http.StatusOK},
+		{"tenant_admin other tenant", "t1", "tenant_admin", "t2", http.StatusForbidden},
+		{"super_admin any tenant", "t1", "super_admin", "t2", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, _, _, secret := testServerWithStores(t)
+			srv.cfg.GatewayURL = gateway.URL
+			srv.gatewayHC = &http.Client{Timeout: 5 * time.Second}
+
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("GET /api/v1/tenants/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(srv.handleGetTenant))))
+
+			req := authReq(t, http.MethodGet, "/api/v1/tenants/"+tt.targetID, nil, secret, "user-1", tt.userTID, tt.role)
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d", rr.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestHandleUpdateTenant_TenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{"data": map[string]string{"id": "t1"}})
+	}))
+	t.Cleanup(gateway.Close)
+
+	tests := []struct {
+		name     string
+		userTID  string
+		role     string
+		targetID string
+		wantCode int
+	}{
+		{"tenant_admin own tenant", "t1", "tenant_admin", "t1", http.StatusOK},
+		{"tenant_admin other tenant", "t1", "tenant_admin", "t2", http.StatusForbidden},
+		{"super_admin any tenant", "t1", "super_admin", "t2", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, _, _, secret := testServerWithStores(t)
+			srv.cfg.GatewayURL = gateway.URL
+			srv.gatewayHC = &http.Client{Timeout: 5 * time.Second}
+
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("PUT /api/v1/tenants/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(srv.handleUpdateTenant))))
+
+			req := authReq(t, http.MethodPut, "/api/v1/tenants/"+tt.targetID,
+				bytes.NewBufferString(`{"display_name":"Test"}`), secret, "user-1", tt.userTID, tt.role)
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d", rr.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestHandleCreateTenantSelfService(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		body     string
+		wantCode int
+	}{
+		{
+			name:     "valid creation",
+			body:     `{"id":"new-tenant","display_name":"New Tenant"}`,
+			wantCode: http.StatusCreated,
+		},
+		{
+			name:     "missing id",
+			body:     `{"display_name":"NoID"}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid json",
+			body:     `{bad`,
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, _, _, secret := testServerWithStores(t)
+			// No GatewayURL — self-service should still work, just skip the gateway proxy.
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("POST /api/v1/tenants/self-service", auth(http.HandlerFunc(srv.handleCreateTenantSelfService)))
+
+			req := authReq(t, http.MethodPost, "/api/v1/tenants/self-service",
+				bytes.NewBufferString(tt.body), secret, "user-1", "default", "dm")
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleCreateTenantSelfService_WithGateway(t *testing.T) {
+	t.Parallel()
+
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/tenants" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(gateway.Close)
+
+	srv, _, _, secret := testServerWithStores(t)
+	srv.cfg.GatewayURL = gateway.URL
+
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("POST /api/v1/tenants/self-service", auth(http.HandlerFunc(srv.handleCreateTenantSelfService)))
+
+	req := authReq(t, http.MethodPost, "/api/v1/tenants/self-service",
+		bytes.NewBufferString(`{"id":"gw-tenant","display_name":"Gateway Tenant"}`), secret, "user-1", "default", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusCreated)
+	}
+
+	var body struct {
+		Data struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"display_name"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data.ID != "gw-tenant" {
+		t.Errorf("id = %q, want %q", body.Data.ID, "gw-tenant")
+	}
+}
+
+func TestTenantHandlers_InsufficientRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		role   string
+	}{
+		{"list requires super_admin", http.MethodGet, "/api/v1/tenants", "tenant_admin"},
+		{"create requires super_admin", http.MethodPost, "/api/v1/tenants", "tenant_admin"},
+		{"delete requires super_admin", http.MethodDelete, "/api/v1/tenants/t1", "tenant_admin"},
+		{"get requires tenant_admin", http.MethodGet, "/api/v1/tenants/t1", "dm"},
+		{"update requires tenant_admin", http.MethodPut, "/api/v1/tenants/t1", "dm"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, _, _, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+
+			srv.mux.Handle("GET /api/v1/tenants", auth(RequireRole("super_admin")(http.HandlerFunc(srv.handleListTenants))))
+			srv.mux.Handle("GET /api/v1/tenants/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(srv.handleGetTenant))))
+			srv.mux.Handle("POST /api/v1/tenants", auth(RequireRole("super_admin")(http.HandlerFunc(srv.handleCreateTenant))))
+			srv.mux.Handle("PUT /api/v1/tenants/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(srv.handleUpdateTenant))))
+			srv.mux.Handle("DELETE /api/v1/tenants/{id}", auth(RequireRole("super_admin")(http.HandlerFunc(srv.handleDeleteTenant))))
+
+			req := authReq(t, http.MethodGet, tt.path, nil, secret, "user-1", "t1", tt.role)
+			// For POST/PUT/DELETE, use the correct method.
+			req = httptest.NewRequest(tt.method, tt.path, nil)
+			token := signTestToken(t, secret, "user-1", "t1", tt.role)
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusForbidden {
+				t.Errorf("status = %d, want %d", rr.Code, http.StatusForbidden)
+			}
+		})
+	}
+}

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -75,14 +75,18 @@ func (m *mockNPCStore) Upsert(_ context.Context, def *npcstore.NPCDefinition) er
 
 // mockWebStore is a simple in-memory implementation of WebStore for tests.
 type mockWebStore struct {
-	users     map[string]*User
-	campaigns map[string]*Campaign
+	users       map[string]*User
+	campaigns   map[string]*Campaign
+	sessions    []SessionSummary
+	transcripts map[string][]TranscriptEntry
+	usage       []UsageRecord
 }
 
 func newMockWebStore() *mockWebStore {
 	return &mockWebStore{
-		users:     make(map[string]*User),
-		campaigns: make(map[string]*Campaign),
+		users:       make(map[string]*User),
+		campaigns:   make(map[string]*Campaign),
+		transcripts: make(map[string][]TranscriptEntry),
 	}
 }
 
@@ -139,20 +143,50 @@ func (m *mockWebStore) DeleteCampaign(_ context.Context, tenantID, id string) er
 	return nil
 }
 
-func (m *mockWebStore) ListSessions(_ context.Context, _ string, _, _ int) ([]SessionSummary, error) {
-	return nil, nil
+func (m *mockWebStore) ListSessions(_ context.Context, tenantID string, limit, offset int) ([]SessionSummary, error) {
+	var filtered []SessionSummary
+	for _, s := range m.sessions {
+		if s.TenantID == tenantID {
+			filtered = append(filtered, s)
+		}
+	}
+	if offset >= len(filtered) {
+		return nil, nil
+	}
+	end := offset + limit
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	return filtered[offset:end], nil
 }
 
-func (m *mockWebStore) GetTranscript(_ context.Context, _, _ string) ([]TranscriptEntry, error) {
-	return nil, nil
+func (m *mockWebStore) GetTranscript(_ context.Context, _, sessionID string) ([]TranscriptEntry, error) {
+	entries, ok := m.transcripts[sessionID]
+	if !ok {
+		return nil, nil
+	}
+	return entries, nil
 }
 
-func (m *mockWebStore) GetUsage(_ context.Context, _ string, _, _ time.Time) ([]UsageRecord, error) {
-	return nil, nil
+func (m *mockWebStore) GetUsage(_ context.Context, tenantID string, from, to time.Time) ([]UsageRecord, error) {
+	var result []UsageRecord
+	for _, r := range m.usage {
+		if r.TenantID == tenantID && !r.Period.Before(from) && !r.Period.After(to) {
+			result = append(result, r)
+		}
+	}
+	return result, nil
 }
 
 // testServer creates a Server with mock stores for testing.
 func testServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	srv, _, _, _ := testServerWithStores(t)
+	return srv, "test-jwt-secret"
+}
+
+// testServerWithStores creates a Server and returns access to mock stores for seeding data.
+func testServerWithStores(t *testing.T) (*Server, *mockWebStore, *mockNPCStore, string) {
 	t.Helper()
 
 	secret := "test-jwt-secret"
@@ -163,13 +197,16 @@ func testServer(t *testing.T) (*Server, string) {
 		DiscordRedirectURI:  "http://localhost/callback",
 	}
 
-	return &Server{
+	ws := newMockWebStore()
+	ns := newMockNPCStore()
+	srv := &Server{
 		mux:       http.NewServeMux(),
 		cfg:       cfg,
-		store:     newMockWebStore(),
-		npcs:      newMockNPCStore(),
+		store:     ws,
+		npcs:      ns,
 		gatewayHC: &http.Client{Timeout: 5 * time.Second},
-	}, secret
+	}
+	return srv, ws, ns, secret
 }
 
 func signTestToken(t *testing.T, secret, userID, tenantID, role string) string {
@@ -184,6 +221,20 @@ func signTestToken(t *testing.T, secret, userID, tenantID, role string) string {
 		t.Fatalf("SignJWT: %v", err)
 	}
 	return token
+}
+
+// authReq creates an HTTP request with a valid JWT Authorization header.
+func authReq(t *testing.T, method, path string, body *bytes.Buffer, secret, userID, tenantID, role string) *http.Request {
+	t.Helper()
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, path, body)
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	token := signTestToken(t, secret, userID, tenantID, role)
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req
 }
 
 func TestHandleDiscordLogin_Redirect(t *testing.T) {

--- a/internal/web/handlers_usage_test.go
+++ b/internal/web/handlers_usage_test.go
@@ -1,0 +1,133 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHandleGetUsage(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/usage", auth(http.HandlerFunc(srv.handleGetUsage)))
+
+	now := time.Now().UTC()
+	ws.usage = []UsageRecord{
+		{TenantID: "tenant-1", Period: now, SessionHours: 10, LLMTokens: 5000, TTSChars: 1000, STTSeconds: 300},
+		{TenantID: "tenant-1", Period: now.AddDate(0, -1, 0), SessionHours: 5, LLMTokens: 2500, TTSChars: 500, STTSeconds: 150},
+		{TenantID: "tenant-2", Period: now, SessionHours: 3, LLMTokens: 1000, TTSChars: 200, STTSeconds: 60},
+	}
+
+	req := authReq(t, http.MethodGet, "/api/v1/usage", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data []UsageRecord `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data) != 2 {
+		t.Errorf("got %d usage records, want 2 (tenant-1 only)", len(body.Data))
+	}
+}
+
+func TestHandleGetUsage_CustomDateRange(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/usage", auth(http.HandlerFunc(srv.handleGetUsage)))
+
+	ws.usage = []UsageRecord{
+		{TenantID: "tenant-1", Period: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), SessionHours: 10},
+		{TenantID: "tenant-1", Period: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), SessionHours: 20},
+		{TenantID: "tenant-1", Period: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), SessionHours: 30},
+	}
+
+	req := authReq(t, http.MethodGet, "/api/v1/usage?from=2026-01-15&to=2026-02-15", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data []UsageRecord `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data) != 1 {
+		t.Errorf("got %d records, want 1 (only Feb within range)", len(body.Data))
+	}
+}
+
+func TestHandleGetUsage_Empty(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/usage", auth(http.HandlerFunc(srv.handleGetUsage)))
+
+	req := authReq(t, http.MethodGet, "/api/v1/usage", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Data []UsageRecord `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data == nil {
+		t.Error("data should be empty array, not null")
+	}
+}
+
+func TestHandleGetUsage_InvalidDateIgnored(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/usage", auth(http.HandlerFunc(srv.handleGetUsage)))
+
+	// Invalid dates should be silently ignored, using defaults.
+	req := authReq(t, http.MethodGet, "/api/v1/usage?from=not-a-date&to=also-bad", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (invalid dates should be ignored)", rr.Code, http.StatusOK)
+	}
+}
+
+func TestHandleGetUsage_Unauthenticated(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/usage", auth(http.HandlerFunc(srv.handleGetUsage)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -199,5 +200,215 @@ func TestCORSMiddleware_RestrictedOrigin(t *testing.T) {
 
 	if got := rr2.Header().Get("Access-Control-Allow-Origin"); got != "" {
 		t.Errorf("CORS origin for disallowed = %q, want empty", got)
+	}
+}
+
+func TestCORSMiddleware_WildcardInList(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// If "*" is in the list, it should allow all.
+	handler := CORSMiddleware([]string{"https://app.example.com", "*"})(inner)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Origin", "https://anything.com")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("CORS origin = %q, want %q (wildcard in list)", got, "*")
+	}
+}
+
+func TestCORSMiddleware_Headers(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := CORSMiddleware(nil)(inner)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Access-Control-Allow-Methods"); got != "GET, POST, PUT, DELETE, OPTIONS" {
+		t.Errorf("Allow-Methods = %q", got)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Headers"); got != "Authorization, Content-Type" {
+		t.Errorf("Allow-Headers = %q", got)
+	}
+	if got := rr.Header().Get("Access-Control-Max-Age"); got != "86400" {
+		t.Errorf("Max-Age = %q", got)
+	}
+}
+
+func TestAuthMiddleware_ExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	secret := "test-secret"
+	token, err := SignJWT(secret, Claims{
+		Sub:      "user-1",
+		TenantID: "t1",
+		Role:     "dm",
+		Expires:  time.Now().Add(-1 * time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("SignJWT: %v", err)
+	}
+
+	handler := AuthMiddleware(secret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("inner handler should not be called for expired token")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestAuthMiddleware_NoBearerPrefix(t *testing.T) {
+	t.Parallel()
+
+	handler := AuthMiddleware("secret")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("inner handler should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz") // Basic auth, not Bearer
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestMaxBytesMiddleware(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Try to read the entire body.
+		buf := make([]byte, 2<<20) // 2 MiB buffer
+		_, err := r.Body.Read(buf)
+		if err != nil {
+			// MaxBytesReader should trigger an error.
+			http.Error(w, "body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := MaxBytesMiddleware(inner)
+
+	// Small body — should succeed.
+	t.Run("small body passes", func(t *testing.T) {
+		t.Parallel()
+		smallBody := make([]byte, 100)
+		req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(smallBody))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		// Should not return 413.
+		if rr.Code == http.StatusRequestEntityTooLarge {
+			t.Error("small body should not be rejected")
+		}
+	})
+
+	// Large body — should fail.
+	t.Run("large body rejected", func(t *testing.T) {
+		t.Parallel()
+		largeBody := make([]byte, 2<<20) // 2 MiB — exceeds 1 MiB limit
+		req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(largeBody))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusRequestEntityTooLarge {
+			t.Errorf("status = %d, want %d", rr.Code, http.StatusRequestEntityTooLarge)
+		}
+	})
+}
+
+func TestLoggingMiddleware(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot) // Unique status to verify statusWriter works.
+	})
+
+	handler := LoggingMiddleware(inner)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// LoggingMiddleware wraps the response in a statusWriter but should pass through the status.
+	if rr.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusTeapot)
+	}
+}
+
+func TestLoggingMiddleware_DefaultStatus(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Don't explicitly write a status — should default to 200.
+		w.Write([]byte("ok"))
+	})
+
+	handler := LoggingMiddleware(inner)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (implicit 200)", rr.Code, http.StatusOK)
+	}
+}
+
+func TestRequireRole_NoClaims(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("inner handler should not be called without claims")
+	})
+
+	handler := RequireRole("dm")(inner)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	// No claims in context.
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestHasMinRole_UnknownRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		userRole string
+		minRole  string
+		want     bool
+	}{
+		{"unknown user role", "wizard", "dm", false},
+		{"unknown min role", "dm", "wizard", false},
+		{"both unknown", "wizard", "mage", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasMinRole(tt.userRole, tt.minRole); got != tt.want {
+				t.Errorf("hasMinRole(%q, %q) = %v, want %v", tt.userRole, tt.minRole, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Adds **77 test functions** (up from ~20) covering all HTTP handlers, middleware, and auth logic for `internal/web/`
- Enhanced mock stores with session, transcript, and usage data support for realistic handler testing
- All tests use `t.Parallel()` and pass with `-race` detector

## What's covered
| Area | Tests |
|------|-------|
| Auth handlers | `/me` (auth/unauth/not found), `/refresh` (auth/not found), Discord OAuth callback (state, code, error) |
| Campaign CRUD | Create (validation), list (tenant isolation, empty), get, update (partial merge), delete |
| NPC CRUD | Create (campaign ownership), list, get, update, delete + cross-campaign/tenant isolation |
| Sessions | List (pagination, defaults), transcript retrieval |
| Usage | Date range, invalid dates, empty results |
| Tenants | Gateway proxy, no-gateway fallback, tenant isolation, self-service, role RBAC |
| Middleware | MaxBytes, Logging, CORS (wildcard/restricted/headers), Auth (expired/no-Bearer), RequireRole |
| Auth units | Claims.Valid, DiscordUser.DisplayName/AvatarURL, JWT defaults, issuer/iat |

## What's not covered (by design)
- `store.go` PostgreSQL implementation (requires real DB, would need integration test tag)
- `ExchangeDiscordCode`/`FetchDiscordUser` (external Discord API)
- `NewServer`/`Handler`/`registerRoutes` (thin wiring, tested transitively)

## Test plan
- [x] `go test -race -count=1 ./internal/web/...` — all pass
- [x] `go vet ./internal/web/...` — clean
- [x] 56.1% statement coverage (uncovered = DB store + external APIs)