### PR TITLE
feat(web): add API-key login fallback

### DIFF
--- a/internal/web/config.go
+++ b/internal/web/config.go
@@ -23,13 +23,21 @@ type Config struct {
 	JWTSecret string
 
 	// DiscordClientID is the Discord OAuth2 application client ID.
+	// Optional when AdminAPIKey is set.
 	DiscordClientID string
 
 	// DiscordClientSecret is the Discord OAuth2 application client secret.
+	// Optional when AdminAPIKey is set.
 	DiscordClientSecret string
 
 	// DiscordRedirectURI is the OAuth2 callback URL registered with Discord.
+	// Optional when AdminAPIKey is set.
 	DiscordRedirectURI string
+
+	// AdminAPIKey is the shared admin key that can be used as a login
+	// fallback when Discord OAuth2 is not configured. Loaded from
+	// GLYPHOXA_WEB_ADMIN_KEY or GLYPHOXA_ADMIN_API_KEY.
+	AdminAPIKey string
 
 	// GatewayURL is the base URL of the gateway's internal admin API.
 	GatewayURL string
@@ -46,12 +54,19 @@ type Config struct {
 // LoadConfig reads configuration from environment variables and validates
 // that all required values are present.
 func LoadConfig() (*Config, error) {
+	// AdminAPIKey: prefer GLYPHOXA_WEB_ADMIN_KEY, fall back to GLYPHOXA_ADMIN_API_KEY.
+	adminKey := os.Getenv("GLYPHOXA_WEB_ADMIN_KEY")
+	if adminKey == "" {
+		adminKey = os.Getenv("GLYPHOXA_ADMIN_API_KEY")
+	}
+
 	cfg := &Config{
 		DatabaseDSN:         os.Getenv("GLYPHOXA_WEB_DATABASE_DSN"),
 		JWTSecret:           os.Getenv("GLYPHOXA_WEB_JWT_SECRET"),
 		DiscordClientID:     os.Getenv("GLYPHOXA_WEB_DISCORD_CLIENT_ID"),
 		DiscordClientSecret: os.Getenv("GLYPHOXA_WEB_DISCORD_CLIENT_SECRET"),
 		DiscordRedirectURI:  os.Getenv("GLYPHOXA_WEB_DISCORD_REDIRECT_URI"),
+		AdminAPIKey:         adminKey,
 		GatewayURL:          os.Getenv("GLYPHOXA_WEB_GATEWAY_URL"),
 		ListenAddr:          os.Getenv("GLYPHOXA_WEB_LISTEN_ADDR"),
 	}
@@ -76,6 +91,7 @@ func LoadConfig() (*Config, error) {
 }
 
 // Validate checks that all required configuration values are set.
+// At least one auth method must be configured: Discord OAuth2 or AdminAPIKey.
 func (c *Config) Validate() error {
 	var errs []error
 	if c.DatabaseDSN == "" {
@@ -86,14 +102,14 @@ func (c *Config) Validate() error {
 	} else if len(c.JWTSecret) < 32 {
 		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_JWT_SECRET must be at least 32 characters"))
 	}
-	if c.DiscordClientID == "" {
-		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_DISCORD_CLIENT_ID is required"))
+
+	// Discord OAuth is only required when no API key fallback is configured.
+	hasDiscord := c.DiscordClientID != "" && c.DiscordClientSecret != "" && c.DiscordRedirectURI != ""
+	hasAPIKey := c.AdminAPIKey != ""
+
+	if !hasDiscord && !hasAPIKey {
+		errs = append(errs, fmt.Errorf("at least one auth method required: set Discord OAuth2 vars or GLYPHOXA_WEB_ADMIN_KEY / GLYPHOXA_ADMIN_API_KEY"))
 	}
-	if c.DiscordClientSecret == "" {
-		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_DISCORD_CLIENT_SECRET is required"))
-	}
-	if c.DiscordRedirectURI == "" {
-		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_DISCORD_REDIRECT_URI is required"))
-	}
+
 	return errors.Join(errs...)
 }

--- a/internal/web/handlers_auth.go
+++ b/internal/web/handlers_auth.go
@@ -1,6 +1,8 @@
 package web
 
 import (
+	"crypto/subtle"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -168,6 +170,68 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to issue token")
 		return
 	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]any{
+			"access_token": token,
+			"token_type":   "Bearer",
+			"expires_in":   86400,
+			"user":         user,
+		},
+	})
+}
+
+// handleAPIKeyLogin authenticates a user via a shared admin API key and
+// returns a JWT for the super_admin user. This is a fallback for environments
+// where Discord OAuth2 is not configured.
+func (s *Server) handleAPIKeyLogin(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.AdminAPIKey == "" {
+		writeError(w, http.StatusNotFound, "not_configured", "API key login is not enabled")
+		return
+	}
+
+	var body struct {
+		APIKey string `json:"api_key"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", "expected JSON with api_key field")
+		return
+	}
+	if body.APIKey == "" {
+		writeError(w, http.StatusBadRequest, "missing_key", "api_key is required")
+		return
+	}
+
+	// Constant-time comparison to prevent timing attacks.
+	if subtle.ConstantTimeCompare([]byte(body.APIKey), []byte(s.cfg.AdminAPIKey)) != 1 {
+		slog.Warn("web: invalid API key login attempt", "remote", r.RemoteAddr)
+		writeError(w, http.StatusUnauthorized, "invalid_key", "invalid API key")
+		return
+	}
+
+	tenantID := "default"
+	user, err := s.store.EnsureAdminUser(r.Context(), tenantID)
+	if err != nil {
+		slog.Error("web: ensure admin user", "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to create admin user")
+		return
+	}
+
+	token, err := SignJWT(s.cfg.JWTSecret, Claims{
+		Sub:      user.ID,
+		TenantID: user.TenantID,
+		Role:     user.Role,
+	})
+	if err != nil {
+		slog.Error("web: sign jwt for apikey login", "user_id", user.ID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to issue token")
+		return
+	}
+
+	slog.Info("web: user authenticated via API key",
+		"user_id", user.ID,
+		"remote", r.RemoteAddr,
+	)
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"data": map[string]any{

--- a/internal/web/handlers_auth_test.go
+++ b/internal/web/handlers_auth_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -217,5 +218,119 @@ func TestHandleDiscordCallback_DiscordError(t *testing.T) {
 	}
 	if body.Error.Code != "discord_error" {
 		t.Errorf("error code = %q, want %q", body.Error.Code, "discord_error")
+	}
+}
+
+func TestHandleAPIKeyLogin_Success(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	srv.cfg.AdminAPIKey = "test-admin-key-12345"
+	srv.mux.HandleFunc("POST /api/v1/auth/apikey", srv.handleAPIKeyLogin)
+
+	body := bytes.NewBufferString(`{"api_key":"test-admin-key-12345"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/apikey", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			AccessToken string `json:"access_token"`
+			TokenType   string `json:"token_type"`
+			ExpiresIn   int    `json:"expires_in"`
+			User        User   `json:"user"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Data.AccessToken == "" {
+		t.Error("expected non-empty access_token")
+	}
+	if resp.Data.TokenType != "Bearer" {
+		t.Errorf("token_type = %q, want %q", resp.Data.TokenType, "Bearer")
+	}
+	if resp.Data.User.Role != "super_admin" {
+		t.Errorf("role = %q, want %q", resp.Data.User.Role, "super_admin")
+	}
+	if resp.Data.User.ID != adminUserID {
+		t.Errorf("user ID = %q, want %q", resp.Data.User.ID, adminUserID)
+	}
+}
+
+func TestHandleAPIKeyLogin_InvalidKey(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	srv.cfg.AdminAPIKey = "correct-key"
+	srv.mux.HandleFunc("POST /api/v1/auth/apikey", srv.handleAPIKeyLogin)
+
+	body := bytes.NewBufferString(`{"api_key":"wrong-key"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/apikey", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestHandleAPIKeyLogin_NotConfigured(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	// AdminAPIKey left empty.
+	srv.mux.HandleFunc("POST /api/v1/auth/apikey", srv.handleAPIKeyLogin)
+
+	body := bytes.NewBufferString(`{"api_key":"anything"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/apikey", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleAPIKeyLogin_MissingKey(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	srv.cfg.AdminAPIKey = "some-key"
+	srv.mux.HandleFunc("POST /api/v1/auth/apikey", srv.handleAPIKeyLogin)
+
+	body := bytes.NewBufferString(`{}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/apikey", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleAPIKeyLogin_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	srv.cfg.AdminAPIKey = "some-key"
+	srv.mux.HandleFunc("POST /api/v1/auth/apikey", srv.handleAPIKeyLogin)
+
+	body := bytes.NewBufferString(`not json`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/apikey", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
 	}
 }

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -99,6 +99,12 @@ func (m *mockWebStore) UpsertDiscordUser(_ context.Context, discordID, email, di
 	return u, nil
 }
 
+func (m *mockWebStore) EnsureAdminUser(_ context.Context, tenantID string) (*User, error) {
+	u := &User{ID: adminUserID, TenantID: tenantID, DisplayName: "Admin", Role: "super_admin"}
+	m.users[adminUserID] = u
+	return u, nil
+}
+
 func (m *mockWebStore) GetUser(_ context.Context, id string) (*User, error) {
 	u, ok := m.users[id]
 	if !ok {
@@ -358,13 +364,34 @@ func TestConfigValidation(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "valid",
+			name: "valid with discord",
 			cfg: Config{
 				DatabaseDSN:         "postgres://localhost/test",
 				JWTSecret:           "a-very-long-jwt-secret-that-is-at-least-32-chars",
 				DiscordClientID:     "id",
 				DiscordClientSecret: "secret",
 				DiscordRedirectURI:  "http://localhost/callback",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with apikey only",
+			cfg: Config{
+				DatabaseDSN: "postgres://localhost/test",
+				JWTSecret:   "a-very-long-jwt-secret-that-is-at-least-32-chars",
+				AdminAPIKey: "my-admin-key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with both",
+			cfg: Config{
+				DatabaseDSN:         "postgres://localhost/test",
+				JWTSecret:           "a-very-long-jwt-secret-that-is-at-least-32-chars",
+				DiscordClientID:     "id",
+				DiscordClientSecret: "secret",
+				DiscordRedirectURI:  "http://localhost/callback",
+				AdminAPIKey:         "my-admin-key",
 			},
 			wantErr: false,
 		},
@@ -380,7 +407,7 @@ func TestConfigValidation(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "empty",
+			name:    "empty — no auth method",
 			cfg:     Config{},
 			wantErr: true,
 		},
@@ -391,6 +418,14 @@ func TestConfigValidation(t *testing.T) {
 				DiscordClientID:     "id",
 				DiscordClientSecret: "secret",
 				DiscordRedirectURI:  "http://localhost/callback",
+			},
+			wantErr: true,
+		},
+		{
+			name: "no auth method configured",
+			cfg: Config{
+				DatabaseDSN: "postgres://localhost/test",
+				JWTSecret:   "a-very-long-jwt-secret-that-is-at-least-32-chars",
 			},
 			wantErr: true,
 		},

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -53,6 +53,7 @@ func (s *Server) registerRoutes() {
 	// Auth endpoints (unauthenticated).
 	s.mux.HandleFunc("GET /api/v1/auth/discord", s.handleDiscordLogin)
 	s.mux.HandleFunc("GET /api/v1/auth/discord/callback", s.handleDiscordCallback)
+	s.mux.HandleFunc("POST /api/v1/auth/apikey", s.handleAPIKeyLogin)
 
 	// Authenticated endpoints — wrap with auth middleware.
 	auth := AuthMiddleware(s.cfg.JWTSecret)

--- a/internal/web/store.go
+++ b/internal/web/store.go
@@ -51,6 +51,7 @@ type Campaign struct {
 type WebStore interface {
 	Ping(ctx context.Context) error
 	UpsertDiscordUser(ctx context.Context, discordID, email, displayName, avatarURL, tenantID string) (*User, error)
+	EnsureAdminUser(ctx context.Context, tenantID string) (*User, error)
 	GetUser(ctx context.Context, id string) (*User, error)
 	CreateCampaign(ctx context.Context, c *Campaign) error
 	GetCampaign(ctx context.Context, tenantID, id string) (*Campaign, error)
@@ -129,6 +130,32 @@ func (s *Store) UpsertDiscordUser(ctx context.Context, discordID, email, display
 	)
 	if err != nil {
 		return nil, fmt.Errorf("web: upsert discord user: %w", err)
+	}
+	return &user, nil
+}
+
+// adminUserID is the well-known user ID for API-key authenticated admins.
+const adminUserID = "apikey-admin"
+
+// EnsureAdminUser upserts the well-known API-key admin user, returning it
+// with the super_admin role. This is used by the API-key login flow.
+func (s *Store) EnsureAdminUser(ctx context.Context, tenantID string) (*User, error) {
+	now := time.Now().UTC()
+	var user User
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO mgmt.users (id, tenant_id, display_name, role, last_login_at, created_at, updated_at)
+		VALUES ($1, $2, 'Admin', 'super_admin', $3, $3, $3)
+		ON CONFLICT (id) DO UPDATE SET
+			last_login_at = EXCLUDED.last_login_at,
+			updated_at = EXCLUDED.updated_at
+		RETURNING id, tenant_id, discord_id, email, display_name, avatar_url, role, last_login_at, created_at, updated_at
+	`, adminUserID, tenantID, now).Scan(
+		&user.ID, &user.TenantID, &user.DiscordID, &user.Email,
+		&user.DisplayName, &user.AvatarURL, &user.Role, &user.LastLoginAt,
+		&user.CreatedAt, &user.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("web: ensure admin user: %w", err)
 	}
 	return &user, nil
 }

--- a/web/src/app/(public)/login/page.tsx
+++ b/web/src/app/(public)/login/page.tsx
@@ -1,7 +1,11 @@
 "use client";
 
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { api } from "@/lib/api";
 
 function DiscordIcon({ className }: { className?: string }) {
@@ -12,7 +16,46 @@ function DiscordIcon({ className }: { className?: string }) {
   );
 }
 
+function KeyIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4" />
+    </svg>
+  );
+}
+
 export default function LoginPage() {
+  const router = useRouter();
+  const [apiKey, setApiKey] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleApiKeyLogin(e: React.FormEvent) {
+    e.preventDefault();
+    if (!apiKey.trim()) return;
+
+    setError("");
+    setLoading(true);
+    try {
+      await api.auth.loginApiKey(apiKey.trim());
+      router.push("/");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Login failed. Check your API key.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
       <div className="w-full max-w-md space-y-6">
@@ -45,16 +88,39 @@ export default function LoginPage() {
               </div>
               <div className="relative flex justify-center text-xs uppercase">
                 <span className="bg-card px-2 text-muted-foreground">
-                  Discord is the primary login method
+                  or use an API key
                 </span>
               </div>
             </div>
 
-            <p className="text-center text-sm text-muted-foreground">
-              Sign in with your Discord account to manage campaigns, NPCs, and
-              voice sessions. Your Discord guilds determine which campaigns you
-              can access.
-            </p>
+            <form onSubmit={handleApiKeyLogin} className="space-y-3">
+              <div className="space-y-2">
+                <Label htmlFor="api-key">Admin API Key</Label>
+                <Input
+                  id="api-key"
+                  type="password"
+                  placeholder="Enter your API key"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  autoComplete="off"
+                />
+              </div>
+              {error && (
+                <p className="text-sm text-destructive" role="alert">
+                  {error}
+                </p>
+              )}
+              <Button
+                type="submit"
+                variant="outline"
+                className="w-full gap-2"
+                size="lg"
+                disabled={loading || !apiKey.trim()}
+              >
+                <KeyIcon className="h-4 w-4" />
+                {loading ? "Signing in..." : "Sign in with API Key"}
+              </Button>
+            </form>
           </CardContent>
         </Card>
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -20,17 +20,44 @@ class ApiError extends Error {
   }
 }
 
+const TOKEN_KEY = "glyphoxa_token";
+
+export function getStoredToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setStoredToken(token: string): void {
+  if (typeof window !== "undefined") {
+    localStorage.setItem(TOKEN_KEY, token);
+  }
+}
+
+export function clearStoredToken(): void {
+  if (typeof window !== "undefined") {
+    localStorage.removeItem(TOKEN_KEY);
+  }
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const token = getStoredToken();
+  const authHeaders: Record<string, string> = {};
+  if (token) {
+    authHeaders["Authorization"] = `Bearer ${token}`;
+  }
+
   const res = await fetch(`${API_BASE}${path}`, {
     ...options,
     credentials: "include",
     headers: {
       "Content-Type": "application/json",
+      ...authHeaders,
       ...options?.headers,
     },
   });
 
   if (res.status === 401) {
+    clearStoredToken();
     if (typeof window !== "undefined") {
       window.location.href = "/login";
     }
@@ -46,11 +73,33 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   return res.json();
 }
 
+interface AuthResponse {
+  data: {
+    access_token: string;
+    token_type: string;
+    expires_in: number;
+    user: User;
+  };
+}
+
 // Auth
 export const auth = {
   me: () => request<User>("/auth/me"),
-  logout: () => request<void>("/auth/logout", { method: "POST" }),
+  logout: () => {
+    clearStoredToken();
+    return request<void>("/auth/logout", { method: "POST" }).catch(() => {
+      // Logout endpoint may not exist; clearing token is sufficient.
+    });
+  },
   discordUrl: () => `${API_BASE}/auth/discord`,
+  loginApiKey: async (apiKey: string): Promise<AuthResponse> => {
+    const res = await request<AuthResponse>("/auth/apikey", {
+      method: "POST",
+      body: JSON.stringify({ api_key: apiKey }),
+    });
+    setStoredToken(res.data.access_token);
+    return res;
+  },
 };
 
 // Dashboard


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/auth/apikey` endpoint — accepts an admin API key, verifies it against `GLYPHOXA_WEB_ADMIN_KEY` or `GLYPHOXA_ADMIN_API_KEY` env var, returns a JWT for the `super_admin` user
- Makes Discord OAuth2 config optional when an API key is set (at least one auth method required)
- Adds API Key login form to the frontend login page alongside the existing Discord button
- Stores JWT in localStorage and attaches it as `Authorization: Bearer` on all API requests

This lets the web UI be used immediately with the existing gateway admin API key, without needing Discord OAuth2 credentials.

## Test plan
- [x] All existing tests pass (`go test -race -count=1 ./internal/web/...`)
- [x] New tests cover: valid key, invalid key, missing key, invalid JSON, not-configured scenarios
- [x] Config validation tests updated for new auth method flexibility
- [x] Frontend builds cleanly (`npm run build`)
- [ ] Manual test: set `GLYPHOXA_WEB_ADMIN_KEY`, visit login page, enter key, verify redirect to dashboard