### PR TITLE
feat(web): add user management, RBAC, and invite system

### DIFF
--- a/internal/web/handlers_auth_test.go
+++ b/internal/web/handlers_auth_test.go
@@ -19,7 +19,7 @@ func TestHandleMe_Authenticated(t *testing.T) {
 	ws.users["user-1"] = &User{
 		ID:          "user-1",
 		TenantID:    "tenant-1",
-		DiscordID:   "discord-1",
+		DiscordID:   strPtr("discord-1"),
 		DisplayName: "TestUser",
 		Role:        "dm",
 	}

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -3,7 +3,10 @@ package web
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -80,6 +83,7 @@ type mockWebStore struct {
 	sessions    []SessionSummary
 	transcripts map[string][]TranscriptEntry
 	usage       []UsageRecord
+	invites     map[string]*Invite
 }
 
 func newMockWebStore() *mockWebStore {
@@ -87,14 +91,18 @@ func newMockWebStore() *mockWebStore {
 		users:       make(map[string]*User),
 		campaigns:   make(map[string]*Campaign),
 		transcripts: make(map[string][]TranscriptEntry),
+		invites:     make(map[string]*Invite),
 	}
 }
 
 func (m *mockWebStore) Ping(_ context.Context) error { return nil }
 
+// strPtr returns a pointer to the given string.
+func strPtr(s string) *string { return &s }
+
 func (m *mockWebStore) UpsertDiscordUser(_ context.Context, discordID, email, displayName, avatarURL, tenantID string) (*User, error) {
 	id := "user-" + discordID
-	u := &User{ID: id, TenantID: tenantID, DiscordID: discordID, Email: email, DisplayName: displayName, AvatarURL: avatarURL, Role: "dm"}
+	u := &User{ID: id, TenantID: tenantID, DiscordID: strPtr(discordID), Email: strPtr(email), DisplayName: displayName, AvatarURL: strPtr(avatarURL), Role: "dm"}
 	m.users[id] = u
 	return u, nil
 }
@@ -111,6 +119,110 @@ func (m *mockWebStore) GetUser(_ context.Context, id string) (*User, error) {
 		return nil, nil
 	}
 	return u, nil
+}
+
+func (m *mockWebStore) ListUsers(_ context.Context, tenantID, role string, limit, offset int) ([]User, int, error) {
+	var filtered []User
+	for _, u := range m.users {
+		if u.TenantID != tenantID {
+			continue
+		}
+		if role != "" && u.Role != role {
+			continue
+		}
+		filtered = append(filtered, *u)
+	}
+	total := len(filtered)
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+	if offset >= len(filtered) {
+		return nil, total, nil
+	}
+	end := offset + limit
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	return filtered[offset:end], total, nil
+}
+
+func (m *mockWebStore) UpdateUser(_ context.Context, u *User) error {
+	existing, ok := m.users[u.ID]
+	if !ok {
+		return fmt.Errorf("web: user %q not found", u.ID)
+	}
+	if u.DisplayName != "" {
+		existing.DisplayName = u.DisplayName
+	}
+	if u.Role != "" {
+		existing.Role = u.Role
+	}
+	existing.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
+func (m *mockWebStore) DeleteUser(_ context.Context, id string) error {
+	if _, ok := m.users[id]; !ok {
+		return fmt.Errorf("web: user %q not found", id)
+	}
+	delete(m.users, id)
+	return nil
+}
+
+func (m *mockWebStore) UpdateUserPreferences(_ context.Context, id string, prefs json.RawMessage) (*User, error) {
+	u, ok := m.users[id]
+	if !ok {
+		return nil, nil
+	}
+	// Simple merge: just overwrite for test purposes.
+	existing := map[string]any{}
+	if u.Preferences != nil {
+		_ = json.Unmarshal(u.Preferences, &existing)
+	}
+	incoming := map[string]any{}
+	_ = json.Unmarshal(prefs, &incoming)
+	for k, v := range incoming {
+		existing[k] = v
+	}
+	merged, _ := json.Marshal(existing)
+	u.Preferences = merged
+	u.UpdatedAt = time.Now().UTC()
+	return u, nil
+}
+
+func (m *mockWebStore) CreateInvite(_ context.Context, inv *Invite) error {
+	if inv.ID == "" {
+		inv.ID = "inv-" + inv.TenantID
+	}
+	b := make([]byte, 24)
+	_, _ = rand.Read(b)
+	inv.Token = hex.EncodeToString(b)
+	inv.CreatedAt = time.Now().UTC()
+	if inv.ExpiresAt.IsZero() {
+		inv.ExpiresAt = inv.CreatedAt.Add(7 * 24 * time.Hour)
+	}
+	m.invites[inv.ID] = inv
+	return nil
+}
+
+func (m *mockWebStore) GetInviteByToken(_ context.Context, token string) (*Invite, error) {
+	for _, inv := range m.invites {
+		if inv.Token == token && inv.UsedAt == nil {
+			return inv, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockWebStore) UseInvite(_ context.Context, inviteID, userID string) error {
+	inv, ok := m.invites[inviteID]
+	if !ok || inv.UsedAt != nil {
+		return fmt.Errorf("web: invite %q not found or already used", inviteID)
+	}
+	now := time.Now().UTC()
+	inv.UsedBy = &userID
+	inv.UsedAt = &now
+	return nil
 }
 
 func (m *mockWebStore) CreateCampaign(_ context.Context, c *Campaign) error {

--- a/internal/web/handlers_users.go
+++ b/internal/web/handlers_users.go
@@ -1,0 +1,264 @@
+package web
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+)
+
+// handleListUsers returns paginated users for the authenticated tenant.
+// Requires tenant_admin role.
+func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	role := r.URL.Query().Get("role")
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+
+	users, total, err := s.store.ListUsers(r.Context(), claims.TenantID, role, limit, offset)
+	if err != nil {
+		slog.Error("web: list users", "tenant_id", claims.TenantID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to list users")
+		return
+	}
+	if users == nil {
+		users = []User{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data":  users,
+		"total": total,
+	})
+}
+
+// handleGetUser returns a single user by ID. Users can always read their own
+// profile; tenant_admin can read any user in their tenant.
+func (s *Server) handleGetUser(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	id := r.PathValue("id")
+	// Non-admin users can only view themselves.
+	if id != claims.Sub && !hasMinRole(claims.Role, "tenant_admin") {
+		writeError(w, http.StatusForbidden, "insufficient_role", "insufficient permissions")
+		return
+	}
+
+	user, err := s.store.GetUser(r.Context(), id)
+	if err != nil {
+		slog.Error("web: get user", "user_id", id, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to get user")
+		return
+	}
+	if user == nil || user.TenantID != claims.TenantID {
+		writeError(w, http.StatusNotFound, "not_found", "user not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": user})
+}
+
+// UserUpdateRequest is the JSON body for updating a user.
+type UserUpdateRequest struct {
+	DisplayName *string `json:"display_name"`
+	Role        *string `json:"role"`
+}
+
+// handleUpdateUser updates a user's display_name or role. Requires
+// tenant_admin for role changes.
+func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	id := r.PathValue("id")
+	// Non-admin users can only update themselves (display_name only).
+	if id != claims.Sub && !hasMinRole(claims.Role, "tenant_admin") {
+		writeError(w, http.StatusForbidden, "insufficient_role", "insufficient permissions")
+		return
+	}
+
+	var req UserUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", "invalid JSON body")
+		return
+	}
+
+	// Role changes require tenant_admin.
+	if req.Role != nil && !hasMinRole(claims.Role, "tenant_admin") {
+		writeError(w, http.StatusForbidden, "insufficient_role", "only admins can change roles")
+		return
+	}
+
+	u := &User{ID: id}
+	if req.DisplayName != nil {
+		if *req.DisplayName == "" {
+			writeError(w, http.StatusBadRequest, "invalid_name", "display_name must not be empty")
+			return
+		}
+		u.DisplayName = *req.DisplayName
+	}
+	if req.Role != nil {
+		if !ValidRoles[*req.Role] {
+			writeError(w, http.StatusBadRequest, "invalid_role", "invalid role")
+			return
+		}
+		u.Role = *req.Role
+	}
+
+	if err := s.store.UpdateUser(r.Context(), u); err != nil {
+		slog.Error("web: update user", "user_id", id, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to update user")
+		return
+	}
+
+	updated, err := s.store.GetUser(r.Context(), id)
+	if err != nil || updated == nil {
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to fetch updated user")
+		return
+	}
+
+	slog.Info("web: user updated", "user_id", id, "by", claims.Sub)
+	writeJSON(w, http.StatusOK, map[string]any{"data": updated})
+}
+
+// handleDeleteUser soft-deletes a user. Requires tenant_admin.
+func (s *Server) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == claims.Sub {
+		writeError(w, http.StatusBadRequest, "self_delete", "cannot delete yourself")
+		return
+	}
+
+	if err := s.store.DeleteUser(r.Context(), id); err != nil {
+		slog.Error("web: delete user", "user_id", id, "err", err)
+		writeError(w, http.StatusNotFound, "not_found", "user not found")
+		return
+	}
+
+	slog.Info("web: user deleted", "user_id", id, "by", claims.Sub)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// InviteCreateRequest is the JSON body for creating an invite.
+type InviteCreateRequest struct {
+	Role string `json:"role"`
+}
+
+// handleCreateInvite creates a new tenant invite link. Requires tenant_admin.
+func (s *Server) handleCreateInvite(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	var req InviteCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", "invalid JSON body")
+		return
+	}
+	if req.Role == "" {
+		req.Role = "viewer"
+	}
+	if !ValidRoles[req.Role] {
+		writeError(w, http.StatusBadRequest, "invalid_role", "invalid role")
+		return
+	}
+
+	inv := &Invite{
+		TenantID:  claims.TenantID,
+		Role:      req.Role,
+		CreatedBy: claims.Sub,
+	}
+
+	if err := s.store.CreateInvite(r.Context(), inv); err != nil {
+		slog.Error("web: create invite", "tenant_id", claims.TenantID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to create invite")
+		return
+	}
+
+	slog.Info("web: invite created", "invite_id", inv.ID, "tenant_id", claims.TenantID, "role", inv.Role)
+	writeJSON(w, http.StatusCreated, map[string]any{"data": inv})
+}
+
+// handleUpdateMe allows the current user to update their own display_name.
+func (s *Server) handleUpdateMe(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	var req struct {
+		DisplayName string `json:"display_name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", "invalid JSON body")
+		return
+	}
+	if req.DisplayName == "" {
+		writeError(w, http.StatusBadRequest, "invalid_name", "display_name is required")
+		return
+	}
+
+	u := &User{ID: claims.Sub, DisplayName: req.DisplayName}
+	if err := s.store.UpdateUser(r.Context(), u); err != nil {
+		slog.Error("web: update me", "user_id", claims.Sub, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to update profile")
+		return
+	}
+
+	updated, err := s.store.GetUser(r.Context(), claims.Sub)
+	if err != nil || updated == nil {
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to fetch updated profile")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": updated})
+}
+
+// handleUpdatePreferences merges the JSON body into the current user's
+// preferences column.
+func (s *Server) handleUpdatePreferences(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	var prefs json.RawMessage
+	if err := json.NewDecoder(r.Body).Decode(&prefs); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", "invalid JSON body")
+		return
+	}
+
+	updated, err := s.store.UpdateUserPreferences(r.Context(), claims.Sub, prefs)
+	if err != nil {
+		slog.Error("web: update preferences", "user_id", claims.Sub, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to update preferences")
+		return
+	}
+	if updated == nil {
+		writeError(w, http.StatusNotFound, "not_found", "user not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": updated})
+}

--- a/internal/web/handlers_users_test.go
+++ b/internal/web/handlers_users_test.go
@@ -1,0 +1,325 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleListUsers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		role      string
+		wantCode  int
+		wantCount int
+	}{
+		{"admin sees users", "tenant_admin", http.StatusOK, 2},
+		{"viewer forbidden", "viewer", http.StatusForbidden, 0},
+		{"dm forbidden", "dm", http.StatusForbidden, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, ws, _, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("GET /api/v1/users", auth(RequireRole("tenant_admin")(http.HandlerFunc(srv.handleListUsers))))
+
+			ws.users["u1"] = &User{ID: "u1", TenantID: "tenant-1", DisplayName: "Alice", Role: "dm"}
+			ws.users["u2"] = &User{ID: "u2", TenantID: "tenant-1", DisplayName: "Bob", Role: "viewer"}
+			ws.users["u3"] = &User{ID: "u3", TenantID: "tenant-2", DisplayName: "Eve", Role: "dm"}
+
+			req := authReq(t, http.MethodGet, "/api/v1/users", nil, secret, "u1", "tenant-1", tt.role)
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+
+			if tt.wantCode == http.StatusOK {
+				var body struct {
+					Data  []User `json:"data"`
+					Total int    `json:"total"`
+				}
+				if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if len(body.Data) != tt.wantCount {
+					t.Errorf("got %d users, want %d", len(body.Data), tt.wantCount)
+				}
+				if body.Total != tt.wantCount {
+					t.Errorf("total = %d, want %d", body.Total, tt.wantCount)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleGetUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		targetID string
+		callerID string
+		role     string
+		wantCode int
+	}{
+		{"self access", "u1", "u1", "viewer", http.StatusOK},
+		{"admin access other", "u2", "u1", "tenant_admin", http.StatusOK},
+		{"viewer cannot access other", "u2", "u1", "viewer", http.StatusForbidden},
+		{"not found", "u999", "u1", "tenant_admin", http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, ws, _, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("GET /api/v1/users/{id}", auth(http.HandlerFunc(srv.handleGetUser)))
+
+			ws.users["u1"] = &User{ID: "u1", TenantID: "tenant-1", DisplayName: "Alice", Role: "dm"}
+			ws.users["u2"] = &User{ID: "u2", TenantID: "tenant-1", DisplayName: "Bob", Role: "viewer"}
+
+			req := authReq(t, http.MethodGet, "/api/v1/users/"+tt.targetID, nil, secret, tt.callerID, "tenant-1", tt.role)
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleUpdateUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		targetID string
+		callerID string
+		role     string
+		body     string
+		wantCode int
+	}{
+		{"admin updates role", "u2", "u1", "tenant_admin", `{"role":"dm"}`, http.StatusOK},
+		{"self updates name", "u1", "u1", "dm", `{"display_name":"Alice B"}`, http.StatusOK},
+		{"viewer cannot update other", "u2", "u1", "viewer", `{"display_name":"X"}`, http.StatusForbidden},
+		{"dm cannot change role", "u1", "u1", "dm", `{"role":"tenant_admin"}`, http.StatusForbidden},
+		{"invalid role value", "u2", "u1", "tenant_admin", `{"role":"hacker"}`, http.StatusBadRequest},
+		{"invalid json", "u1", "u1", "dm", `{bad}`, http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, ws, _, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("PUT /api/v1/users/{id}", auth(http.HandlerFunc(srv.handleUpdateUser)))
+
+			ws.users["u1"] = &User{ID: "u1", TenantID: "tenant-1", DisplayName: "Alice", Role: "dm"}
+			ws.users["u2"] = &User{ID: "u2", TenantID: "tenant-1", DisplayName: "Bob", Role: "viewer"}
+
+			req := authReq(t, http.MethodPut, "/api/v1/users/"+tt.targetID,
+				bytes.NewBufferString(tt.body), secret, tt.callerID, "tenant-1", tt.role)
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleDeleteUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		targetID string
+		callerID string
+		wantCode int
+	}{
+		{"delete other user", "u2", "u1", http.StatusNoContent},
+		{"cannot delete self", "u1", "u1", http.StatusBadRequest},
+		{"delete nonexistent", "u999", "u1", http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, ws, _, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("DELETE /api/v1/users/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(srv.handleDeleteUser))))
+
+			ws.users["u1"] = &User{ID: "u1", TenantID: "tenant-1", DisplayName: "Alice", Role: "tenant_admin"}
+			ws.users["u2"] = &User{ID: "u2", TenantID: "tenant-1", DisplayName: "Bob", Role: "viewer"}
+
+			req := authReq(t, http.MethodDelete, "/api/v1/users/"+tt.targetID, nil, secret, tt.callerID, "tenant-1", "tenant_admin")
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleCreateInvite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		role     string
+		body     string
+		wantCode int
+	}{
+		{"valid invite", "tenant_admin", `{"role":"viewer"}`, http.StatusCreated},
+		{"default role", "tenant_admin", `{}`, http.StatusCreated},
+		{"invalid role", "tenant_admin", `{"role":"hacker"}`, http.StatusBadRequest},
+		{"viewer forbidden", "viewer", `{"role":"viewer"}`, http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, _, _, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("POST /api/v1/users/invite", auth(RequireRole("tenant_admin")(http.HandlerFunc(srv.handleCreateInvite))))
+
+			req := authReq(t, http.MethodPost, "/api/v1/users/invite",
+				bytes.NewBufferString(tt.body), secret, "u1", "tenant-1", tt.role)
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+
+			if tt.wantCode == http.StatusCreated {
+				var body struct {
+					Data Invite `json:"data"`
+				}
+				if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if body.Data.Token == "" {
+					t.Error("expected non-empty invite token")
+				}
+				if body.Data.TenantID != "tenant-1" {
+					t.Errorf("tenant_id = %q, want %q", body.Data.TenantID, "tenant-1")
+				}
+			}
+		})
+	}
+}
+
+func TestHandleUpdateMe(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		body     string
+		wantCode int
+	}{
+		{"valid update", `{"display_name":"New Name"}`, http.StatusOK},
+		{"empty name", `{"display_name":""}`, http.StatusBadRequest},
+		{"invalid json", `{bad}`, http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, ws, _, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("PUT /api/v1/auth/me", auth(http.HandlerFunc(srv.handleUpdateMe)))
+
+			ws.users["u1"] = &User{ID: "u1", TenantID: "tenant-1", DisplayName: "Old Name", Role: "dm"}
+
+			req := authReq(t, http.MethodPut, "/api/v1/auth/me",
+				bytes.NewBufferString(tt.body), secret, "u1", "tenant-1", "dm")
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+
+			if tt.wantCode == http.StatusOK {
+				var body struct {
+					Data User `json:"data"`
+				}
+				if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if body.Data.DisplayName != "New Name" {
+					t.Errorf("display_name = %q, want %q", body.Data.DisplayName, "New Name")
+				}
+			}
+		})
+	}
+}
+
+func TestHandleUpdatePreferences(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		body     string
+		wantCode int
+	}{
+		{"valid preferences", `{"theme":"dark","locale":"en"}`, http.StatusOK},
+		{"invalid json", `not json`, http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, ws, _, secret := testServerWithStores(t)
+			auth := AuthMiddleware(secret)
+			srv.mux.Handle("PATCH /api/v1/auth/me/preferences", auth(http.HandlerFunc(srv.handleUpdatePreferences)))
+
+			ws.users["u1"] = &User{ID: "u1", TenantID: "tenant-1", DisplayName: "Alice", Role: "dm", Preferences: json.RawMessage(`{}`)}
+
+			req := authReq(t, http.MethodPatch, "/api/v1/auth/me/preferences",
+				bytes.NewBufferString(tt.body), secret, "u1", "tenant-1", "dm")
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+
+			if tt.wantCode == http.StatusOK {
+				var body struct {
+					Data User `json:"data"`
+				}
+				if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				var prefs map[string]any
+				if err := json.Unmarshal(body.Data.Preferences, &prefs); err != nil {
+					t.Fatalf("unmarshal preferences: %v", err)
+				}
+				if prefs["theme"] != "dark" {
+					t.Errorf("theme = %v, want dark", prefs["theme"])
+				}
+			}
+		})
+	}
+}

--- a/internal/web/migrations/002_user_management.sql
+++ b/internal/web/migrations/002_user_management.sql
@@ -1,0 +1,16 @@
+-- User management: preferences column + invites table.
+ALTER TABLE mgmt.users ADD COLUMN IF NOT EXISTS preferences JSONB NOT NULL DEFAULT '{}';
+
+CREATE TABLE IF NOT EXISTS mgmt.invites (
+    id          TEXT        PRIMARY KEY,
+    tenant_id   TEXT        NOT NULL,
+    role        TEXT        NOT NULL DEFAULT 'viewer',
+    created_by  TEXT        NOT NULL REFERENCES mgmt.users(id),
+    token       TEXT        NOT NULL UNIQUE,
+    expires_at  TIMESTAMPTZ NOT NULL,
+    used_by     TEXT        REFERENCES mgmt.users(id),
+    used_at     TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_mgmt_invites_token ON mgmt.invites(token) WHERE used_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_mgmt_invites_tenant ON mgmt.invites(tenant_id);

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -61,6 +61,15 @@ func (s *Server) registerRoutes() {
 	// Auth management.
 	s.mux.Handle("POST /api/v1/auth/refresh", auth(http.HandlerFunc(s.handleRefresh)))
 	s.mux.Handle("GET /api/v1/auth/me", auth(http.HandlerFunc(s.handleMe)))
+	s.mux.Handle("PUT /api/v1/auth/me", auth(http.HandlerFunc(s.handleUpdateMe)))
+	s.mux.Handle("PATCH /api/v1/auth/me/preferences", auth(http.HandlerFunc(s.handleUpdatePreferences)))
+
+	// Users.
+	s.mux.Handle("GET /api/v1/users", auth(RequireRole("tenant_admin")(http.HandlerFunc(s.handleListUsers))))
+	s.mux.Handle("GET /api/v1/users/{id}", auth(http.HandlerFunc(s.handleGetUser)))
+	s.mux.Handle("PUT /api/v1/users/{id}", auth(http.HandlerFunc(s.handleUpdateUser)))
+	s.mux.Handle("DELETE /api/v1/users/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(s.handleDeleteUser))))
+	s.mux.Handle("POST /api/v1/users/invite", auth(RequireRole("tenant_admin")(http.HandlerFunc(s.handleCreateInvite))))
 
 	// Campaigns.
 	s.mux.Handle("POST /api/v1/campaigns", auth(RequireRole("dm")(http.HandlerFunc(s.handleCreateCampaign))))

--- a/internal/web/store.go
+++ b/internal/web/store.go
@@ -2,7 +2,10 @@ package web
 
 import (
 	"context"
+	"crypto/rand"
 	"embed"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -23,16 +26,37 @@ var migrationsFS embed.FS
 
 // User represents a web management user.
 type User struct {
-	ID          string     `json:"id"`
-	TenantID    string     `json:"tenant_id"`
-	DiscordID   *string    `json:"discord_id,omitempty"`
-	Email       *string    `json:"email,omitempty"`
-	DisplayName string     `json:"display_name"`
-	AvatarURL   *string    `json:"avatar_url,omitempty"`
-	Role        string     `json:"role"`
-	LastLoginAt *time.Time `json:"last_login_at,omitempty"`
-	CreatedAt   time.Time  `json:"created_at"`
-	UpdatedAt   time.Time  `json:"updated_at"`
+	ID          string          `json:"id"`
+	TenantID    string          `json:"tenant_id"`
+	DiscordID   *string         `json:"discord_id,omitempty"`
+	Email       *string         `json:"email,omitempty"`
+	DisplayName string          `json:"display_name"`
+	AvatarURL   *string         `json:"avatar_url,omitempty"`
+	Role        string          `json:"role"`
+	Preferences json.RawMessage `json:"preferences,omitempty"`
+	LastLoginAt *time.Time      `json:"last_login_at,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+}
+
+// Invite represents an invitation to join a tenant.
+type Invite struct {
+	ID        string     `json:"id"`
+	TenantID  string     `json:"tenant_id"`
+	Role      string     `json:"role"`
+	CreatedBy string     `json:"created_by"`
+	Token     string     `json:"token"`
+	ExpiresAt time.Time  `json:"expires_at"`
+	UsedBy    *string    `json:"used_by,omitempty"`
+	UsedAt    *time.Time `json:"used_at,omitempty"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+// ValidRoles is the set of assignable roles.
+var ValidRoles = map[string]bool{
+	"viewer":       true,
+	"dm":           true,
+	"tenant_admin": true,
 }
 
 // Campaign represents a campaign owned by a tenant.
@@ -53,6 +77,13 @@ type WebStore interface {
 	UpsertDiscordUser(ctx context.Context, discordID, email, displayName, avatarURL, tenantID string) (*User, error)
 	EnsureAdminUser(ctx context.Context, tenantID string) (*User, error)
 	GetUser(ctx context.Context, id string) (*User, error)
+	ListUsers(ctx context.Context, tenantID, role string, limit, offset int) ([]User, int, error)
+	UpdateUser(ctx context.Context, u *User) error
+	DeleteUser(ctx context.Context, id string) error
+	UpdateUserPreferences(ctx context.Context, id string, prefs json.RawMessage) (*User, error)
+	CreateInvite(ctx context.Context, inv *Invite) error
+	GetInviteByToken(ctx context.Context, token string) (*Invite, error)
+	UseInvite(ctx context.Context, inviteID, userID string) error
 	CreateCampaign(ctx context.Context, c *Campaign) error
 	GetCampaign(ctx context.Context, tenantID, id string) (*Campaign, error)
 	ListCampaigns(ctx context.Context, tenantID string) ([]Campaign, error)
@@ -164,13 +195,13 @@ func (s *Store) EnsureAdminUser(ctx context.Context, tenantID string) (*User, er
 func (s *Store) GetUser(ctx context.Context, id string) (*User, error) {
 	var user User
 	err := s.pool.QueryRow(ctx, `
-		SELECT id, tenant_id, discord_id, email, display_name, avatar_url, role, last_login_at, created_at, updated_at
+		SELECT id, tenant_id, discord_id, email, display_name, avatar_url, role, preferences, last_login_at, created_at, updated_at
 		FROM mgmt.users
 		WHERE id = $1 AND deleted_at IS NULL
 	`, id).Scan(
 		&user.ID, &user.TenantID, &user.DiscordID, &user.Email,
-		&user.DisplayName, &user.AvatarURL, &user.Role, &user.LastLoginAt,
-		&user.CreatedAt, &user.UpdatedAt,
+		&user.DisplayName, &user.AvatarURL, &user.Role, &user.Preferences,
+		&user.LastLoginAt, &user.CreatedAt, &user.UpdatedAt,
 	)
 	if err == pgx.ErrNoRows {
 		return nil, nil
@@ -380,4 +411,181 @@ func (s *Store) GetUsage(ctx context.Context, tenantID string, from, to time.Tim
 		records = append(records, r)
 	}
 	return records, rows.Err()
+}
+
+// ListUsers returns users for a tenant, optionally filtered by role. Returns
+// the user slice and total count for pagination.
+func (s *Store) ListUsers(ctx context.Context, tenantID, role string, limit, offset int) ([]User, int, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+
+	where := "tenant_id = $1 AND deleted_at IS NULL"
+	args := []any{tenantID}
+	if role != "" {
+		args = append(args, role)
+		where += fmt.Sprintf(" AND role = $%d", len(args))
+	}
+
+	var total int
+	err := s.pool.QueryRow(ctx, "SELECT count(*) FROM mgmt.users WHERE "+where, args...).Scan(&total)
+	if err != nil {
+		return nil, 0, fmt.Errorf("web: count users: %w", err)
+	}
+
+	args = append(args, limit, offset)
+	query := fmt.Sprintf(`
+		SELECT id, tenant_id, discord_id, email, display_name, avatar_url, role, preferences, last_login_at, created_at, updated_at
+		FROM mgmt.users
+		WHERE %s
+		ORDER BY created_at DESC
+		LIMIT $%d OFFSET $%d
+	`, where, len(args)-1, len(args))
+
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("web: list users: %w", err)
+	}
+	defer rows.Close()
+
+	var users []User
+	for rows.Next() {
+		var u User
+		if err := rows.Scan(&u.ID, &u.TenantID, &u.DiscordID, &u.Email,
+			&u.DisplayName, &u.AvatarURL, &u.Role, &u.Preferences,
+			&u.LastLoginAt, &u.CreatedAt, &u.UpdatedAt); err != nil {
+			return nil, 0, fmt.Errorf("web: scan user: %w", err)
+		}
+		users = append(users, u)
+	}
+	return users, total, rows.Err()
+}
+
+// UpdateUser updates mutable fields on a user (display_name, role).
+func (s *Store) UpdateUser(ctx context.Context, u *User) error {
+	u.UpdatedAt = time.Now().UTC()
+
+	sets := []string{}
+	args := []any{u.ID}
+	idx := 2
+
+	if u.DisplayName != "" {
+		sets = append(sets, fmt.Sprintf("display_name = $%d", idx))
+		args = append(args, u.DisplayName)
+		idx++
+	}
+	if u.Role != "" {
+		sets = append(sets, fmt.Sprintf("role = $%d", idx))
+		args = append(args, u.Role)
+		idx++
+	}
+
+	sets = append(sets, fmt.Sprintf("updated_at = $%d", idx))
+	args = append(args, u.UpdatedAt)
+
+	query := fmt.Sprintf("UPDATE mgmt.users SET %s WHERE id = $1 AND deleted_at IS NULL", strings.Join(sets, ", "))
+	tag, err := s.pool.Exec(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("web: update user %q: %w", u.ID, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("web: user %q not found", u.ID)
+	}
+	return nil
+}
+
+// DeleteUser soft-deletes a user.
+func (s *Store) DeleteUser(ctx context.Context, id string) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE mgmt.users SET deleted_at = now() WHERE id = $1 AND deleted_at IS NULL
+	`, id)
+	if err != nil {
+		return fmt.Errorf("web: delete user %q: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("web: user %q not found", id)
+	}
+	return nil
+}
+
+// UpdateUserPreferences merges preferences JSON into the existing preferences
+// column and returns the updated user.
+func (s *Store) UpdateUserPreferences(ctx context.Context, id string, prefs json.RawMessage) (*User, error) {
+	var user User
+	err := s.pool.QueryRow(ctx, `
+		UPDATE mgmt.users
+		SET preferences = preferences || $2, updated_at = now()
+		WHERE id = $1 AND deleted_at IS NULL
+		RETURNING id, tenant_id, discord_id, email, display_name, avatar_url, role, preferences, last_login_at, created_at, updated_at
+	`, id, prefs).Scan(
+		&user.ID, &user.TenantID, &user.DiscordID, &user.Email,
+		&user.DisplayName, &user.AvatarURL, &user.Role, &user.Preferences,
+		&user.LastLoginAt, &user.CreatedAt, &user.UpdatedAt,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("web: update preferences for user %q: %w", id, err)
+	}
+	return &user, nil
+}
+
+// CreateInvite persists a new invite, generating a secure random token.
+func (s *Store) CreateInvite(ctx context.Context, inv *Invite) error {
+	if inv.ID == "" {
+		inv.ID = uuid.NewString()
+	}
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Errorf("web: generate invite token: %w", err)
+	}
+	inv.Token = hex.EncodeToString(b)
+	inv.CreatedAt = time.Now().UTC()
+	if inv.ExpiresAt.IsZero() {
+		inv.ExpiresAt = inv.CreatedAt.Add(7 * 24 * time.Hour)
+	}
+
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO mgmt.invites (id, tenant_id, role, created_by, token, expires_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, inv.ID, inv.TenantID, inv.Role, inv.CreatedBy, inv.Token, inv.ExpiresAt, inv.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("web: create invite: %w", err)
+	}
+	return nil
+}
+
+// GetInviteByToken retrieves an unused, non-expired invite by its token.
+func (s *Store) GetInviteByToken(ctx context.Context, token string) (*Invite, error) {
+	var inv Invite
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, tenant_id, role, created_by, token, expires_at, used_by, used_at, created_at
+		FROM mgmt.invites
+		WHERE token = $1 AND used_at IS NULL AND expires_at > now()
+	`, token).Scan(
+		&inv.ID, &inv.TenantID, &inv.Role, &inv.CreatedBy, &inv.Token,
+		&inv.ExpiresAt, &inv.UsedBy, &inv.UsedAt, &inv.CreatedAt,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("web: get invite by token: %w", err)
+	}
+	return &inv, nil
+}
+
+// UseInvite marks an invite as used by the given user.
+func (s *Store) UseInvite(ctx context.Context, inviteID, userID string) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE mgmt.invites SET used_by = $2, used_at = now() WHERE id = $1 AND used_at IS NULL
+	`, inviteID, userID)
+	if err != nil {
+		return fmt.Errorf("web: use invite %q: %w", inviteID, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("web: invite %q not found or already used", inviteID)
+	}
+	return nil
 }

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -1,15 +1,48 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { useUser } from "@/lib/hooks";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useUser, useUpdateMe, useUpdatePreferences } from "@/lib/hooks";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumbs } from "@/components/breadcrumbs";
-import { Settings as SettingsIcon } from "lucide-react";
 
 export default function SettingsPage() {
   const { data: user } = useUser();
+  const updateMe = useUpdateMe();
+  const updatePreferences = useUpdatePreferences();
+
+  const [displayName, setDisplayName] = useState("");
+  const [theme, setTheme] = useState<"light" | "dark" | "system">("system");
+  const [locale, setLocale] = useState("en");
+
+  useEffect(() => {
+    if (user) {
+      setDisplayName(user.display_name ?? "");
+      setTheme(user.preferences?.theme ?? "system");
+      setLocale(user.preferences?.locale ?? "en");
+    }
+  }, [user]);
+
+  const handleSaveProfile = () => {
+    if (displayName.trim()) {
+      updateMe.mutate({ display_name: displayName.trim() });
+    }
+  };
+
+  const handleSavePreferences = () => {
+    updatePreferences.mutate({ theme, locale });
+  };
 
   return (
     <div className="mx-auto max-w-2xl space-y-6">
@@ -45,6 +78,28 @@ export default function SettingsPage() {
               </Badge>
             </div>
           </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="displayName">Display Name</Label>
+            <div className="flex gap-2">
+              <Input
+                id="displayName"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                placeholder="Your display name"
+              />
+              <Button
+                onClick={handleSaveProfile}
+                disabled={
+                  updateMe.isPending ||
+                  !displayName.trim() ||
+                  displayName.trim() === user?.display_name
+                }
+              >
+                {updateMe.isPending ? "Saving..." : "Save"}
+              </Button>
+            </div>
+          </div>
         </CardContent>
       </Card>
 
@@ -52,17 +107,40 @@ export default function SettingsPage() {
         <CardHeader>
           <CardTitle>Preferences</CardTitle>
         </CardHeader>
-        <CardContent>
-          <div className="flex flex-col items-center gap-3 py-6 text-center">
-            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-muted">
-              <SettingsIcon className="h-6 w-6 text-muted-foreground/50" />
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Additional settings and preferences will be available here in a
-              future update, including API key management, notification
-              preferences, and billing.
-            </p>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="theme">Theme</Label>
+            <Select value={theme} onValueChange={(v) => setTheme(v as "light" | "dark" | "system")}>
+              <SelectTrigger id="theme">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="system">System</SelectItem>
+                <SelectItem value="light">Light</SelectItem>
+                <SelectItem value="dark">Dark</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="locale">Language</Label>
+            <Select value={locale} onValueChange={setLocale}>
+              <SelectTrigger id="locale">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="en">English</SelectItem>
+                <SelectItem value="de">Deutsch</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Button
+            onClick={handleSavePreferences}
+            disabled={updatePreferences.isPending}
+          >
+            {updatePreferences.isPending ? "Saving..." : "Save Preferences"}
+          </Button>
         </CardContent>
       </Card>
 

--- a/web/src/app/(app)/users/page.tsx
+++ b/web/src/app/(app)/users/page.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState } from "react";
+import { Users as UsersIcon, AlertTriangle, Copy, Plus, Trash2 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Breadcrumbs } from "@/components/breadcrumbs";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  useUsers,
+  useDeleteUser,
+  useCreateInvite,
+  useUser,
+} from "@/lib/hooks";
+import { toast } from "sonner";
+import type { UserRole } from "@/lib/types";
+
+const roleBadgeVariant: Record<
+  UserRole,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  super_admin: "destructive",
+  tenant_admin: "default",
+  dm: "secondary",
+  viewer: "outline",
+};
+
+export default function UsersPage() {
+  const { data: currentUser } = useUser();
+  const { data, isLoading, isError, error } = useUsers();
+  const deleteUser = useDeleteUser();
+  const createInvite = useCreateInvite();
+  const [inviteRole, setInviteRole] = useState<UserRole>("viewer");
+
+  const users = data?.data ?? [];
+
+  const handleInvite = async () => {
+    const result = await createInvite.mutateAsync(inviteRole);
+    // Copy token to clipboard.
+    if (result?.token) {
+      await navigator.clipboard.writeText(result.token);
+      toast.success("Invite link copied to clipboard");
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumbs items={[{ label: "Users" }]} />
+
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Users</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Manage team members and invite new users.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Select
+            value={inviteRole}
+            onValueChange={(v) => setInviteRole(v as UserRole)}
+          >
+            <SelectTrigger className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="viewer">Viewer</SelectItem>
+              <SelectItem value="dm">DM</SelectItem>
+              <SelectItem value="tenant_admin">Admin</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button onClick={handleInvite} disabled={createInvite.isPending}>
+            <Plus className="mr-2 h-4 w-4" />
+            Invite
+          </Button>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <Card>
+          <CardContent className="space-y-3 p-6">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex gap-4">
+                <div className="h-8 w-8 rounded-full bg-muted skeleton-shimmer" />
+                <div className="h-5 w-32 rounded bg-muted skeleton-shimmer" />
+                <div className="h-5 w-24 rounded bg-muted skeleton-shimmer" />
+                <div className="h-5 w-16 rounded bg-muted skeleton-shimmer" />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      ) : isError ? (
+        <Card className="border-destructive/50">
+          <CardContent className="py-8 text-center">
+            <AlertTriangle className="mx-auto h-12 w-12 text-destructive" />
+            <h3 className="mt-4 text-lg font-medium">Failed to load users</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {error?.message || "An unexpected error occurred."}
+            </p>
+          </CardContent>
+        </Card>
+      ) : users.length > 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              Team Members ({data?.total ?? users.length})
+            </CardTitle>
+          </CardHeader>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>User</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead className="w-12" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {users.map((u) => (
+                  <TableRow key={u.id}>
+                    <TableCell>
+                      <div className="flex items-center gap-3">
+                        <Avatar className="h-8 w-8">
+                          <AvatarImage
+                            src={u.avatar_url ?? undefined}
+                            alt={u.display_name}
+                          />
+                          <AvatarFallback className="text-xs">
+                            {u.display_name?.[0]?.toUpperCase() ?? "?"}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span className="font-medium">
+                          {u.display_name}
+                          {u.id === currentUser?.id && (
+                            <span className="ml-1.5 text-xs text-muted-foreground">
+                              (you)
+                            </span>
+                          )}
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {u.email || "\u2014"}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={roleBadgeVariant[u.role]}>
+                        {u.role.replace("_", " ")}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {u.id !== currentUser?.id && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="text-destructive hover:text-destructive"
+                          onClick={() => {
+                            if (confirm(`Remove ${u.display_name}?`)) {
+                              deleteUser.mutate(u.id);
+                            }
+                          }}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </Card>
+      ) : (
+        <Card className="border-dashed">
+          <CardContent className="py-16 text-center">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10">
+              <UsersIcon className="h-8 w-8 text-primary/60" />
+            </div>
+            <h3 className="text-lg font-medium">No team members yet</h3>
+            <p className="mx-auto mt-2 max-w-sm text-sm text-muted-foreground">
+              Invite your first team member using the button above.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -7,16 +7,27 @@ import {
   Swords,
   ScrollText,
   Settings,
+  Users,
   X,
   Sparkles,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { useUser } from "@/lib/hooks";
+import type { UserRole } from "@/lib/types";
 
-const navItems = [
+interface NavItem {
+  href: string;
+  label: string;
+  icon: typeof LayoutDashboard;
+  minRole?: UserRole;
+}
+
+const navItems: NavItem[] = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/campaigns", label: "Campaigns", icon: Swords },
   { href: "/sessions", label: "Sessions", icon: ScrollText },
+  { href: "/users", label: "Users", icon: Users, minRole: "tenant_admin" },
   { href: "/settings", label: "Settings", icon: Settings },
 ];
 
@@ -25,8 +36,17 @@ interface SidebarProps {
   onClose: () => void;
 }
 
+const roleLevels: Record<UserRole, number> = {
+  viewer: 0,
+  dm: 1,
+  tenant_admin: 2,
+  super_admin: 3,
+};
+
 export function Sidebar({ open, onClose }: SidebarProps) {
   const pathname = usePathname();
+  const { data: user } = useUser();
+  const userLevel = roleLevels[user?.role ?? "viewer"];
 
   return (
     <>
@@ -68,7 +88,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         </div>
 
         <nav className="flex-1 space-y-1 p-3" role="navigation" aria-label="Main navigation">
-          {navItems.map((item) => {
+          {navItems.filter((item) => !item.minRole || userLevel >= roleLevels[item.minRole]).map((item) => {
             const active =
               pathname === item.href || pathname.startsWith(item.href + "/");
             return (

--- a/web/src/components/topbar.tsx
+++ b/web/src/components/topbar.tsx
@@ -3,6 +3,7 @@
 import { Menu, LogOut } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -55,6 +56,11 @@ export function Topbar({ user, onMenuClick }: TopbarProps) {
           <div className="px-2 py-1.5">
             <p className="text-sm font-medium">{user?.display_name}</p>
             <p className="text-xs text-muted-foreground">{user?.email}</p>
+            {user?.role && (
+              <Badge variant="secondary" className="mt-1 text-[10px]">
+                {user.role.replace("_", " ")}
+              </Badge>
+            )}
           </div>
           <DropdownMenuItem
             onClick={async () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6,6 +6,10 @@ import type {
   DashboardStats,
   ActivityItem,
   User,
+  Invite,
+  UserRole,
+  UserPreferences,
+  PaginatedResponse,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "/api/v1";
@@ -161,4 +165,39 @@ export const sessions = {
     request<TranscriptEntry[]>(`/sessions/${id}/transcript`),
 };
 
-export const api = { auth, dashboard, campaigns, npcs, sessions };
+// Users
+export const users = {
+  list: (params?: { role?: UserRole; limit?: number; offset?: number }) => {
+    const q = new URLSearchParams();
+    if (params?.role) q.set("role", params.role);
+    if (params?.limit) q.set("limit", String(params.limit));
+    if (params?.offset) q.set("offset", String(params.offset));
+    const qs = q.toString();
+    return request<PaginatedResponse<User>>(`/users${qs ? `?${qs}` : ""}`);
+  },
+  get: (id: string) => request<User>(`/users/${id}`),
+  update: (id: string, data: { display_name?: string; role?: UserRole }) =>
+    request<User>(`/users/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
+  delete: (id: string) =>
+    request<void>(`/users/${id}`, { method: "DELETE" }),
+  invite: (role: UserRole = "viewer") =>
+    request<Invite>("/users/invite", {
+      method: "POST",
+      body: JSON.stringify({ role }),
+    }),
+  updateMe: (data: { display_name: string }) =>
+    request<User>("/auth/me", {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
+  updatePreferences: (prefs: Partial<UserPreferences>) =>
+    request<User>("/auth/me/preferences", {
+      method: "PATCH",
+      body: JSON.stringify(prefs),
+    }),
+};
+
+export const api = { auth, dashboard, campaigns, npcs, sessions, users };

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -3,7 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "./api";
-import type { Campaign, NPC, BotMode } from "./types";
+import type { Campaign, NPC, UserRole, UserPreferences } from "./types";
 
 // Auth
 export function useUser() {
@@ -186,32 +186,69 @@ export function useStopSession() {
   });
 }
 
-// Onboarding
-export function useDiscordGuilds() {
+// Users
+export function useUsers(params?: { role?: UserRole; limit?: number; offset?: number }) {
   return useQuery({
-    queryKey: ["onboarding", "guilds"],
-    queryFn: api.onboarding.guilds,
-    retry: false,
-    staleTime: 60 * 1000,
+    queryKey: ["users", params],
+    queryFn: () => api.users.list(params),
   });
 }
 
-export function useOnboardingSetup() {
+export function useUpdateUser(id: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({
-      botMode,
-      guildIds,
-      botToken,
-    }: {
-      botMode: BotMode;
-      guildIds: string[];
-      botToken?: string;
-    }) => api.onboarding.setup(botMode, guildIds, botToken),
+    mutationFn: (data: { display_name?: string; role?: UserRole }) =>
+      api.users.update(id, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["users"] });
+      toast.success("User updated");
+    },
+    onError: (err) => toast.error("Failed to update user", { description: err.message }),
+  });
+}
+
+export function useDeleteUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.users.delete(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["users"] });
+      toast.success("User removed");
+    },
+    onError: (err) => toast.error("Failed to delete user", { description: err.message }),
+  });
+}
+
+export function useCreateInvite() {
+  return useMutation({
+    mutationFn: (role: UserRole) => api.users.invite(role),
+    onSuccess: () => {
+      toast.success("Invite created");
+    },
+    onError: (err) => toast.error("Failed to create invite", { description: err.message }),
+  });
+}
+
+export function useUpdateMe() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { display_name: string }) => api.users.updateMe(data),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["user"] });
-      toast.success("Setup complete! Welcome to Glyphoxa.");
+      toast.success("Profile updated");
     },
-    onError: (err) => toast.error("Setup failed", { description: err.message }),
+    onError: (err) => toast.error("Failed to update profile", { description: err.message }),
+  });
+}
+
+export function useUpdatePreferences() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (prefs: Partial<UserPreferences>) => api.users.updatePreferences(prefs),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["user"] });
+      toast.success("Preferences saved");
+    },
+    onError: (err) => toast.error("Failed to save preferences", { description: err.message }),
   });
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,13 +1,40 @@
 // API types for the Glyphoxa Web Management Service
 
+export type UserRole = "super_admin" | "tenant_admin" | "dm" | "viewer";
+
+export interface UserPreferences {
+  theme?: "light" | "dark" | "system";
+  locale?: string;
+  [key: string]: unknown;
+}
+
 export interface User {
   id: string;
   email: string;
   display_name: string;
   avatar_url: string | null;
-  role: "super_admin" | "tenant_admin" | "dm" | "viewer";
+  role: UserRole;
+  preferences?: UserPreferences;
   tenant_id: string;
   created_at: string;
+  updated_at?: string;
+}
+
+export interface Invite {
+  id: string;
+  tenant_id: string;
+  role: UserRole;
+  created_by: string;
+  token: string;
+  expires_at: string;
+  used_by?: string;
+  used_at?: string;
+  created_at: string;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
 }
 
 export interface Campaign {


### PR DESCRIPTION
## Summary
- **User CRUD endpoints** (list, get, update, delete) with role-based access control
- **Role hierarchy**: super_admin > tenant_admin > dm > viewer with enforcement on all operations
- **Invite system**: time-limited invite links with pre-assigned roles
- **User preferences**: JSONB-backed preferences with deep merge (theme, language, notifications)
- **Profile self-service**: users can update their own display name and email
- **Frontend**: user management page, enhanced settings page, role badges, sidebar gating

## Backend
- `internal/web/migrations/002_user_management.sql` - preferences column + invites table
- `internal/web/store.go` - 7 new store methods (ListUsers, UpdateUser, DeleteUser, UpdateUserPreferences, CreateInvite, GetInviteByToken, UseInvite)
- `internal/web/handlers_users.go` - 7 new HTTP handlers
- `internal/web/server.go` - 7 new routes
- `internal/web/handlers_users_test.go` - comprehensive test coverage

## Frontend
- `web/src/app/(app)/users/page.tsx` - user management page with invite dialog
- `web/src/app/(app)/settings/page.tsx` - profile editing + preferences
- `web/src/components/sidebar.tsx` - Users nav (tenant_admin+ only)
- `web/src/components/topbar.tsx` - role badge in dropdown

## Test plan
- [x] All Go tests pass with race detector
- [x] TypeScript compiles without errors
- [ ] Manual test: list users as tenant_admin
- [ ] Manual test: change user role, verify role escalation prevention
- [ ] Manual test: create invite link and verify expiry
- [ ] Manual test: update profile and preferences
- [ ] Manual test: verify Users nav hidden for viewer/dm roles