### PR TITLE
fix(security): cross-tenant isolation, gRPC auth for web management

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -553,36 +553,22 @@ func runGateway(cfg *config.Config) int {
 		grpcOpts = append(grpcOpts, tlsCred)
 	}
 
+	// Shared secret for ManagementService RPCs. When set, callers must
+	// include the secret in gRPC metadata to access management endpoints.
+	mgmtSecret := os.Getenv("GLYPHOXA_GRPC_MGMT_SECRET")
+	if mgmtSecret != "" {
+		slog.Info("management gRPC auth enabled (shared secret)")
+		grpcOpts = append(grpcOpts,
+			grpc.ChainUnaryInterceptor(grpctransport.ManagementAuthUnaryInterceptor(mgmtSecret)),
+			grpc.ChainStreamInterceptor(grpctransport.ManagementAuthStreamInterceptor(mgmtSecret)),
+		)
+	} else {
+		slog.Warn("GLYPHOXA_GRPC_MGMT_SECRET not set — ManagementService RPCs are unauthenticated; restrict network access in production")
+	}
+
 	gwGRPCServer := grpc.NewServer(grpcOpts...)
 	grpctransport.NewGatewayServer(recordingBridge).Register(gwGRPCServer)
 	audioBridgeSrv.Register(gwGRPCServer)
-
-	grpctransport.NewManagementServer(grpctransport.ManagementServerConfig{
-		Store:      adminStore,
-		Bots:       botConnector,
-		Orch:       orch,
-		UsageStore: usageStore,
-		BotChecker: botMgr,
-		CtrlLookup: ctrlRegistry.Lookup,
-	}).Register(gwGRPCServer)
-
-	grpctransport.NewManagementServer(grpctransport.ManagementServerConfig{
-		Store:      adminStore,
-		Bots:       botConnector,
-		Orch:       orch,
-		UsageStore: usageStore,
-		BotChecker: botMgr,
-		CtrlLookup: ctrlRegistry.Lookup,
-	}).Register(gwGRPCServer)
-
-	grpctransport.NewManagementServer(grpctransport.ManagementServerConfig{
-		Store:      adminStore,
-		Bots:       botConnector,
-		Orch:       orch,
-		UsageStore: usageStore,
-		BotChecker: botMgr,
-		CtrlLookup: ctrlRegistry.Lookup,
-	}).Register(gwGRPCServer)
 
 	// Management gRPC service — used by the web management service for
 	// tenant CRUD, session start/stop, usage queries, and bot status.

--- a/internal/gateway/grpctransport/mgmt_auth.go
+++ b/internal/gateway/grpctransport/mgmt_auth.go
@@ -1,0 +1,105 @@
+package grpctransport
+
+import (
+	"context"
+	"crypto/subtle"
+	"log/slog"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	// mgmtSecretKey is the gRPC metadata key used to transmit the
+	// management shared secret.
+	mgmtSecretKey = "x-mgmt-secret"
+
+	// managementServicePrefix matches all ManagementService RPCs.
+	managementServicePrefix = "/glyphoxa.v1.ManagementService/"
+)
+
+// ManagementAuthUnaryInterceptor returns a [grpc.UnaryServerInterceptor] that
+// validates a shared secret in gRPC metadata for ManagementService RPCs.
+// Other services (GatewayService, AudioBridgeService) pass through unchecked.
+//
+// If secret is empty the interceptor is a no-op (backward compatible for dev).
+func ManagementAuthUnaryInterceptor(secret string) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		if secret == "" || !strings.HasPrefix(info.FullMethod, managementServicePrefix) {
+			return handler(ctx, req)
+		}
+		if err := verifyMgmtSecret(ctx, secret); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// ManagementAuthStreamInterceptor returns a [grpc.StreamServerInterceptor]
+// that validates a shared secret for ManagementService streaming RPCs.
+func ManagementAuthStreamInterceptor(secret string) grpc.StreamServerInterceptor {
+	return func(
+		srv any,
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		if secret == "" || !strings.HasPrefix(info.FullMethod, managementServicePrefix) {
+			return handler(srv, ss)
+		}
+		if err := verifyMgmtSecret(ss.Context(), secret); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+}
+
+// verifyMgmtSecret extracts the shared secret from gRPC metadata and compares
+// it against the expected value using constant-time comparison.
+func verifyMgmtSecret(ctx context.Context, expected string) error {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		slog.Warn("mgmt-auth: request missing metadata")
+		return status.Error(codes.Unauthenticated, "missing authentication metadata")
+	}
+
+	vals := md.Get(mgmtSecretKey)
+	if len(vals) == 0 || vals[0] == "" {
+		slog.Warn("mgmt-auth: request missing shared secret")
+		return status.Error(codes.Unauthenticated, "missing management secret")
+	}
+
+	if subtle.ConstantTimeCompare([]byte(vals[0]), []byte(expected)) != 1 {
+		slog.Warn("mgmt-auth: invalid shared secret")
+		return status.Error(codes.Unauthenticated, "invalid management secret")
+	}
+
+	return nil
+}
+
+// MgmtSecretUnaryClientInterceptor returns a [grpc.UnaryClientInterceptor]
+// that injects the shared secret into outgoing gRPC metadata.
+// If secret is empty the interceptor is a no-op.
+func MgmtSecretUnaryClientInterceptor(secret string) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		if secret != "" {
+			ctx = metadata.AppendToOutgoingContext(ctx, mgmtSecretKey, secret)
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}

--- a/internal/gateway/grpctransport/mgmt_auth_test.go
+++ b/internal/gateway/grpctransport/mgmt_auth_test.go
@@ -1,0 +1,155 @@
+package grpctransport
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func TestManagementAuthUnaryInterceptor(t *testing.T) {
+	t.Parallel()
+
+	dummyHandler := func(_ context.Context, _ any) (any, error) {
+		return "ok", nil
+	}
+
+	tests := []struct {
+		name     string
+		secret   string
+		method   string
+		mdSecret string
+		wantCode codes.Code
+		wantPass bool
+	}{
+		{
+			name:     "no secret configured — passthrough",
+			secret:   "",
+			method:   "/glyphoxa.v1.ManagementService/CreateTenant",
+			mdSecret: "",
+			wantPass: true,
+		},
+		{
+			name:     "non-management RPC — passthrough",
+			secret:   "my-secret",
+			method:   "/glyphoxa.v1.GatewayService/SessionReady",
+			mdSecret: "",
+			wantPass: true,
+		},
+		{
+			name:     "valid secret",
+			secret:   "my-secret",
+			method:   "/glyphoxa.v1.ManagementService/CreateTenant",
+			mdSecret: "my-secret",
+			wantPass: true,
+		},
+		{
+			name:     "missing secret",
+			secret:   "my-secret",
+			method:   "/glyphoxa.v1.ManagementService/CreateTenant",
+			mdSecret: "",
+			wantCode: codes.Unauthenticated,
+		},
+		{
+			name:     "wrong secret",
+			secret:   "my-secret",
+			method:   "/glyphoxa.v1.ManagementService/CreateTenant",
+			mdSecret: "wrong-secret",
+			wantCode: codes.Unauthenticated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			interceptor := ManagementAuthUnaryInterceptor(tt.secret)
+
+			ctx := context.Background()
+			if tt.mdSecret != "" {
+				md := metadata.Pairs(mgmtSecretKey, tt.mdSecret)
+				ctx = metadata.NewIncomingContext(ctx, md)
+			}
+
+			info := &grpc.UnaryServerInfo{FullMethod: tt.method}
+			resp, err := interceptor(ctx, nil, info, dummyHandler)
+
+			if tt.wantPass {
+				if err != nil {
+					t.Fatalf("expected pass, got error: %v", err)
+				}
+				if resp != "ok" {
+					t.Errorf("expected response 'ok', got %v", resp)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				st, ok := status.FromError(err)
+				if !ok {
+					t.Fatalf("expected gRPC status error, got: %v", err)
+				}
+				if st.Code() != tt.wantCode {
+					t.Errorf("code = %v, want %v", st.Code(), tt.wantCode)
+				}
+			}
+		})
+	}
+}
+
+func TestMgmtSecretUnaryClientInterceptor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("injects secret into metadata", func(t *testing.T) {
+		t.Parallel()
+
+		interceptor := MgmtSecretUnaryClientInterceptor("client-secret")
+
+		var capturedCtx context.Context
+		fakeInvoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			capturedCtx = ctx
+			return nil
+		}
+
+		ctx := context.Background()
+		err := interceptor(ctx, "/test/method", nil, nil, nil, fakeInvoker)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		md, ok := metadata.FromOutgoingContext(capturedCtx)
+		if !ok {
+			t.Fatal("expected outgoing metadata")
+		}
+		vals := md.Get(mgmtSecretKey)
+		if len(vals) != 1 || vals[0] != "client-secret" {
+			t.Errorf("secret in metadata = %v, want [client-secret]", vals)
+		}
+	})
+
+	t.Run("no-op when empty secret", func(t *testing.T) {
+		t.Parallel()
+
+		interceptor := MgmtSecretUnaryClientInterceptor("")
+
+		var capturedCtx context.Context
+		fakeInvoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			capturedCtx = ctx
+			return nil
+		}
+
+		ctx := context.Background()
+		err := interceptor(ctx, "/test/method", nil, nil, nil, fakeInvoker)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		md, ok := metadata.FromOutgoingContext(capturedCtx)
+		if ok && len(md.Get(mgmtSecretKey)) > 0 {
+			t.Error("expected no secret in metadata when secret is empty")
+		}
+	})
+}

--- a/internal/web/config.go
+++ b/internal/web/config.go
@@ -59,6 +59,11 @@ type Config struct {
 	// gateway's server certificate.
 	GatewayTLSCA string
 
+	// GatewaySharedSecret is the shared secret for authenticating to the
+	// gateway's ManagementService gRPC endpoint. When set, the secret is
+	// sent in gRPC metadata on every management RPC.
+	GatewaySharedSecret string
+
 	// AllowedOrigins is the list of origins permitted by CORS. An empty list
 	// defaults to ["*"] (allow all), which is acceptable for development but
 	// should be restricted in production.
@@ -89,6 +94,7 @@ func LoadConfig() (*Config, error) {
 		GatewayTLSCert:      os.Getenv("GLYPHOXA_WEB_GATEWAY_TLS_CERT"),
 		GatewayTLSKey:       os.Getenv("GLYPHOXA_WEB_GATEWAY_TLS_KEY"),
 		GatewayTLSCA:        os.Getenv("GLYPHOXA_WEB_GATEWAY_TLS_CA"),
+		GatewaySharedSecret: os.Getenv("GLYPHOXA_WEB_GATEWAY_SECRET"),
 		ListenAddr:          os.Getenv("GLYPHOXA_WEB_LISTEN_ADDR"),
 	}
 

--- a/internal/web/gateway_client.go
+++ b/internal/web/gateway_client.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	pb "github.com/MrWong99/glyphoxa/gen/glyphoxa/v1"
+	"github.com/MrWong99/glyphoxa/internal/gateway/grpctransport"
 )
 
 // DialGateway establishes a gRPC connection to the gateway's ManagementService.
@@ -31,6 +32,13 @@ func DialGateway(cfg *Config) (pb.ManagementServiceClient, *grpc.ClientConn, err
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)))
 	} else {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
+	// Send shared secret in gRPC metadata for ManagementService auth.
+	if cfg.GatewaySharedSecret != "" {
+		opts = append(opts, grpc.WithUnaryInterceptor(
+			grpctransport.MgmtSecretUnaryClientInterceptor(cfg.GatewaySharedSecret),
+		))
 	}
 
 	conn, err := grpc.NewClient(cfg.GatewayGRPCAddr, opts...)

--- a/internal/web/handlers_campaign_npcs.go
+++ b/internal/web/handlers_campaign_npcs.go
@@ -31,6 +31,13 @@ func (s *Server) handleLinkNPCToCampaign(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Verify the NPC's home campaign belongs to this tenant (prevent cross-tenant linking).
+	npcCampaign, err := s.store.GetCampaign(r.Context(), claims.TenantID, npc.CampaignID)
+	if err != nil || npcCampaign == nil {
+		writeError(w, http.StatusNotFound, "not_found", "NPC not found")
+		return
+	}
+
 	// Reject linking to the NPC's home campaign.
 	if npc.CampaignID == campaignID {
 		writeError(w, http.StatusBadRequest, "same_campaign", "cannot link NPC to its home campaign")

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -177,8 +177,9 @@ func (m *mockWebStore) UpdateUser(_ context.Context, u *User) error {
 	return nil
 }
 
-func (m *mockWebStore) DeleteUser(_ context.Context, id string) error {
-	if _, ok := m.users[id]; !ok {
+func (m *mockWebStore) DeleteUser(_ context.Context, tenantID, id string) error {
+	u, ok := m.users[id]
+	if !ok || u.TenantID != tenantID {
 		return fmt.Errorf("web: user %q not found", id)
 	}
 	delete(m.users, id)

--- a/internal/web/handlers_users.go
+++ b/internal/web/handlers_users.go
@@ -88,6 +88,15 @@ func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// When admins update another user, verify they belong to the same tenant.
+	if id != claims.Sub {
+		target, err := s.store.GetUser(r.Context(), id)
+		if err != nil || target == nil || target.TenantID != claims.TenantID {
+			writeError(w, http.StatusNotFound, "not_found", "user not found")
+			return
+		}
+	}
+
 	var req UserUpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_json", "invalid JSON body")
@@ -146,7 +155,14 @@ func (s *Server) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.store.DeleteUser(r.Context(), id); err != nil {
+	// Verify the target user belongs to the same tenant before deleting.
+	target, err := s.store.GetUser(r.Context(), id)
+	if err != nil || target == nil || target.TenantID != claims.TenantID {
+		writeError(w, http.StatusNotFound, "not_found", "user not found")
+		return
+	}
+
+	if err := s.store.DeleteUser(r.Context(), claims.TenantID, id); err != nil {
 		slog.Error("web: delete user", "user_id", id, "err", err)
 		writeError(w, http.StatusNotFound, "not_found", "user not found")
 		return

--- a/internal/web/handlers_users_test.go
+++ b/internal/web/handlers_users_test.go
@@ -116,6 +116,7 @@ func TestHandleUpdateUser(t *testing.T) {
 		{"dm cannot change role", "u1", "u1", "dm", `{"role":"tenant_admin"}`, http.StatusForbidden},
 		{"invalid role value", "u2", "u1", "tenant_admin", `{"role":"hacker"}`, http.StatusBadRequest},
 		{"invalid json", "u1", "u1", "dm", `{bad}`, http.StatusBadRequest},
+		{"cross-tenant update blocked", "u3", "u1", "tenant_admin", `{"role":"dm"}`, http.StatusNotFound},
 	}
 
 	for _, tt := range tests {
@@ -128,6 +129,7 @@ func TestHandleUpdateUser(t *testing.T) {
 
 			ws.users["u1"] = &User{ID: "u1", TenantID: "tenant-1", DisplayName: "Alice", Role: "dm"}
 			ws.users["u2"] = &User{ID: "u2", TenantID: "tenant-1", DisplayName: "Bob", Role: "viewer"}
+			ws.users["u3"] = &User{ID: "u3", TenantID: "tenant-2", DisplayName: "Eve", Role: "viewer"}
 
 			req := authReq(t, http.MethodPut, "/api/v1/users/"+tt.targetID,
 				bytes.NewBufferString(tt.body), secret, tt.callerID, "tenant-1", tt.role)
@@ -148,11 +150,13 @@ func TestHandleDeleteUser(t *testing.T) {
 		name     string
 		targetID string
 		callerID string
+		tenant   string
 		wantCode int
 	}{
-		{"delete other user", "u2", "u1", http.StatusNoContent},
-		{"cannot delete self", "u1", "u1", http.StatusBadRequest},
-		{"delete nonexistent", "u999", "u1", http.StatusNotFound},
+		{"delete other user", "u2", "u1", "tenant-1", http.StatusNoContent},
+		{"cannot delete self", "u1", "u1", "tenant-1", http.StatusBadRequest},
+		{"delete nonexistent", "u999", "u1", "tenant-1", http.StatusNotFound},
+		{"cross-tenant delete blocked", "u3", "u1", "tenant-1", http.StatusNotFound},
 	}
 
 	for _, tt := range tests {
@@ -165,13 +169,21 @@ func TestHandleDeleteUser(t *testing.T) {
 
 			ws.users["u1"] = &User{ID: "u1", TenantID: "tenant-1", DisplayName: "Alice", Role: "tenant_admin"}
 			ws.users["u2"] = &User{ID: "u2", TenantID: "tenant-1", DisplayName: "Bob", Role: "viewer"}
+			ws.users["u3"] = &User{ID: "u3", TenantID: "tenant-2", DisplayName: "Eve", Role: "viewer"}
 
-			req := authReq(t, http.MethodDelete, "/api/v1/users/"+tt.targetID, nil, secret, tt.callerID, "tenant-1", "tenant_admin")
+			req := authReq(t, http.MethodDelete, "/api/v1/users/"+tt.targetID, nil, secret, tt.callerID, tt.tenant, "tenant_admin")
 			rr := httptest.NewRecorder()
 			srv.mux.ServeHTTP(rr, req)
 
 			if rr.Code != tt.wantCode {
 				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+
+			// Verify cross-tenant user was not deleted.
+			if tt.name == "cross-tenant delete blocked" {
+				if _, ok := ws.users["u3"]; !ok {
+					t.Error("cross-tenant user u3 was deleted — tenant isolation breached")
+				}
 			}
 		})
 	}

--- a/internal/web/store.go
+++ b/internal/web/store.go
@@ -109,7 +109,7 @@ type WebStore interface {
 	GetUser(ctx context.Context, id string) (*User, error)
 	ListUsers(ctx context.Context, tenantID, role string, limit, offset int) ([]User, int, error)
 	UpdateUser(ctx context.Context, u *User) error
-	DeleteUser(ctx context.Context, id string) error
+	DeleteUser(ctx context.Context, tenantID, id string) error
 	UpdateUserPreferences(ctx context.Context, id string, prefs json.RawMessage) (*User, error)
 	CreateInvite(ctx context.Context, inv *Invite) error
 	GetInviteByToken(ctx context.Context, token string) (*Invite, error)
@@ -800,11 +800,12 @@ func (s *Store) UpdateUser(ctx context.Context, u *User) error {
 	return nil
 }
 
-// DeleteUser soft-deletes a user.
-func (s *Store) DeleteUser(ctx context.Context, id string) error {
+// DeleteUser soft-deletes a user. The tenant_id parameter ensures users
+// cannot be deleted across tenant boundaries (defense-in-depth).
+func (s *Store) DeleteUser(ctx context.Context, tenantID, id string) error {
 	tag, err := s.pool.Exec(ctx, `
-		UPDATE mgmt.users SET deleted_at = now() WHERE id = $1 AND deleted_at IS NULL
-	`, id)
+		UPDATE mgmt.users SET deleted_at = now() WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NULL
+	`, id, tenantID)
 	if err != nil {
 		return fmt.Errorf("web: delete user %q: %w", id, err)
 	}


### PR DESCRIPTION
## Summary

Security review of PRs #104-#108 (web management service). Found and fixed **3 critical/high cross-tenant isolation bugs** and **1 unauthenticated gRPC service**:

- **Cross-tenant user deletion**: `handleDeleteUser` didn't verify target user's tenant — a `tenant_admin` could delete any user by ID
- **Cross-tenant user update**: `handleUpdateUser` allowed modifying users from other tenants (role escalation across tenants)
- **Cross-tenant NPC linking**: `handleLinkNPCToCampaign` verified target campaign's tenant but not the source NPC's tenant — could leak NPC data across tenants
- **Unauthenticated gRPC ManagementService**: Anyone reaching the gRPC port could create/delete tenants, start/stop sessions. Added opt-in shared-secret interceptor (`GLYPHOXA_GRPC_MGMT_SECRET`)
- **Duplicate ManagementServer registrations**: Cleaned up 3 duplicate `.Register()` calls in gateway `main.go`

### What was NOT an issue (reviewed and confirmed secure):
- Discord access tokens: not stored, only used once for user profile fetch
- Invite tokens: 192-bit crypto/rand, hex-encoded, single-use, 7-day TTL
- Role escalation: `super_admin` not in `ValidRoles`, can't be assigned via API
- OAuth callback: proper state cookie (HttpOnly, Secure, SameSite=Lax), CSRF validated
- Frontend: no `dangerouslySetInnerHTML`, React auto-escapes, no markdown rendering
- JWT: HS256 with constant-time HMAC comparison, 32-char min secret
- API key login: constant-time comparison via `crypto/subtle`
- CORS: wildcard `*` mode correctly omits `Allow-Credentials` header

## Test plan
- [x] New test: cross-tenant user deletion returns 404 and doesn't delete
- [x] New test: cross-tenant user update returns 404
- [x] New test: gRPC management auth interceptor (valid/invalid/missing secret, non-management passthrough)
- [x] New test: client interceptor injects secret into metadata
- [x] All existing tests pass (`make check` green except pre-existing whisper build issue)