### PR TITLE
fix(web): resolve E2E bugs — API envelope, field names, toasts

### DIFF
--- a/internal/web/handlers_campaigns.go
+++ b/internal/web/handlers_campaigns.go
@@ -9,14 +9,16 @@ import (
 // CampaignCreateRequest is the JSON body for creating a campaign.
 type CampaignCreateRequest struct {
 	Name        string `json:"name"`
-	System      string `json:"system"`
+	System      string `json:"game_system"`
+	Language    string `json:"language"`
 	Description string `json:"description"`
 }
 
 // CampaignUpdateRequest is the JSON body for updating a campaign.
 type CampaignUpdateRequest struct {
 	Name        *string `json:"name"`
-	System      *string `json:"system"`
+	System      *string `json:"game_system"`
+	Language    *string `json:"language"`
 	Description *string `json:"description"`
 }
 
@@ -49,6 +51,7 @@ func (s *Server) handleCreateCampaign(w http.ResponseWriter, r *http.Request) {
 		TenantID:    claims.TenantID,
 		Name:        req.Name,
 		System:      req.System,
+		Language:    req.Language,
 		Description: req.Description,
 	}
 
@@ -150,6 +153,9 @@ func (s *Server) handleUpdateCampaign(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.System != nil {
 		existing.System = *req.System
+	}
+	if req.Language != nil {
+		existing.Language = *req.Language
 	}
 	if req.Description != nil {
 		existing.Description = *req.Description

--- a/internal/web/handlers_campaigns_test.go
+++ b/internal/web/handlers_campaigns_test.go
@@ -20,13 +20,13 @@ func TestHandleCreateCampaign(t *testing.T) {
 	}{
 		{
 			name:     "valid campaign",
-			body:     `{"name":"Rabenheim","system":"D&D 5e","description":"A dark fantasy campaign"}`,
+			body:     `{"name":"Rabenheim","game_system":"D&D 5e","description":"A dark fantasy campaign"}`,
 			role:     "dm",
 			wantCode: http.StatusCreated,
 		},
 		{
 			name:     "missing name",
-			body:     `{"system":"D&D 5e"}`,
+			body:     `{"game_system":"D&D 5e"}`,
 			role:     "dm",
 			wantCode: http.StatusBadRequest,
 		},
@@ -287,8 +287,8 @@ func TestHandleUpdateCampaign_PartialFieldPreservation(t *testing.T) {
 		Description: "Keep this",
 	}
 
-	// Only update system, name and description should remain.
-	body := `{"system":"Pathfinder 2e"}`
+	// Only update game_system, name and description should remain.
+	body := `{"game_system":"Pathfinder 2e"}`
 	req := authReq(t, http.MethodPut, "/api/v1/campaigns/c1",
 		bytes.NewBufferString(body), secret, "user-1", "tenant-1", "dm")
 	rr := httptest.NewRecorder()

--- a/internal/web/migrations/003_campaign_language.sql
+++ b/internal/web/migrations/003_campaign_language.sql
@@ -1,0 +1,2 @@
+-- Add language column to campaigns table.
+ALTER TABLE mgmt.campaigns ADD COLUMN IF NOT EXISTS language TEXT NOT NULL DEFAULT '';

--- a/internal/web/store.go
+++ b/internal/web/store.go
@@ -64,7 +64,8 @@ type Campaign struct {
 	ID          string    `json:"id"`
 	TenantID    string    `json:"tenant_id"`
 	Name        string    `json:"name"`
-	System      string    `json:"system,omitempty"`
+	System      string    `json:"game_system,omitempty"`
+	Language    string    `json:"language,omitempty"`
 	Description string    `json:"description,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
@@ -267,9 +268,9 @@ func (s *Store) CreateCampaign(ctx context.Context, c *Campaign) error {
 	c.CreatedAt = now
 	c.UpdatedAt = now
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO mgmt.campaigns (id, tenant_id, name, system, description, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
-	`, c.ID, c.TenantID, c.Name, c.System, c.Description, c.CreatedAt, c.UpdatedAt)
+		INSERT INTO mgmt.campaigns (id, tenant_id, name, system, language, description, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, c.ID, c.TenantID, c.Name, c.System, c.Language, c.Description, c.CreatedAt, c.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("web: create campaign %q: %w", c.ID, err)
 	}
@@ -280,10 +281,10 @@ func (s *Store) CreateCampaign(ctx context.Context, c *Campaign) error {
 func (s *Store) GetCampaign(ctx context.Context, tenantID, id string) (*Campaign, error) {
 	var c Campaign
 	err := s.pool.QueryRow(ctx, `
-		SELECT id, tenant_id, name, system, description, created_at, updated_at
+		SELECT id, tenant_id, name, system, language, description, created_at, updated_at
 		FROM mgmt.campaigns
 		WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NULL
-	`, id, tenantID).Scan(&c.ID, &c.TenantID, &c.Name, &c.System, &c.Description, &c.CreatedAt, &c.UpdatedAt)
+	`, id, tenantID).Scan(&c.ID, &c.TenantID, &c.Name, &c.System, &c.Language, &c.Description, &c.CreatedAt, &c.UpdatedAt)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}
@@ -309,7 +310,7 @@ func (s *Store) ListCampaigns(ctx context.Context, tenantID string, page CursorP
 		}
 		cursorTime := time.UnixMicro(cd.UnixMicros).UTC()
 		rows, err = s.pool.Query(ctx, `
-			SELECT id, tenant_id, name, system, description, created_at, updated_at
+			SELECT id, tenant_id, name, system, language, description, created_at, updated_at
 			FROM mgmt.campaigns
 			WHERE tenant_id = $1 AND deleted_at IS NULL
 			  AND (created_at, id) < ($3, $4)
@@ -318,7 +319,7 @@ func (s *Store) ListCampaigns(ctx context.Context, tenantID string, page CursorP
 		`, tenantID, limit+1, cursorTime, cd.ID)
 	} else {
 		rows, err = s.pool.Query(ctx, `
-			SELECT id, tenant_id, name, system, description, created_at, updated_at
+			SELECT id, tenant_id, name, system, language, description, created_at, updated_at
 			FROM mgmt.campaigns
 			WHERE tenant_id = $1 AND deleted_at IS NULL
 			ORDER BY created_at DESC, id DESC
@@ -333,7 +334,7 @@ func (s *Store) ListCampaigns(ctx context.Context, tenantID string, page CursorP
 	var campaigns []Campaign
 	for rows.Next() {
 		var c Campaign
-		if err := rows.Scan(&c.ID, &c.TenantID, &c.Name, &c.System, &c.Description, &c.CreatedAt, &c.UpdatedAt); err != nil {
+		if err := rows.Scan(&c.ID, &c.TenantID, &c.Name, &c.System, &c.Language, &c.Description, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("web: scan campaign: %w", err)
 		}
 		campaigns = append(campaigns, c)
@@ -346,9 +347,9 @@ func (s *Store) UpdateCampaign(ctx context.Context, c *Campaign) error {
 	c.UpdatedAt = time.Now().UTC()
 	tag, err := s.pool.Exec(ctx, `
 		UPDATE mgmt.campaigns
-		SET name = $3, system = $4, description = $5, updated_at = $6
+		SET name = $3, system = $4, language = $5, description = $6, updated_at = $7
 		WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NULL
-	`, c.ID, c.TenantID, c.Name, c.System, c.Description, c.UpdatedAt)
+	`, c.ID, c.TenantID, c.Name, c.System, c.Language, c.Description, c.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("web: update campaign %q: %w", c.ID, err)
 	}

--- a/web/src/components/providers.tsx
+++ b/web/src/components/providers.tsx
@@ -1,9 +1,19 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useState, type ReactNode } from "react";
+import { useState, useEffect, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { Toaster } from "sonner";
+import { Toaster, toast } from "sonner";
+
+/** Dismiss all toasts on client-side route changes. */
+function RouteChangeToastDismisser() {
+  const pathname = usePathname();
+  useEffect(() => {
+    toast.dismiss();
+  }, [pathname]);
+  return null;
+}
 
 export function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(
@@ -21,12 +31,14 @@ export function Providers({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
+        <RouteChangeToastDismisser />
         {children}
         <Toaster
           theme="dark"
           position="bottom-right"
           richColors
           closeButton
+          duration={4000}
         />
       </TooltipProvider>
     </QueryClientProvider>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -77,6 +77,15 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   return res.json();
 }
 
+// Unwraps the standard API envelope { data: T } returned by all endpoints.
+async function requestData<T>(
+  path: string,
+  options?: RequestInit,
+): Promise<T> {
+  const envelope = await request<{ data: T }>(path, options);
+  return envelope.data;
+}
+
 interface AuthResponse {
   data: {
     access_token: string;
@@ -88,7 +97,7 @@ interface AuthResponse {
 
 // Auth
 export const auth = {
-  me: () => request<User>("/auth/me"),
+  me: () => requestData<User>("/auth/me"),
   logout: () => {
     clearStoredToken();
     return request<void>("/auth/logout", { method: "POST" }).catch(() => {
@@ -108,22 +117,22 @@ export const auth = {
 
 // Dashboard
 export const dashboard = {
-  stats: () => request<DashboardStats>("/dashboard/stats"),
-  activity: () => request<ActivityItem[]>("/dashboard/activity"),
-  activeSessions: () => request<Session[]>("/dashboard/active-sessions"),
+  stats: () => requestData<DashboardStats>("/dashboard/stats"),
+  activity: () => requestData<ActivityItem[]>("/dashboard/activity"),
+  activeSessions: () => requestData<Session[]>("/dashboard/active-sessions"),
 };
 
 // Campaigns
 export const campaigns = {
-  list: () => request<Campaign[]>("/campaigns"),
-  get: (id: string) => request<Campaign>(`/campaigns/${id}`),
+  list: () => requestData<Campaign[]>("/campaigns"),
+  get: (id: string) => requestData<Campaign>(`/campaigns/${id}`),
   create: (data: Partial<Campaign>) =>
-    request<Campaign>("/campaigns", {
+    requestData<Campaign>("/campaigns", {
       method: "POST",
       body: JSON.stringify(data),
     }),
   update: (id: string, data: Partial<Campaign>) =>
-    request<Campaign>(`/campaigns/${id}`, {
+    requestData<Campaign>(`/campaigns/${id}`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
@@ -134,16 +143,16 @@ export const campaigns = {
 // NPCs
 export const npcs = {
   list: (campaignId: string) =>
-    request<NPC[]>(`/campaigns/${campaignId}/npcs`),
+    requestData<NPC[]>(`/campaigns/${campaignId}/npcs`),
   get: (campaignId: string, npcId: string) =>
-    request<NPC>(`/campaigns/${campaignId}/npcs/${npcId}`),
+    requestData<NPC>(`/campaigns/${campaignId}/npcs/${npcId}`),
   create: (campaignId: string, data: Partial<NPC>) =>
-    request<NPC>(`/campaigns/${campaignId}/npcs`, {
+    requestData<NPC>(`/campaigns/${campaignId}/npcs`, {
       method: "POST",
       body: JSON.stringify(data),
     }),
   update: (campaignId: string, npcId: string, data: Partial<NPC>) =>
-    request<NPC>(`/campaigns/${campaignId}/npcs/${npcId}`, {
+    requestData<NPC>(`/campaigns/${campaignId}/npcs/${npcId}`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
@@ -155,14 +164,14 @@ export const npcs = {
 
 // Sessions
 export const sessions = {
-  list: () => request<Session[]>("/sessions"),
+  list: () => requestData<Session[]>("/sessions"),
   listByCampaign: (campaignId: string) =>
-    request<Session[]>(`/campaigns/${campaignId}/sessions`),
-  get: (id: string) => request<Session>(`/sessions/${id}`),
+    requestData<Session[]>(`/campaigns/${campaignId}/sessions`),
+  get: (id: string) => requestData<Session>(`/sessions/${id}`),
   stop: (id: string) =>
     request<void>(`/sessions/${id}`, { method: "DELETE" }),
   transcript: (id: string) =>
-    request<TranscriptEntry[]>(`/sessions/${id}/transcript`),
+    requestData<TranscriptEntry[]>(`/sessions/${id}/transcript`),
 };
 
 // Users
@@ -175,26 +184,26 @@ export const users = {
     const qs = q.toString();
     return request<PaginatedResponse<User>>(`/users${qs ? `?${qs}` : ""}`);
   },
-  get: (id: string) => request<User>(`/users/${id}`),
+  get: (id: string) => requestData<User>(`/users/${id}`),
   update: (id: string, data: { display_name?: string; role?: UserRole }) =>
-    request<User>(`/users/${id}`, {
+    requestData<User>(`/users/${id}`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
   delete: (id: string) =>
     request<void>(`/users/${id}`, { method: "DELETE" }),
   invite: (role: UserRole = "viewer") =>
-    request<Invite>("/users/invite", {
+    requestData<Invite>("/users/invite", {
       method: "POST",
       body: JSON.stringify({ role }),
     }),
   updateMe: (data: { display_name: string }) =>
-    request<User>("/auth/me", {
+    requestData<User>("/auth/me", {
       method: "PUT",
       body: JSON.stringify(data),
     }),
   updatePreferences: (prefs: Partial<UserPreferences>) =>
-    request<User>("/auth/me/preferences", {
+    requestData<User>("/auth/me/preferences", {
       method: "PATCH",
       body: JSON.stringify(prefs),
     }),


### PR DESCRIPTION
## Summary
- **Campaign list never displays**: Frontend `request<T>()` returned the raw `{data: T}` envelope. Added `requestData<T>()` helper that unwraps `.data` from all standard API responses. This also fixes the dashboard greeting (bug 7) and settings display name (bug 5) since `auth/me` was similarly affected.
- **Field name mismatch**: Renamed backend JSON tags from `system` to `game_system` on `Campaign`, `CampaignCreateRequest`, and `CampaignUpdateRequest` to match frontend types.
- **Missing language field**: Added `Language` field to `Campaign` struct, request types, handlers, store SQL queries, and a new DB migration (`003_campaign_language.sql`).
- **Users page not in sidebar**: Already present (gated to `tenant_admin+`), no change needed.
- **Toast persistence**: Added `RouteChangeToastDismisser` component that calls `toast.dismiss()` on pathname changes, plus explicit `duration={4000}` on `<Toaster>`.

## Test plan
- [x] `go build ./cmd/glyphoxa-web/` passes
- [x] `cd web && npm run build` passes
- [x] `go test -race -count=1 ./internal/web/...` passes (updated test payloads for `game_system`)
- [ ] Manual E2E: create/edit/list campaigns, verify `game_system` and `language` round-trip
- [ ] Verify dashboard greeting shows actual user name after login
- [ ] Verify toasts dismiss on navigation