### PR TITLE
fix(web): fix RBAC bugs — backend 500s, role enforcement, frontend guards

### DIFF
--- a/internal/web/handlers_lore.go
+++ b/internal/web/handlers_lore.go
@@ -7,8 +7,10 @@ import (
 )
 
 // LoreCreateRequest is the JSON body for creating a lore document.
+// Accepts both "content" and "content_markdown" for the body text.
 type LoreCreateRequest struct {
 	Title           string `json:"title"`
+	Content         string `json:"content"`
 	ContentMarkdown string `json:"content_markdown"`
 	SortOrder       int    `json:"sort_order"`
 }
@@ -42,6 +44,11 @@ func (s *Server) handleCreateLoreDocument(w http.ResponseWriter, r *http.Request
 	if req.Title == "" {
 		writeError(w, http.StatusBadRequest, "missing_title", "title is required")
 		return
+	}
+
+	// Accept "content" as an alias for "content_markdown".
+	if req.ContentMarkdown == "" && req.Content != "" {
+		req.ContentMarkdown = req.Content
 	}
 
 	doc := &LoreDocument{

--- a/internal/web/handlers_npcs.go
+++ b/internal/web/handlers_npcs.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/MrWong99/glyphoxa/internal/agent/npcstore"
 )
 
@@ -53,6 +54,10 @@ func (s *Server) handleCreateNPC(w http.ResponseWriter, r *http.Request) {
 	if len(req.Name) > 255 {
 		writeError(w, http.StatusBadRequest, "name_too_long", "name must be 255 characters or fewer")
 		return
+	}
+
+	if req.ID == "" {
+		req.ID = uuid.NewString()
 	}
 
 	def := &npcstore.NPCDefinition{

--- a/internal/web/handlers_sessions.go
+++ b/internal/web/handlers_sessions.go
@@ -53,6 +53,18 @@ func (s *Server) handleGetTranscript(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sessionID := r.PathValue("id")
+
+	exists, err := s.store.SessionExists(r.Context(), claims.TenantID, sessionID)
+	if err != nil {
+		slog.Error("web: check session exists", "session_id", sessionID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to check session")
+		return
+	}
+	if !exists {
+		writeError(w, http.StatusNotFound, "not_found", "session not found")
+		return
+	}
+
 	entries, err := s.store.GetTranscript(r.Context(), claims.TenantID, sessionID)
 	if err != nil {
 		slog.Error("web: get transcript", "session_id", sessionID, "err", err)

--- a/internal/web/handlers_sessions_test.go
+++ b/internal/web/handlers_sessions_test.go
@@ -17,9 +17,9 @@ func TestHandleListSessions(t *testing.T) {
 
 	now := time.Now().UTC()
 	ws.sessions = []SessionSummary{
-		{ID: "s1", TenantID: "tenant-1", State: "active", CreatedAt: now},
-		{ID: "s2", TenantID: "tenant-1", State: "ended", CreatedAt: now.Add(-time.Hour)},
-		{ID: "s3", TenantID: "tenant-2", State: "active", CreatedAt: now},
+		{ID: "s1", TenantID: "tenant-1", State: "active", StartedAt: now},
+		{ID: "s2", TenantID: "tenant-1", State: "ended", StartedAt: now.Add(-time.Hour)},
+		{ID: "s3", TenantID: "tenant-2", State: "active", StartedAt: now},
 	}
 
 	req := authReq(t, http.MethodGet, "/api/v1/sessions", nil, secret, "user-1", "tenant-1", "dm")
@@ -64,7 +64,7 @@ func TestHandleListSessions_Pagination(t *testing.T) {
 			ID:        "s" + string(rune('1'+i)),
 			TenantID:  "tenant-1",
 			State:     "ended",
-			CreatedAt: now.Add(-time.Duration(i) * time.Hour),
+			StartedAt: now.Add(-time.Duration(i) * time.Hour),
 		})
 	}
 
@@ -181,6 +181,9 @@ func TestHandleGetTranscript(t *testing.T) {
 	srv.mux.Handle("GET /api/v1/sessions/{id}/transcript", auth(http.HandlerFunc(srv.handleGetTranscript)))
 
 	now := time.Now().UTC()
+	ws.sessions = []SessionSummary{
+		{ID: "session-1", TenantID: "tenant-1", State: "ended", StartedAt: now},
+	}
 	ws.transcripts["session-1"] = []TranscriptEntry{
 		{ID: 1, Speaker: "Heinrich", Content: "Willkommen!", CreatedAt: now},
 		{ID: 2, Speaker: "Player", Content: "Hello there", CreatedAt: now.Add(time.Second)},
@@ -208,7 +211,7 @@ func TestHandleGetTranscript(t *testing.T) {
 	}
 }
 
-func TestHandleGetTranscript_Empty(t *testing.T) {
+func TestHandleGetTranscript_NotFound(t *testing.T) {
 	t.Parallel()
 
 	srv, _, _, secret := testServerWithStores(t)
@@ -219,17 +222,7 @@ func TestHandleGetTranscript_Empty(t *testing.T) {
 	rr := httptest.NewRecorder()
 	srv.mux.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
-	}
-
-	var body struct {
-		Data []TranscriptEntry `json:"data"`
-	}
-	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if body.Data == nil {
-		t.Error("data should be empty array, not null")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNotFound)
 	}
 }

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -298,6 +298,15 @@ func (m *mockWebStore) ListSessions(_ context.Context, tenantID string, limit, o
 	return filtered[offset:end], nil
 }
 
+func (m *mockWebStore) SessionExists(_ context.Context, tenantID, sessionID string) (bool, error) {
+	for _, s := range m.sessions {
+		if s.ID == sessionID && s.TenantID == tenantID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (m *mockWebStore) GetTranscript(_ context.Context, _, sessionID string) ([]TranscriptEntry, error) {
 	entries, ok := m.transcripts[sessionID]
 	if !ok {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -114,7 +114,7 @@ func (s *Server) registerRoutes() {
 	s.mux.Handle("POST /api/v1/tenants", auth(RequireRole("super_admin")(http.HandlerFunc(s.handleCreateTenant))))
 	s.mux.Handle("PUT /api/v1/tenants/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(s.handleUpdateTenant))))
 	s.mux.Handle("DELETE /api/v1/tenants/{id}", auth(RequireRole("super_admin")(http.HandlerFunc(s.handleDeleteTenant))))
-	s.mux.Handle("GET /api/v1/usage", auth(http.HandlerFunc(s.handleGetUsage)))
+	s.mux.Handle("GET /api/v1/usage", auth(RequireRole("tenant_admin")(http.HandlerFunc(s.handleGetUsage))))
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/web/store.go
+++ b/internal/web/store.go
@@ -121,6 +121,7 @@ type WebStore interface {
 	UpdateCampaign(ctx context.Context, c *Campaign) error
 	DeleteCampaign(ctx context.Context, tenantID, id string) error
 	ListSessions(ctx context.Context, tenantID string, limit, offset int) ([]SessionSummary, error)
+	SessionExists(ctx context.Context, tenantID, sessionID string) (bool, error)
 	GetTranscript(ctx context.Context, tenantID, sessionID string) ([]TranscriptEntry, error)
 	GetUsage(ctx context.Context, tenantID string, from, to time.Time) ([]UsageRecord, error)
 
@@ -378,7 +379,7 @@ type SessionSummary struct {
 	ID        string     `json:"id"`
 	TenantID  string     `json:"tenant_id"`
 	State     string     `json:"state"`
-	CreatedAt time.Time  `json:"created_at"`
+	StartedAt time.Time  `json:"started_at"`
 	EndedAt   *time.Time `json:"ended_at,omitempty"`
 }
 
@@ -388,10 +389,10 @@ func (s *Store) ListSessions(ctx context.Context, tenantID string, limit, offset
 		limit = 25
 	}
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, tenant_id, state, created_at, ended_at
+		SELECT id, tenant_id, state, started_at, ended_at
 		FROM sessions
 		WHERE tenant_id = $1
-		ORDER BY created_at DESC
+		ORDER BY started_at DESC
 		LIMIT $2 OFFSET $3
 	`, tenantID, limit, offset)
 	if err != nil {
@@ -402,12 +403,25 @@ func (s *Store) ListSessions(ctx context.Context, tenantID string, limit, offset
 	var sessions []SessionSummary
 	for rows.Next() {
 		var ss SessionSummary
-		if err := rows.Scan(&ss.ID, &ss.TenantID, &ss.State, &ss.CreatedAt, &ss.EndedAt); err != nil {
+		if err := rows.Scan(&ss.ID, &ss.TenantID, &ss.State, &ss.StartedAt, &ss.EndedAt); err != nil {
 			return nil, fmt.Errorf("web: scan session: %w", err)
 		}
 		sessions = append(sessions, ss)
 	}
 	return sessions, rows.Err()
+}
+
+// SessionExists checks whether a session exists for the given tenant.
+func (s *Store) SessionExists(ctx context.Context, tenantID, sessionID string) (bool, error) {
+	var exists bool
+	err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM sessions WHERE id = $1 AND tenant_id = $2)`,
+		sessionID, tenantID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("web: check session exists: %w", err)
+	}
+	return exists, nil
 }
 
 // TranscriptEntry represents a single entry in a session transcript.
@@ -662,23 +676,21 @@ func (s *Store) ListKnowledgeEntities(ctx context.Context, tenantID, campaignID 
 		}
 		cursorTime := time.UnixMicro(cd.UnixMicros).UTC()
 		query := fmt.Sprintf(`
-			SELECT campaign_id, id, type, name, attributes, created_at, updated_at
+			SELECT id, type, name, attributes, created_at, updated_at
 			FROM %s
-			WHERE campaign_id = $1
-			  AND (created_at, id) < ($3, $4)
+			WHERE (created_at, id) < ($2, $3)
 			ORDER BY created_at DESC, id DESC
-			LIMIT $2
+			LIMIT $1
 		`, table)
-		rows, err = s.pool.Query(ctx, query, campaignID, limit+1, cursorTime, cd.ID)
+		rows, err = s.pool.Query(ctx, query, limit+1, cursorTime, cd.ID)
 	} else {
 		query := fmt.Sprintf(`
-			SELECT campaign_id, id, type, name, attributes, created_at, updated_at
+			SELECT id, type, name, attributes, created_at, updated_at
 			FROM %s
-			WHERE campaign_id = $1
 			ORDER BY created_at DESC, id DESC
-			LIMIT $2
+			LIMIT $1
 		`, table)
-		rows, err = s.pool.Query(ctx, query, campaignID, limit+1)
+		rows, err = s.pool.Query(ctx, query, limit+1)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("web: list knowledge entities: %w", err)
@@ -688,9 +700,10 @@ func (s *Store) ListKnowledgeEntities(ctx context.Context, tenantID, campaignID 
 	var entities []KnowledgeEntity
 	for rows.Next() {
 		var e KnowledgeEntity
-		if err := rows.Scan(&e.CampaignID, &e.ID, &e.Type, &e.Name, &e.Attributes, &e.CreatedAt, &e.UpdatedAt); err != nil {
+		if err := rows.Scan(&e.ID, &e.Type, &e.Name, &e.Attributes, &e.CreatedAt, &e.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("web: scan knowledge entity: %w", err)
 		}
+		e.CampaignID = campaignID
 		entities = append(entities, e)
 	}
 	return entities, rows.Err()
@@ -705,8 +718,8 @@ func (s *Store) DeleteKnowledgeEntity(ctx context.Context, tenantID, campaignID,
 	schema := "tenant_" + tenantID
 	table := pgx.Identifier{schema, "entities"}.Sanitize()
 
-	query := fmt.Sprintf(`DELETE FROM %s WHERE campaign_id = $1 AND id = $2`, table)
-	tag, err := s.pool.Exec(ctx, query, campaignID, entityID)
+	query := fmt.Sprintf(`DELETE FROM %s WHERE id = $1`, table)
+	tag, err := s.pool.Exec(ctx, query, entityID)
 	if err != nil {
 		return fmt.Errorf("web: delete knowledge entity %q: %w", entityID, err)
 	}

--- a/web/src/app/(app)/campaigns/[id]/npcs/npc-list.tsx
+++ b/web/src/app/(app)/campaigns/[id]/npcs/npc-list.tsx
@@ -5,7 +5,7 @@ import { Plus, Mic, Brain, Zap, Sparkles } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { useNPCs } from "@/lib/hooks";
+import { useNPCs, useHasRole } from "@/lib/hooks";
 
 const engineLabels: Record<string, string> = {
   cascaded: "Cascaded",
@@ -25,6 +25,7 @@ interface NPCListProps {
 
 export function NPCList({ campaignId }: NPCListProps) {
   const { data: npcs, isLoading } = useNPCs(campaignId);
+  const canCreate = useHasRole("dm");
 
   if (isLoading) {
     return (
@@ -49,10 +50,12 @@ export function NPCList({ campaignId }: NPCListProps) {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">NPCs</h2>
-        <Button render={<Link href={`/campaigns/${campaignId}/npcs/new`} />}>
-            <Plus className="mr-1 h-4 w-4" />
-            New NPC
-        </Button>
+        {canCreate && (
+          <Button render={<Link href={`/campaigns/${campaignId}/npcs/new`} />}>
+              <Plus className="mr-1 h-4 w-4" />
+              New NPC
+          </Button>
+        )}
       </div>
 
       {npcs && npcs.length > 0 ? (
@@ -101,10 +104,12 @@ export function NPCList({ campaignId }: NPCListProps) {
             <p className="mt-1 text-sm text-muted-foreground">
               Create your first NPC to bring your campaign to life.
             </p>
-            <Button className="mt-4" size="sm" render={<Link href={`/campaigns/${campaignId}/npcs/new`} />}>
-                <Plus className="mr-1 h-4 w-4" />
-                Create NPC
-            </Button>
+            {canCreate && (
+              <Button className="mt-4" size="sm" render={<Link href={`/campaigns/${campaignId}/npcs/new`} />}>
+                  <Plus className="mr-1 h-4 w-4" />
+                  Create NPC
+              </Button>
+            )}
           </CardContent>
         </Card>
       )}

--- a/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -27,7 +27,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Breadcrumbs } from "@/components/breadcrumbs";
-import { useCampaign, useUpdateCampaign, useDeleteCampaign } from "@/lib/hooks";
+import { useCampaign, useUpdateCampaign, useDeleteCampaign, useHasRole } from "@/lib/hooks";
 import { NPCList } from "./npcs/npc-list";
 import { CampaignSessions } from "./sessions";
 import type { Campaign, GameSystem } from "@/lib/types";
@@ -49,6 +49,7 @@ function CampaignForm({ campaign, campaignId }: { campaign: Campaign; campaignId
   const updateCampaign = useUpdateCampaign(campaignId);
   const deleteCampaign = useDeleteCampaign();
   const [deleteConfirm, setDeleteConfirm] = useState("");
+  const canEdit = useHasRole("dm");
 
   const [name, setName] = useState(campaign.name);
   const [gameSystem, setGameSystem] = useState(campaign.game_system);
@@ -89,7 +90,7 @@ function CampaignForm({ campaign, campaignId }: { campaign: Campaign; campaignId
 
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight">{campaign.name}</h1>
-        {dirty && (
+        {canEdit && dirty && (
           <Button onClick={handleSave} disabled={updateCampaign.isPending}>
             <Save className="mr-1 h-4 w-4" />
             {updateCampaign.isPending ? "Saving..." : "Save Changes"}
@@ -122,6 +123,7 @@ function CampaignForm({ campaign, campaignId }: { campaign: Campaign; campaignId
                   id="name"
                   value={name}
                   onChange={(e) => handleChange(setName)(e.target.value)}
+                  readOnly={!canEdit}
                 />
               </div>
 
@@ -130,6 +132,7 @@ function CampaignForm({ campaign, campaignId }: { campaign: Campaign; campaignId
                 <Select
                   value={gameSystem}
                   onValueChange={(v) => v && handleChange(setGameSystem)(v)}
+                  disabled={!canEdit}
                 >
                   <SelectTrigger>
                     <SelectValue />
@@ -149,6 +152,7 @@ function CampaignForm({ campaign, campaignId }: { campaign: Campaign; campaignId
                 <Select
                   value={language}
                   onValueChange={(v) => v && handleChange(setLanguage)(v)}
+                  disabled={!canEdit}
                 >
                   <SelectTrigger>
                     <SelectValue />
@@ -171,59 +175,62 @@ function CampaignForm({ campaign, campaignId }: { campaign: Campaign; campaignId
                     handleChange(setDescription)(e.target.value)
                   }
                   rows={8}
+                  readOnly={!canEdit}
                 />
               </div>
             </CardContent>
           </Card>
 
-          {/* Danger zone */}
-          <Card className="border-destructive/50">
-            <CardHeader>
-              <CardTitle className="text-destructive">Danger Zone</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <Dialog>
-                <DialogTrigger render={<Button variant="destructive" />}>
-                    <Trash2 className="mr-1 h-4 w-4" />
-                    Delete Campaign
-                </DialogTrigger>
-                <DialogContent>
-                  <DialogHeader>
-                    <DialogTitle>Delete Campaign</DialogTitle>
-                    <DialogDescription>
-                      This action cannot be undone. This will permanently delete
-                      the campaign &quot;{campaign.name}&quot; and all its NPCs,
-                      sessions, and transcripts.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className="space-y-2">
-                    <Label>
-                      Type <strong>{campaign.name}</strong> to confirm
-                    </Label>
-                    <Input
-                      value={deleteConfirm}
-                      onChange={(e) => setDeleteConfirm(e.target.value)}
-                      placeholder={campaign.name}
-                    />
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant="destructive"
-                      disabled={
-                        deleteConfirm !== campaign.name ||
-                        deleteCampaign.isPending
-                      }
-                      onClick={handleDelete}
-                    >
-                      {deleteCampaign.isPending
-                        ? "Deleting..."
-                        : "Delete Campaign"}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-            </CardContent>
-          </Card>
+          {/* Danger zone — only visible for DM+ roles */}
+          {canEdit && (
+            <Card className="border-destructive/50">
+              <CardHeader>
+                <CardTitle className="text-destructive">Danger Zone</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Dialog>
+                  <DialogTrigger render={<Button variant="destructive" />}>
+                      <Trash2 className="mr-1 h-4 w-4" />
+                      Delete Campaign
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>Delete Campaign</DialogTitle>
+                      <DialogDescription>
+                        This action cannot be undone. This will permanently delete
+                        the campaign &quot;{campaign.name}&quot; and all its NPCs,
+                        sessions, and transcripts.
+                      </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-2">
+                      <Label>
+                        Type <strong>{campaign.name}</strong> to confirm
+                      </Label>
+                      <Input
+                        value={deleteConfirm}
+                        onChange={(e) => setDeleteConfirm(e.target.value)}
+                        placeholder={campaign.name}
+                      />
+                    </div>
+                    <DialogFooter>
+                      <Button
+                        variant="destructive"
+                        disabled={
+                          deleteConfirm !== campaign.name ||
+                          deleteCampaign.isPending
+                        }
+                        onClick={handleDelete}
+                      >
+                        {deleteCampaign.isPending
+                          ? "Deleting..."
+                          : "Delete Campaign"}
+                      </Button>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
+              </CardContent>
+            </Card>
+          )}
         </TabsContent>
 
         <TabsContent value="npcs">

--- a/web/src/app/(app)/campaigns/page.tsx
+++ b/web/src/app/(app)/campaigns/page.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumbs } from "@/components/breadcrumbs";
-import { useCampaigns } from "@/lib/hooks";
+import { useCampaigns, useHasRole } from "@/lib/hooks";
 import { formatRelativeTime } from "@/lib/utils";
 
 function CampaignCardSkeleton() {
@@ -28,6 +28,7 @@ function CampaignCardSkeleton() {
 
 export default function CampaignsPage() {
   const { data: campaigns, isLoading, isError, error } = useCampaigns();
+  const canCreate = useHasRole("dm");
 
   return (
     <div className="space-y-6">
@@ -40,10 +41,12 @@ export default function CampaignsPage() {
             Manage your tabletop RPG campaigns and their AI voice NPCs.
           </p>
         </div>
-        <Button render={<Link href="/campaigns/new" />}>
-            <Plus className="mr-1 h-4 w-4" />
-            New Campaign
-        </Button>
+        {canCreate && (
+          <Button render={<Link href="/campaigns/new" />}>
+              <Plus className="mr-1 h-4 w-4" />
+              New Campaign
+          </Button>
+        )}
       </div>
 
       {isLoading ? (
@@ -104,18 +107,20 @@ export default function CampaignsPage() {
           ))}
 
           {/* Create new card */}
-          <Link href="/campaigns/new">
-            <Card className="flex h-full items-center justify-center border-dashed transition-all duration-200 hover:border-primary/40 hover:bg-primary/5">
-              <CardContent className="py-12 text-center">
-                <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
-                  <Plus className="h-6 w-6 text-primary" />
-                </div>
-                <p className="text-sm font-medium text-muted-foreground">
-                  Create New Campaign
-                </p>
-              </CardContent>
-            </Card>
-          </Link>
+          {canCreate && (
+            <Link href="/campaigns/new">
+              <Card className="flex h-full items-center justify-center border-dashed transition-all duration-200 hover:border-primary/40 hover:bg-primary/5">
+                <CardContent className="py-12 text-center">
+                  <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+                    <Plus className="h-6 w-6 text-primary" />
+                  </div>
+                  <p className="text-sm font-medium text-muted-foreground">
+                    Create New Campaign
+                  </p>
+                </CardContent>
+              </Card>
+            </Link>
+          )}
         </div>
       ) : (
         <Card className="border-dashed">
@@ -127,10 +132,12 @@ export default function CampaignsPage() {
             <p className="mx-auto mt-2 max-w-sm text-sm text-muted-foreground">
               Create your first campaign to get started with AI voice NPCs for your tabletop sessions.
             </p>
-            <Button className="mt-6" render={<Link href="/campaigns/new" />}>
-                <Plus className="mr-1 h-4 w-4" />
-                Create Campaign
-            </Button>
+            {canCreate && (
+              <Button className="mt-6" render={<Link href="/campaigns/new" />}>
+                  <Plus className="mr-1 h-4 w-4" />
+                  Create Campaign
+              </Button>
+            )}
           </CardContent>
         </Card>
       )}

--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -22,6 +22,7 @@ import {
   useActiveSessions,
   useActivity,
   useStopSession,
+  useHasRole,
 } from "@/lib/hooks";
 import { formatRelativeTime } from "@/lib/utils";
 
@@ -87,6 +88,7 @@ export default function DashboardPage() {
   const { data: activeSessions } = useActiveSessions();
   const { data: activity, isLoading: activityLoading, isError: activityError } = useActivity();
   const stopSession = useStopSession();
+  const canManage = useHasRole("dm");
 
   const usagePercent = Math.min(100, ((stats?.hours_used ?? 0) / (stats?.hours_limit ?? 100)) * 100);
 
@@ -234,15 +236,17 @@ export default function DashboardPage() {
                           <Eye className="mr-1 h-3 w-3" />
                           View
                       </Button>
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        onClick={() => stopSession.mutate(session.id)}
-                        disabled={stopSession.isPending}
-                      >
-                        <Square className="mr-1 h-3 w-3" />
-                        Stop
-                      </Button>
+                      {canManage && (
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => stopSession.mutate(session.id)}
+                          disabled={stopSession.isPending}
+                        >
+                          <Square className="mr-1 h-3 w-3" />
+                          Stop
+                        </Button>
+                      )}
                     </div>
                   </div>
                 </CardContent>
@@ -308,21 +312,23 @@ export default function DashboardPage() {
         <div className="space-y-4">
           <h2 className="text-lg font-semibold">Quick Actions</h2>
           <div className="grid gap-3">
-            <Link href="/campaigns/new">
-              <Card className="group cursor-pointer transition-all duration-200 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5">
-                <CardContent className="flex items-center gap-4 p-4">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 transition-colors group-hover:bg-primary/20">
-                    <Plus className="h-5 w-5 text-primary" />
-                  </div>
-                  <div>
-                    <p className="font-medium">New Campaign</p>
-                    <p className="text-sm text-muted-foreground">
-                      Create a new campaign with AI voice NPCs
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
+            {canManage && (
+              <Link href="/campaigns/new">
+                <Card className="group cursor-pointer transition-all duration-200 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5">
+                  <CardContent className="flex items-center gap-4 p-4">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 transition-colors group-hover:bg-primary/20">
+                      <Plus className="h-5 w-5 text-primary" />
+                    </div>
+                    <div>
+                      <p className="font-medium">New Campaign</p>
+                      <p className="text-sm text-muted-foreground">
+                        Create a new campaign with AI voice NPCs
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            )}
             <Link href="/sessions">
               <Card className="group cursor-pointer transition-all duration-200 hover:border-primary/30">
                 <CardContent className="flex items-center gap-4 p-4">

--- a/web/src/app/(app)/users/page.tsx
+++ b/web/src/app/(app)/users/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { Users as UsersIcon, AlertTriangle, Copy, Plus, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Users as UsersIcon, AlertTriangle, Copy, Plus, Trash2, ShieldAlert } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -27,6 +28,7 @@ import {
   useDeleteUser,
   useCreateInvite,
   useUser,
+  useHasRole,
 } from "@/lib/hooks";
 import { toast } from "sonner";
 import type { UserRole } from "@/lib/types";
@@ -43,12 +45,25 @@ const roleBadgeVariant: Record<
 
 export default function UsersPage() {
   const { data: currentUser } = useUser();
+  const isAdmin = useHasRole("tenant_admin");
   const { data, isLoading, isError, error } = useUsers();
   const deleteUser = useDeleteUser();
   const createInvite = useCreateInvite();
   const [inviteRole, setInviteRole] = useState<UserRole>("viewer");
 
   const users = data?.data ?? [];
+
+  if (currentUser && !isAdmin) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-16 text-center">
+        <ShieldAlert className="h-12 w-12 text-destructive" />
+        <h2 className="text-lg font-semibold">Access Denied</h2>
+        <p className="text-sm text-muted-foreground">
+          You need tenant admin permissions to manage users.
+        </p>
+      </div>
+    );
+  }
 
   const handleInvite = async () => {
     const result = await createInvite.mutateAsync(inviteRole);

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -14,6 +14,7 @@ import {
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { useUser } from "@/lib/hooks";
+import { hasMinRole } from "@/lib/rbac";
 import type { UserRole } from "@/lib/types";
 
 interface NavItem {
@@ -36,17 +37,9 @@ interface SidebarProps {
   onClose: () => void;
 }
 
-const roleLevels: Record<UserRole, number> = {
-  viewer: 0,
-  dm: 1,
-  tenant_admin: 2,
-  super_admin: 3,
-};
-
 export function Sidebar({ open, onClose }: SidebarProps) {
   const pathname = usePathname();
   const { data: user } = useUser();
-  const userLevel = roleLevels[user?.role ?? "viewer"];
 
   return (
     <>
@@ -88,7 +81,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         </div>
 
         <nav className="flex-1 space-y-1 p-3" role="navigation" aria-label="Main navigation">
-          {navItems.filter((item) => !item.minRole || userLevel >= roleLevels[item.minRole]).map((item) => {
+          {navItems.filter((item) => !item.minRole || hasMinRole(user?.role, item.minRole)).map((item) => {
             const active =
               pathname === item.href || pathname.startsWith(item.href + "/");
             return (

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "./api";
+import { hasMinRole } from "./rbac";
 import type { Campaign, NPC, UserRole, UserPreferences } from "./types";
 
 // Auth
@@ -13,6 +14,12 @@ export function useUser() {
     retry: false,
     staleTime: 5 * 60 * 1000,
   });
+}
+
+/** Returns true if the current user has at least the given role. */
+export function useHasRole(minRole: UserRole): boolean {
+  const { data: user } = useUser();
+  return hasMinRole(user?.role, minRole);
 }
 
 // Dashboard

--- a/web/src/lib/rbac.ts
+++ b/web/src/lib/rbac.ts
@@ -1,0 +1,17 @@
+import type { UserRole } from "./types";
+
+const roleLevels: Record<UserRole, number> = {
+  viewer: 0,
+  dm: 1,
+  tenant_admin: 2,
+  super_admin: 3,
+};
+
+/** Returns true if the user's role meets or exceeds the minimum required role. */
+export function hasMinRole(
+  userRole: UserRole | undefined,
+  minRole: UserRole,
+): boolean {
+  if (!userRole) return false;
+  return (roleLevels[userRole] ?? 0) >= (roleLevels[minRole] ?? 0);
+}


### PR DESCRIPTION
## Summary

- **NPC creation 500**: generate UUID when client doesn't provide one
- **Sessions list 500**: fix SQL column name (`created_at` → `started_at` matching sessions table schema)
- **Knowledge graph 500**: remove nonexistent `campaign_id` column from tenant-schema `entities` query
- **Lore content dropped**: accept both `content` and `content_markdown` fields in create request
- **Transcript 500 for missing session**: verify session exists first, return 404
- **Usage API open to all roles**: restrict `GET /api/v1/usage` to `tenant_admin+` via `RequireRole` middleware
- **Frontend RBAC**: add `hasMinRole` utility + `useHasRole` hook; conditionally render create/edit/delete buttons, form controls, and quick actions based on role; add access-denied guard on users page

## Test plan

- [x] `go vet ./internal/web/...` passes
- [x] `go test -race -count=1 ./internal/web/...` passes  
- [x] `go build ./cmd/glyphoxa-web/...` compiles
- [x] `npx next build` compiles without errors
- [ ] Manual: create NPC without providing ID → should succeed with auto-generated UUID
- [ ] Manual: `GET /api/v1/sessions` returns sessions correctly
- [ ] Manual: `GET /api/v1/campaigns/{id}/knowledge` returns entities
- [ ] Manual: create lore with `{"content": "..."}` → body is preserved
- [ ] Manual: `GET /api/v1/sessions/{id}/transcript` with invalid ID → 404
- [ ] Manual: `GET /api/v1/usage` as `dm` role → 403 Forbidden
- [ ] Manual: viewer role sees no create/edit/delete buttons in UI
- [ ] Manual: non-admin navigating to `/users` sees access denied