### PR TITLE
fix(web): redirect OAuth callback to frontend instead of returning JSON

### DIFF
--- a/internal/web/handlers_auth.go
+++ b/internal/web/handlers_auth.go
@@ -135,14 +135,10 @@ func (s *Server) handleDiscordCallback(w http.ResponseWriter, r *http.Request) {
 		"display_name", user.DisplayName,
 	)
 
-	writeJSON(w, http.StatusOK, map[string]any{
-		"data": map[string]any{
-			"access_token": token,
-			"token_type":   "Bearer",
-			"expires_in":   86400,
-			"user":         user,
-		},
-	})
+	// Redirect to the frontend callback page with the JWT as a query param.
+	// The frontend will store the token and redirect to the dashboard.
+	redirect := "/auth/callback?token=" + url.QueryEscape(token)
+	http.Redirect(w, r, redirect, http.StatusFound)
 }
 
 // handleRefresh issues a new JWT from a valid existing token.

--- a/web/src/app/(public)/auth/callback/page.tsx
+++ b/web/src/app/(public)/auth/callback/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Suspense, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { setStoredToken } from "@/lib/api";
+import { Loader2 } from "lucide-react";
+
+function CallbackHandler() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+    if (!token) {
+      router.replace("/login");
+      return;
+    }
+
+    setStoredToken(token);
+    router.replace("/dashboard");
+  }, [searchParams, router]);
+
+  return null;
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="flex flex-col items-center gap-3 text-muted-foreground">
+        <Loader2 className="h-8 w-8 animate-spin" />
+        <p>Signing you in...</p>
+      </div>
+      <Suspense>
+        <CallbackHandler />
+      </Suspense>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Backend `handleDiscordCallback` now redirects to `/auth/callback?token=<JWT>` instead of returning a raw JSON response
- New frontend page at `/auth/callback` reads the token from the URL, stores it in localStorage, and redirects to `/dashboard`
- If no token is present in the URL, redirects back to `/login`

## Test plan
- [x] Backend tests pass (`go test -race ./internal/web/...`)
- [x] Frontend builds successfully (`next build`)
- [ ] Manual: click "Continue with Discord" on login page, verify redirect flow lands on dashboard