### PR TITLE
Add legal pages: ToS, privacy policy, imprint, cookie notice

### DIFF
--- a/web/src/app/(public)/imprint/page.tsx
+++ b/web/src/app/(public)/imprint/page.tsx
@@ -1,0 +1,175 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Imprint — Glyphoxa",
+  description: "Legal notice (Impressum) for the Glyphoxa AI voice NPC platform.",
+};
+
+export default function ImprintPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <Link href="/login" className="text-sm text-muted-foreground hover:text-primary">
+          &larr; Back to login
+        </Link>
+      </div>
+
+      <h1 className="mb-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+        Imprint
+      </h1>
+      <p className="mb-2 text-lg text-muted-foreground">
+        Impressum gem&auml;&szlig; &sect; 5 TMG (Telemediengesetz)
+      </p>
+      <p className="mb-8 text-sm text-muted-foreground">
+        Last updated: March 24, 2026
+      </p>
+
+      <div className="mb-10 rounded-lg border border-border/50 bg-card/50 p-4">
+        <p className="text-sm text-muted-foreground italic">
+          This is a template. The placeholders below must be filled in with actual data before
+          publication. An Impressum is legally required in Germany under &sect; 5 TMG.
+        </p>
+      </div>
+
+      <div className="space-y-8">
+        <section>
+          <h2 className="mb-3 text-xl font-semibold text-foreground">
+            Angaben gem&auml;&szlig; &sect; 5 TMG
+          </h2>
+          <address className="not-italic space-y-1 text-muted-foreground leading-relaxed">
+            <p className="font-medium text-foreground">[COMPANY_NAME]</p>
+            <p>[STREET_ADDRESS]</p>
+            <p>[POSTAL_CODE] [CITY], Germany</p>
+          </address>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-xl font-semibold text-foreground">Kontakt / Contact</h2>
+          <div className="space-y-1 text-muted-foreground leading-relaxed">
+            <p>
+              Email:{" "}
+              <a href="mailto:[CONTACT_EMAIL]" className="text-primary hover:underline">
+                [CONTACT_EMAIL]
+              </a>
+            </p>
+            <p>Phone: [PHONE_NUMBER]</p>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-xl font-semibold text-foreground">
+            Vertreten durch / Represented by
+          </h2>
+          <p className="text-muted-foreground leading-relaxed">[FULL_NAME]</p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-xl font-semibold text-foreground">
+            Umsatzsteuer-Identifikationsnummer / VAT ID
+          </h2>
+          <p className="text-muted-foreground leading-relaxed">
+            Umsatzsteuer-Identifikationsnummer gem&auml;&szlig; &sect; 27a UStG: [VAT_ID]
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-xl font-semibold text-foreground">
+            Verantwortlich f&uuml;r den Inhalt / Responsible for Content
+          </h2>
+          <p className="text-muted-foreground leading-relaxed">
+            Verantwortlich gem&auml;&szlig; &sect; 18 Abs. 2 MStV:
+          </p>
+          <address className="not-italic mt-2 space-y-1 text-muted-foreground leading-relaxed">
+            <p className="font-medium text-foreground">[FULL_NAME]</p>
+            <p>[STREET_ADDRESS]</p>
+            <p>[POSTAL_CODE] [CITY], Germany</p>
+          </address>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-xl font-semibold text-foreground">
+            EU-Streitschlichtung / EU Dispute Resolution
+          </h2>
+          <div className="space-y-3 text-muted-foreground leading-relaxed">
+            <p>
+              Die Europ&auml;ische Kommission stellt eine Plattform zur Online-Streitbeilegung
+              (OS) bereit:{" "}
+              <a
+                href="https://ec.europa.eu/consumers/odr"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                https://ec.europa.eu/consumers/odr
+              </a>
+            </p>
+            <p>
+              The European Commission provides an Online Dispute Resolution (ODR) platform:{" "}
+              <a
+                href="https://ec.europa.eu/consumers/odr"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                https://ec.europa.eu/consumers/odr
+              </a>
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-xl font-semibold text-foreground">
+            Verbraucherstreitbeilegung / Consumer Dispute Resolution
+          </h2>
+          <p className="text-muted-foreground leading-relaxed">
+            Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer
+            Verbraucherschlichtungsstelle teilzunehmen.
+          </p>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            We are not willing or obliged to participate in dispute resolution proceedings before
+            a consumer arbitration board.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-xl font-semibold text-foreground">
+            Haftungsausschluss / Disclaimer
+          </h2>
+          <div className="space-y-3 text-muted-foreground leading-relaxed">
+            <div>
+              <h3 className="mb-1 text-base font-medium text-foreground">Haftung f&uuml;r Inhalte</h3>
+              <p>
+                Die Inhalte unserer Seiten wurden mit gr&ouml;&szlig;ter Sorgfalt erstellt. F&uuml;r
+                die Richtigkeit, Vollst&auml;ndigkeit und Aktualit&auml;t der Inhalte k&ouml;nnen
+                wir jedoch keine Gew&auml;hr &uuml;bernehmen.
+              </p>
+            </div>
+            <div>
+              <h3 className="mb-1 text-base font-medium text-foreground">Haftung f&uuml;r Links</h3>
+              <p>
+                Unser Angebot enth&auml;lt Links zu externen Webseiten Dritter, auf deren Inhalte
+                wir keinen Einfluss haben. F&uuml;r die Inhalte der verlinkten Seiten ist stets
+                der jeweilige Anbieter verantwortlich.
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div className="mt-12 flex gap-4 border-t border-border/50 pt-8 text-sm text-muted-foreground">
+        <Link href="/terms" className="hover:text-primary">
+          Terms of Service
+        </Link>
+        <span>&middot;</span>
+        <Link href="/privacy" className="hover:text-primary">
+          Privacy Policy
+        </Link>
+        <span>&middot;</span>
+        <Link href="/login" className="hover:text-primary">
+          Back to login
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(public)/login/page.tsx
+++ b/web/src/app/(public)/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -137,7 +138,15 @@ export default function LoginPage() {
         </Card>
 
         <p className="text-center text-xs text-muted-foreground/70">
-          By signing in, you agree to our Terms of Service and Privacy Policy.
+          By signing in, you agree to our{" "}
+          <Link href="/terms" className="text-muted-foreground underline hover:text-primary">
+            Terms of Service
+          </Link>{" "}
+          and{" "}
+          <Link href="/privacy" className="text-muted-foreground underline hover:text-primary">
+            Privacy Policy
+          </Link>
+          .
         </p>
       </div>
     </div>

--- a/web/src/app/(public)/privacy/page.tsx
+++ b/web/src/app/(public)/privacy/page.tsx
@@ -1,0 +1,421 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — Glyphoxa",
+  description: "Privacy Policy for the Glyphoxa AI voice NPC platform. GDPR-compliant.",
+};
+
+function TOCLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <li>
+      <a href={href} className="text-primary hover:underline">
+        {children}
+      </a>
+    </li>
+  );
+}
+
+function Section({ id, title, children }: { id: string; title: string; children: React.ReactNode }) {
+  return (
+    <section id={id} className="scroll-mt-24">
+      <h2 className="mb-3 text-xl font-semibold text-foreground">{title}</h2>
+      <div className="space-y-3 text-muted-foreground leading-relaxed">{children}</div>
+    </section>
+  );
+}
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <Link href="/login" className="text-sm text-muted-foreground hover:text-primary">
+          &larr; Back to login
+        </Link>
+      </div>
+
+      <h1 className="mb-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+        Privacy Policy
+      </h1>
+      <p className="mb-8 text-sm text-muted-foreground">
+        Last updated: March 24, 2026
+      </p>
+
+      <div className="mb-10 rounded-lg border border-border/50 bg-card/50 p-4">
+        <p className="text-sm text-muted-foreground italic">
+          This document is a template and has not been reviewed by a lawyer. It should be reviewed
+          by a qualified legal professional before being relied upon.
+        </p>
+      </div>
+
+      <nav className="mb-10">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Table of Contents
+        </h2>
+        <ol className="list-decimal space-y-1 pl-5 text-sm">
+          <TOCLink href="#data-controller">Data Controller</TOCLink>
+          <TOCLink href="#data-collected">What Data We Collect</TOCLink>
+          <TOCLink href="#legal-basis">Legal Basis for Processing</TOCLink>
+          <TOCLink href="#data-usage">How We Use Your Data</TOCLink>
+          <TOCLink href="#data-retention">Data Retention</TOCLink>
+          <TOCLink href="#third-party">Third-Party Services</TOCLink>
+          <TOCLink href="#data-transfers">International Data Transfers</TOCLink>
+          <TOCLink href="#your-rights">Your Rights (GDPR)</TOCLink>
+          <TOCLink href="#cookies">Cookies and Local Storage</TOCLink>
+          <TOCLink href="#children">Children&apos;s Privacy</TOCLink>
+          <TOCLink href="#changes">Changes to This Policy</TOCLink>
+          <TOCLink href="#contact">Contact and DPO</TOCLink>
+        </ol>
+      </nav>
+
+      <div className="space-y-10">
+        <Section id="data-controller" title="1. Data Controller">
+          <p>
+            The data controller responsible for processing your personal data is:
+          </p>
+          <address className="not-italic rounded-lg border border-border/50 bg-card/50 p-4">
+            <p className="font-medium text-foreground">[COMPANY_NAME]</p>
+            <p>[ADDRESS]</p>
+            <p>
+              Email:{" "}
+              <a href="mailto:[CONTACT_EMAIL]" className="text-primary hover:underline">
+                [CONTACT_EMAIL]
+              </a>
+            </p>
+          </address>
+        </Section>
+
+        <Section id="data-collected" title="2. What Data We Collect">
+          <h3 className="text-base font-medium text-foreground">2.1 Discord Account Information</h3>
+          <p>
+            When you sign in via Discord OAuth2, we receive and store:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>Discord user ID</li>
+            <li>Email address (as provided by Discord)</li>
+            <li>Username and display name</li>
+            <li>Avatar URL</li>
+          </ul>
+          <p>
+            We do not receive or store your Discord password. Authentication is handled entirely
+            by Discord&apos;s OAuth2 flow.
+          </p>
+
+          <h3 className="mt-4 text-base font-medium text-foreground">2.2 Voice Audio</h3>
+          <p>
+            During voice sessions, audio from participants is:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>Processed in real-time for speech-to-text conversion.</li>
+            <li>
+              <strong className="text-foreground">Not permanently stored as audio files</strong> unless
+              explicitly enabled by the campaign owner.
+            </li>
+            <li>Transmitted to third-party STT providers for transcription (see Section 6).</li>
+          </ul>
+
+          <h3 className="mt-4 text-base font-medium text-foreground">2.3 Transcripts</h3>
+          <p>
+            Text transcriptions of voice sessions are stored in our PostgreSQL database. Transcripts
+            are scoped per tenant and campaign. Campaign owners can configure retention settings and
+            delete transcripts.
+          </p>
+
+          <h3 className="mt-4 text-base font-medium text-foreground">2.4 API Keys</h3>
+          <p>
+            If you provide API keys for third-party AI services:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>Keys are encrypted at rest using HashiCorp Vault Transit encryption.</li>
+            <li>Keys are only decrypted at the moment of use for API calls.</li>
+            <li>Keys are never logged, displayed in full, or shared.</li>
+          </ul>
+
+          <h3 className="mt-4 text-base font-medium text-foreground">2.5 Usage Data</h3>
+          <p>
+            We collect operational data to run and improve the Service:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>Session duration and frequency</li>
+            <li>Token counts (LLM usage per session)</li>
+            <li>Error logs (anonymized where possible)</li>
+            <li>Feature usage metrics</li>
+          </ul>
+
+          <h3 className="mt-4 text-base font-medium text-foreground">2.6 NPC and Campaign Data</h3>
+          <p>
+            NPC definitions (name, personality, voice settings) and campaign configurations you
+            create are stored to provide the Service. This data is scoped to your tenant and is not
+            shared with other users.
+          </p>
+        </Section>
+
+        <Section id="legal-basis" title="3. Legal Basis for Processing">
+          <p>
+            We process your personal data on the following legal bases under GDPR:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>
+              <strong className="text-foreground">Consent</strong> (Art. 6(1)(a) GDPR): When you
+              sign in via Discord OAuth2, you consent to the transfer of your Discord profile
+              information.
+            </li>
+            <li>
+              <strong className="text-foreground">Contract performance</strong> (Art. 6(1)(b) GDPR):
+              Processing necessary to provide the Service you signed up for, including voice session
+              processing, transcript storage, and account management.
+            </li>
+            <li>
+              <strong className="text-foreground">Legitimate interest</strong> (Art. 6(1)(f) GDPR):
+              Service security, fraud prevention, usage analytics for service improvement, and
+              debugging.
+            </li>
+          </ul>
+        </Section>
+
+        <Section id="data-usage" title="4. How We Use Your Data">
+          <p>We use your data to:</p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>Provide and maintain the Service (voice sessions, NPC interactions, transcripts).</li>
+            <li>Authenticate your identity and manage your account.</li>
+            <li>Enforce usage quotas and subscription limits.</li>
+            <li>Improve the Service based on aggregated, anonymized usage patterns.</li>
+            <li>Communicate with you about your account or important Service updates.</li>
+            <li>Comply with legal obligations.</li>
+          </ul>
+          <p>
+            We do <strong className="text-foreground">not</strong> sell your personal data. We do{" "}
+            <strong className="text-foreground">not</strong> use your data for advertising. We do{" "}
+            <strong className="text-foreground">not</strong> use your content to train AI models.
+          </p>
+        </Section>
+
+        <Section id="data-retention" title="5. Data Retention">
+          <ul className="list-disc space-y-1 pl-5">
+            <li>
+              <strong className="text-foreground">Account data</strong> (Discord profile, email): Retained
+              until you delete your account or request deletion.
+            </li>
+            <li>
+              <strong className="text-foreground">Transcripts</strong>: Retained according to campaign-level
+              settings configured by the campaign owner. Defaults to indefinite retention unless
+              configured otherwise.
+            </li>
+            <li>
+              <strong className="text-foreground">Voice audio</strong>: Processed in real-time and
+              discarded immediately after transcription. Not stored permanently.
+            </li>
+            <li>
+              <strong className="text-foreground">API keys</strong>: Retained until you delete them
+              or your account is terminated.
+            </li>
+            <li>
+              <strong className="text-foreground">Usage data</strong>: Retained for up to 24 months
+              for analytics, then anonymized or deleted.
+            </li>
+          </ul>
+          <p>
+            Upon account deletion, your personal data will be removed within 30 days. Some data may
+            be retained longer if required by law.
+          </p>
+        </Section>
+
+        <Section id="third-party" title="6. Third-Party Services">
+          <p>
+            Glyphoxa integrates with third-party services to provide its functionality. Data shared
+            with these services is limited to what is necessary:
+          </p>
+          <ul className="list-disc space-y-2 pl-5">
+            <li>
+              <strong className="text-foreground">Discord</strong> — Authentication (OAuth2) and
+              voice chat connectivity. Subject to{" "}
+              <a
+                href="https://discord.com/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                Discord&apos;s Privacy Policy
+              </a>
+              .
+            </li>
+            <li>
+              <strong className="text-foreground">ElevenLabs</strong> — Text-to-speech and
+              speech-to-text processing. Voice audio snippets are sent for processing.
+            </li>
+            <li>
+              <strong className="text-foreground">Google (Gemini)</strong> — Large language model
+              inference and embedding generation. Transcript text is sent for NPC response
+              generation.
+            </li>
+            <li>
+              <strong className="text-foreground">Stripe</strong> — Payment processing (if
+              applicable). We do not store credit card numbers; Stripe handles all payment data.
+              Subject to{" "}
+              <a
+                href="https://stripe.com/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                Stripe&apos;s Privacy Policy
+              </a>
+              .
+            </li>
+          </ul>
+          <p>
+            When you provide your own API keys, requests to these services are made with your
+            credentials. When using Glyphoxa-provided keys, requests are made with our credentials.
+          </p>
+        </Section>
+
+        <Section id="data-transfers" title="7. International Data Transfers">
+          <p>
+            Some of our third-party service providers may process data outside the European Economic
+            Area (EEA). In such cases, we ensure appropriate safeguards are in place:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>
+              EU Standard Contractual Clauses (SCCs) where applicable.
+            </li>
+            <li>
+              Adequacy decisions by the European Commission (e.g., EU-US Data Privacy Framework).
+            </li>
+            <li>
+              Provider-specific data processing agreements.
+            </li>
+          </ul>
+          <p>
+            Our own infrastructure is hosted within the EU.
+          </p>
+        </Section>
+
+        <Section id="your-rights" title="8. Your Rights (GDPR)">
+          <p>
+            Under the General Data Protection Regulation (GDPR), you have the following rights
+            regarding your personal data:
+          </p>
+          <ul className="list-disc space-y-2 pl-5">
+            <li>
+              <strong className="text-foreground">Right of access</strong> (Art. 15) — Request a
+              copy of the personal data we hold about you.
+            </li>
+            <li>
+              <strong className="text-foreground">Right to rectification</strong> (Art. 16) —
+              Request correction of inaccurate or incomplete personal data.
+            </li>
+            <li>
+              <strong className="text-foreground">Right to erasure</strong> (Art. 17) — Request
+              deletion of your personal data (&quot;right to be forgotten&quot;).
+            </li>
+            <li>
+              <strong className="text-foreground">Right to restrict processing</strong> (Art. 18) —
+              Request that we limit how we use your data.
+            </li>
+            <li>
+              <strong className="text-foreground">Right to data portability</strong> (Art. 20) —
+              Receive your data in a structured, machine-readable format.
+            </li>
+            <li>
+              <strong className="text-foreground">Right to object</strong> (Art. 21) — Object to
+              processing based on legitimate interests.
+            </li>
+            <li>
+              <strong className="text-foreground">Right to withdraw consent</strong> (Art. 7(3)) —
+              Withdraw consent at any time (does not affect prior processing).
+            </li>
+          </ul>
+          <p>
+            To exercise any of these rights, contact us at{" "}
+            <a href="mailto:[CONTACT_EMAIL]" className="text-primary hover:underline">
+              [CONTACT_EMAIL]
+            </a>
+            . We will respond within 30 days as required by law.
+          </p>
+          <p>
+            You also have the right to lodge a complaint with your local data protection authority.
+            In Germany, this is the relevant state data protection authority
+            (Landesdatenschutzbeauftragter).
+          </p>
+        </Section>
+
+        <Section id="cookies" title="9. Cookies and Local Storage">
+          <p>
+            Glyphoxa uses only <strong className="text-foreground">functional cookies and local
+            storage</strong>. We do not use tracking cookies, analytics cookies, or advertising
+            cookies.
+          </p>
+          <ul className="list-disc space-y-2 pl-5">
+            <li>
+              <strong className="text-foreground">Authentication token</strong> — Stored in
+              localStorage as <code className="rounded bg-muted px-1.5 py-0.5 text-xs">glyphoxa_token</code>.
+              This is necessary for keeping you signed in. It is removed when you log out.
+            </li>
+            <li>
+              <strong className="text-foreground">UI preferences</strong> — Settings like sidebar
+              state may be stored in localStorage for your convenience. These contain no personal
+              data.
+            </li>
+          </ul>
+          <p>
+            Since we only use strictly necessary/functional storage, no consent is required under
+            the ePrivacy Directive. We still inform you of their use here for transparency.
+          </p>
+        </Section>
+
+        <Section id="children" title="10. Children&apos;s Privacy">
+          <p>
+            Glyphoxa is not directed at children under 16 years of age. We do not knowingly collect
+            personal data from children under 16. If you believe a child under 16 has provided us
+            with personal data, please contact us and we will take steps to delete that information.
+          </p>
+        </Section>
+
+        <Section id="changes" title="11. Changes to This Policy">
+          <p>
+            We may update this Privacy Policy from time to time. When we make material changes:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>We will update the &quot;Last updated&quot; date at the top.</li>
+            <li>We will provide at least 30 days&apos; notice for significant changes.</li>
+            <li>We may notify you via email or in-app notification.</li>
+          </ul>
+        </Section>
+
+        <Section id="contact" title="12. Contact and DPO">
+          <p>
+            For any privacy-related questions or to exercise your data protection rights:
+          </p>
+          <address className="not-italic rounded-lg border border-border/50 bg-card/50 p-4">
+            <p className="font-medium text-foreground">[COMPANY_NAME]</p>
+            <p>[ADDRESS]</p>
+            <p>
+              Email:{" "}
+              <a href="mailto:[CONTACT_EMAIL]" className="text-primary hover:underline">
+                [CONTACT_EMAIL]
+              </a>
+            </p>
+          </address>
+          <p className="mt-3">
+            If a Data Protection Officer (DPO) has been appointed, their contact details will be
+            provided here: [DPO_EMAIL]
+          </p>
+        </Section>
+      </div>
+
+      <div className="mt-12 flex gap-4 border-t border-border/50 pt-8 text-sm text-muted-foreground">
+        <Link href="/terms" className="hover:text-primary">
+          Terms of Service
+        </Link>
+        <span>&middot;</span>
+        <Link href="/imprint" className="hover:text-primary">
+          Imprint
+        </Link>
+        <span>&middot;</span>
+        <Link href="/login" className="hover:text-primary">
+          Back to login
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(public)/terms/page.tsx
+++ b/web/src/app/(public)/terms/page.tsx
@@ -1,0 +1,329 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Terms of Service — Glyphoxa",
+  description: "Terms of Service for the Glyphoxa AI voice NPC platform.",
+};
+
+function TOCLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <li>
+      <a href={href} className="text-primary hover:underline">
+        {children}
+      </a>
+    </li>
+  );
+}
+
+function Section({ id, title, children }: { id: string; title: string; children: React.ReactNode }) {
+  return (
+    <section id={id} className="scroll-mt-24">
+      <h2 className="mb-3 text-xl font-semibold text-foreground">{title}</h2>
+      <div className="space-y-3 text-muted-foreground leading-relaxed">{children}</div>
+    </section>
+  );
+}
+
+export default function TermsOfServicePage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <Link href="/login" className="text-sm text-muted-foreground hover:text-primary">
+          &larr; Back to login
+        </Link>
+      </div>
+
+      <h1 className="mb-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+        Terms of Service
+      </h1>
+      <p className="mb-8 text-sm text-muted-foreground">
+        Last updated: March 24, 2026
+      </p>
+
+      <div className="mb-10 rounded-lg border border-border/50 bg-card/50 p-4">
+        <p className="text-sm text-muted-foreground italic">
+          This document is a template and has not been reviewed by a lawyer. It should be reviewed
+          by a qualified legal professional before being relied upon.
+        </p>
+      </div>
+
+      <nav className="mb-10">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Table of Contents
+        </h2>
+        <ol className="list-decimal space-y-1 pl-5 text-sm">
+          <TOCLink href="#service-description">Service Description</TOCLink>
+          <TOCLink href="#account-terms">Account Terms</TOCLink>
+          <TOCLink href="#acceptable-use">Acceptable Use</TOCLink>
+          <TOCLink href="#subscriptions-billing">Subscriptions and Billing</TOCLink>
+          <TOCLink href="#intellectual-property">Intellectual Property</TOCLink>
+          <TOCLink href="#api-keys">API Key Handling</TOCLink>
+          <TOCLink href="#service-availability">Service Availability</TOCLink>
+          <TOCLink href="#termination">Termination</TOCLink>
+          <TOCLink href="#limitation-of-liability">Limitation of Liability</TOCLink>
+          <TOCLink href="#governing-law">Governing Law</TOCLink>
+          <TOCLink href="#changes">Changes to These Terms</TOCLink>
+          <TOCLink href="#contact">Contact</TOCLink>
+        </ol>
+      </nav>
+
+      <div className="space-y-10">
+        <Section id="service-description" title="1. Service Description">
+          <p>
+            Glyphoxa (&quot;the Service&quot;) is an AI-powered voice NPC platform for tabletop
+            role-playing games. It is operated by [COMPANY_NAME], [ADDRESS] (&quot;we&quot;,
+            &quot;us&quot;, &quot;our&quot;).
+          </p>
+          <p>
+            The Service allows game masters to create AI-driven non-player characters (NPCs) with
+            distinct voices, personalities, and persistent memory. NPCs participate in live voice
+            chat sessions via supported platforms (e.g., Discord, WebRTC).
+          </p>
+          <p>
+            By accessing or using Glyphoxa, you agree to be bound by these Terms of Service. If you
+            do not agree to these terms, do not use the Service.
+          </p>
+        </Section>
+
+        <Section id="account-terms" title="2. Account Terms">
+          <p>
+            To use Glyphoxa, you must sign in with a Discord account or an API key provided by a
+            tenant administrator. You must be at least 16 years old to use the Service.
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>One account per person. Do not create multiple accounts.</li>
+            <li>You are responsible for keeping your login credentials and API keys secure.</li>
+            <li>
+              You are responsible for all activity that occurs under your account.
+            </li>
+            <li>
+              Notify us immediately if you suspect unauthorized access to your account.
+            </li>
+          </ul>
+        </Section>
+
+        <Section id="acceptable-use" title="3. Acceptable Use">
+          <p>You agree not to use Glyphoxa to:</p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>Violate any applicable law or regulation.</li>
+            <li>
+              Generate, distribute, or facilitate content that is illegal, harmful, threatening,
+              abusive, harassing, defamatory, or otherwise objectionable.
+            </li>
+            <li>Impersonate any person or entity, or misrepresent your affiliation.</li>
+            <li>
+              Attempt to gain unauthorized access to the Service, other accounts, or connected
+              systems.
+            </li>
+            <li>
+              Interfere with or disrupt the Service or servers/networks connected to it.
+            </li>
+            <li>Use the Service for any purpose that is not related to tabletop RPGs or gaming.</li>
+            <li>
+              Use automated tools (bots, scrapers) to access the Service without prior written
+              consent.
+            </li>
+          </ul>
+          <p>
+            We reserve the right to suspend or terminate accounts that violate these terms, at our
+            sole discretion.
+          </p>
+        </Section>
+
+        <Section id="subscriptions-billing" title="4. Subscriptions and Billing">
+          <p>
+            Glyphoxa offers tiered subscription plans. Details of available plans, pricing, and
+            included features are available on the Service&apos;s pricing page.
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>
+              Subscriptions are billed in advance on a monthly or annual basis, depending on the
+              plan selected.
+            </li>
+            <li>
+              You may cancel your subscription at any time. Cancellation takes effect at the end of
+              the current billing period. No partial refunds are provided for unused time.
+            </li>
+            <li>
+              We reserve the right to change pricing with 30 days&apos; notice. Existing
+              subscriptions will honor the current price until the next renewal.
+            </li>
+            <li>
+              Free tiers and trials may be offered at our discretion and can be modified or
+              discontinued at any time.
+            </li>
+          </ul>
+        </Section>
+
+        <Section id="intellectual-property" title="5. Intellectual Property">
+          <p>
+            <strong className="text-foreground">Your content:</strong> You retain ownership of all
+            content you create through Glyphoxa, including NPC definitions, campaign settings,
+            transcripts, and any creative material you provide. By using the Service, you grant us a
+            limited license to process and store your content solely for the purpose of providing the
+            Service.
+          </p>
+          <p>
+            <strong className="text-foreground">Our service:</strong> Glyphoxa, its code, design,
+            branding, and documentation are the intellectual property of [COMPANY_NAME]. You may not
+            copy, modify, distribute, or reverse-engineer any part of the Service without prior
+            written consent.
+          </p>
+          <p>
+            <strong className="text-foreground">AI-generated content:</strong> Content generated by
+            AI during voice sessions (NPC dialogue, narration) is produced in real-time and is
+            considered part of your creative output as the game master. We make no claim of ownership
+            over AI-generated content produced during your sessions.
+          </p>
+        </Section>
+
+        <Section id="api-keys" title="6. API Key Handling">
+          <p>
+            Glyphoxa allows you to provide your own API keys for third-party AI services (e.g., LLM,
+            TTS, STT providers). These keys are:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>Encrypted at rest using industry-standard encryption (HashiCorp Vault Transit).</li>
+            <li>Used solely for making API calls on your behalf during voice sessions.</li>
+            <li>Never shared with other users or third parties.</li>
+            <li>Deletable at any time through your account settings.</li>
+          </ul>
+          <p>
+            You are responsible for the costs incurred through your own API keys. We are not liable
+            for charges from third-party providers resulting from your use of the Service.
+          </p>
+        </Section>
+
+        <Section id="service-availability" title="7. Service Availability">
+          <p>
+            We aim to provide reliable service, but Glyphoxa is currently in beta. As such:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>
+              We do not guarantee any specific uptime or service level agreement (SLA).
+            </li>
+            <li>
+              The Service may be temporarily unavailable due to maintenance, updates, or
+              circumstances beyond our control.
+            </li>
+            <li>
+              Features may change, be added, or be removed as the Service evolves.
+            </li>
+            <li>We will make reasonable efforts to notify users of planned downtime.</li>
+          </ul>
+        </Section>
+
+        <Section id="termination" title="8. Termination">
+          <p>
+            Either party may terminate this agreement at any time:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>
+              <strong className="text-foreground">You</strong> may delete your account or stop using
+              the Service at any time.
+            </li>
+            <li>
+              <strong className="text-foreground">We</strong> may suspend or terminate your access if
+              you violate these terms, or for any other reason with reasonable notice.
+            </li>
+          </ul>
+          <p>
+            Upon termination, your right to use the Service ceases immediately. We may retain your
+            data for a reasonable period to comply with legal obligations, after which it will be
+            deleted.
+          </p>
+        </Section>
+
+        <Section id="limitation-of-liability" title="9. Limitation of Liability">
+          <p>
+            To the maximum extent permitted by applicable law:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>
+              The Service is provided &quot;as is&quot; and &quot;as available&quot; without
+              warranties of any kind, whether express or implied.
+            </li>
+            <li>
+              We are not liable for any indirect, incidental, special, consequential, or punitive
+              damages arising from your use of the Service.
+            </li>
+            <li>
+              Our total liability is limited to the amount you paid us in the 12 months preceding the
+              claim.
+            </li>
+            <li>
+              We are not responsible for the accuracy, quality, or appropriateness of AI-generated
+              content.
+            </li>
+          </ul>
+        </Section>
+
+        <Section id="governing-law" title="10. Governing Law">
+          <p>
+            These Terms are governed by the laws of the Federal Republic of Germany. Any disputes
+            arising from or related to these Terms shall be subject to the exclusive jurisdiction of
+            the courts in [CITY], Germany.
+          </p>
+          <p>
+            If you are a consumer within the European Union, you also enjoy the protection of the
+            mandatory provisions of consumer protection law in your country of residence. You may
+            also use the{" "}
+            <a
+              href="https://ec.europa.eu/consumers/odr"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              EU Online Dispute Resolution platform
+            </a>
+            .
+          </p>
+        </Section>
+
+        <Section id="changes" title="11. Changes to These Terms">
+          <p>
+            We may update these Terms of Service from time to time. When we do, we will:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>Update the &quot;Last updated&quot; date at the top of this page.</li>
+            <li>Provide at least 30 days&apos; notice for material changes (via email or in-app notification).</li>
+            <li>
+              Your continued use of the Service after the notice period constitutes acceptance of the
+              updated terms.
+            </li>
+          </ul>
+        </Section>
+
+        <Section id="contact" title="12. Contact">
+          <p>
+            If you have any questions about these Terms of Service, contact us at:
+          </p>
+          <ul className="list-none space-y-1 pl-0">
+            <li>
+              Email:{" "}
+              <a href="mailto:[CONTACT_EMAIL]" className="text-primary hover:underline">
+                [CONTACT_EMAIL]
+              </a>
+            </li>
+            <li>Address: [ADDRESS]</li>
+          </ul>
+        </Section>
+      </div>
+
+      <div className="mt-12 flex gap-4 border-t border-border/50 pt-8 text-sm text-muted-foreground">
+        <Link href="/privacy" className="hover:text-primary">
+          Privacy Policy
+        </Link>
+        <span>&middot;</span>
+        <Link href="/imprint" className="hover:text-primary">
+          Imprint
+        </Link>
+        <span>&middot;</span>
+        <Link href="/login" className="hover:text-primary">
+          Back to login
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Providers } from "@/components/providers";
+import { CookieNotice } from "@/components/cookie-notice";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -34,6 +35,7 @@ export default function RootLayout({
           Skip to content
         </a>
         <Providers>{children}</Providers>
+        <CookieNotice />
       </body>
     </html>
   );

--- a/web/src/components/cookie-notice.tsx
+++ b/web/src/components/cookie-notice.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const COOKIE_NOTICE_KEY = "glyphoxa_cookie_notice_dismissed";
+
+export function CookieNotice() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const dismissed = localStorage.getItem(COOKIE_NOTICE_KEY);
+    if (!dismissed) {
+      setVisible(true);
+    }
+  }, []);
+
+  function dismiss() {
+    localStorage.setItem(COOKIE_NOTICE_KEY, "1");
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="status"
+      aria-label="Cookie notice"
+      className="fixed bottom-0 left-0 right-0 z-50 border-t border-border/50 bg-card/95 backdrop-blur-sm"
+    >
+      <div className="mx-auto flex max-w-4xl items-center gap-4 px-4 py-3 sm:px-6">
+        <p className="flex-1 text-sm text-muted-foreground">
+          This site uses only functional cookies and localStorage to keep you signed in. No tracking
+          or analytics cookies are used.{" "}
+          <Link href="/privacy#cookies" className="text-primary hover:underline">
+            Learn more
+          </Link>
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={dismiss}
+          className="shrink-0"
+        >
+          Got it
+        </Button>
+        <button
+          onClick={dismiss}
+          className="shrink-0 rounded-md p-1 text-muted-foreground hover:text-foreground"
+          aria-label="Dismiss cookie notice"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Terms of Service** (`/terms`) — 12-section SaaS ToS covering service description, account terms, acceptable use, billing, IP, API keys, availability, termination, liability, governing law (German), changes, and contact
- **Privacy Policy** (`/privacy`) — GDPR-compliant policy covering data controller, collected data (Discord, voice, transcripts, API keys, usage), legal basis (consent/contract/legitimate interest), retention, third parties (Discord, ElevenLabs, Gemini, Stripe), international transfers, GDPR rights (Art. 15-22), cookies/localStorage, children's privacy
- **Imprint** (`/imprint`) — Impressum per §5 TMG (Telemediengesetz), bilingual German/English, EU dispute resolution links
- **Cookie notice banner** — Informational notice (functional cookies only, no tracking), dismissible, persisted in localStorage
- **Login page** — "Terms of Service" and "Privacy Policy" text now link to `/terms` and `/privacy`

All pages match the dark Glyphoxa theme, include table of contents with anchor links, "last updated" dates, cross-links between legal pages, and a back-to-login link.

Placeholder tokens (`[COMPANY_NAME]`, `[CONTACT_EMAIL]`, `[ADDRESS]`, etc.) need to be replaced before going live. Each page includes a disclaimer that it should be reviewed by a lawyer.

## Test plan
- [ ] Visit `/login` and verify ToS and Privacy Policy links work
- [ ] Navigate `/terms`, `/privacy`, `/imprint` — check rendering, anchor links, cross-navigation
- [ ] Verify cookie notice appears on first visit, dismisses on "Got it", doesn't reappear after refresh
- [ ] `npm run build` passes (verified locally)