### PR TITLE
fix(ci): fix gofmt lint and Docker CGO_ENABLED=0 build failure

### DIFF
--- a/internal/web/gateway_client.go
+++ b/internal/web/gateway_client.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -9,9 +10,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/MrWong99/glyphoxa/gen/glyphoxa/v1"
-	"github.com/MrWong99/glyphoxa/internal/gateway/grpctransport"
 )
 
 // DialGateway establishes a gRPC connection to the gateway's ManagementService.
@@ -36,8 +37,19 @@ func DialGateway(cfg *Config) (pb.ManagementServiceClient, *grpc.ClientConn, err
 
 	// Send shared secret in gRPC metadata for ManagementService auth.
 	if cfg.GatewaySharedSecret != "" {
+		secret := cfg.GatewaySharedSecret
 		opts = append(opts, grpc.WithUnaryInterceptor(
-			grpctransport.MgmtSecretUnaryClientInterceptor(cfg.GatewaySharedSecret),
+			func(
+				ctx context.Context,
+				method string,
+				req, reply any,
+				cc *grpc.ClientConn,
+				invoker grpc.UnaryInvoker,
+				callOpts ...grpc.CallOption,
+			) error {
+				ctx = metadata.AppendToOutgoingContext(ctx, "x-mgmt-secret", secret)
+				return invoker(ctx, method, req, reply, cc, callOpts...)
+			},
 		))
 	}
 

--- a/internal/web/handlers_npcs.go
+++ b/internal/web/handlers_npcs.go
@@ -5,8 +5,8 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/google/uuid"
 	"github.com/MrWong99/glyphoxa/internal/agent/npcstore"
+	"github.com/google/uuid"
 )
 
 // NPCCreateRequest is the JSON body for creating an NPC.


### PR DESCRIPTION
## Summary

- **CI Lint failure**: `internal/web/handlers_npcs.go` had misordered imports (`github.com/google/uuid` before the project import), which fails `gofmt -l` check. Fixed import ordering.
- **Docker build failure**: `Dockerfile.web` builds `glyphoxa-web` with `CGO_ENABLED=0`, but `internal/web/gateway_client.go` imported `internal/gateway/grpctransport` which transitively pulls in `layeh.com/gopus` (requires CGO). Inlined the small `MgmtSecretUnaryClientInterceptor` function directly in `gateway_client.go` to break the import chain — the interceptor only needs `google.golang.org/grpc/metadata` with no CGO deps.

## Test plan

- [x] `gofmt -l .` reports no files
- [x] `CGO_ENABLED=0 go build ./cmd/glyphoxa-web` succeeds
- [x] `go vet ./...` passes
- [ ] CI workflow passes on this PR
- [ ] Docker workflow builds successfully on merge