### PR TITLE
feat(test): add integration tests for cross-component interactions

### DIFF
--- a/internal/config/integration_test.go
+++ b/internal/config/integration_test.go
@@ -1,0 +1,395 @@
+//go:build integration
+
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/glyphoxa/internal/config"
+)
+
+// TestIntegration_ConfigLoadAndValidate tests the full config loading and
+// validation pipeline with various configurations that exercise cross-field
+// validation, provider availability checks, and NPC constraints.
+func TestIntegration_ConfigLoadAndValidate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("minimal valid config", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+server:
+  listen_addr: ":8080"
+  log_level: info
+providers:
+  llm:
+    name: openai
+    api_key: test-key
+    model: gpt-4o-mini
+  tts:
+    name: elevenlabs
+    api_key: test-key
+  stt:
+    name: deepgram
+    api_key: test-key
+  vad:
+    name: silero
+  audio:
+    name: discord
+    api_key: test-bot-token
+npcs:
+  - name: TestNPC
+    personality: A test NPC
+    engine: cascaded
+    voice:
+      voice_id: test-voice
+memory:
+  postgres_dsn: "postgres://test:test@localhost/test"
+  embedding_dimensions: 1536
+`
+		cfg, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err != nil {
+			t.Fatalf("LoadFromReader: %v", err)
+		}
+		if cfg.Server.ListenAddr != ":8080" {
+			t.Errorf("ListenAddr = %q, want :8080", cfg.Server.ListenAddr)
+		}
+		if len(cfg.NPCs) != 1 {
+			t.Errorf("NPCs = %d, want 1", len(cfg.NPCs))
+		}
+		if cfg.NPCs[0].Name != "TestNPC" {
+			t.Errorf("NPC name = %q, want TestNPC", cfg.NPCs[0].Name)
+		}
+	})
+
+	t.Run("invalid engine returns error", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+providers:
+  llm:
+    name: openai
+npcs:
+  - name: BadNPC
+    engine: invalid_engine
+`
+		_, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err == nil {
+			t.Fatal("expected error for invalid engine")
+		}
+		if !strings.Contains(err.Error(), "invalid") {
+			t.Errorf("error = %q, expected to contain 'invalid'", err.Error())
+		}
+	})
+
+	t.Run("duplicate NPC names return error", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+npcs:
+  - name: DuplicateNPC
+    engine: cascaded
+  - name: DuplicateNPC
+    engine: cascaded
+providers:
+  llm:
+    name: openai
+  tts:
+    name: elevenlabs
+`
+		_, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err == nil {
+			t.Fatal("expected error for duplicate NPC names")
+		}
+		if !strings.Contains(err.Error(), "duplicate") {
+			t.Errorf("error = %q, expected to contain 'duplicate'", err.Error())
+		}
+	})
+
+	t.Run("cascaded engine without LLM provider returns error", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+npcs:
+  - name: NoLLM
+    engine: cascaded
+providers:
+  tts:
+    name: elevenlabs
+`
+		_, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err == nil {
+			t.Fatal("expected error for cascaded without LLM")
+		}
+		if !strings.Contains(err.Error(), "LLM") {
+			t.Errorf("error = %q, expected to mention LLM", err.Error())
+		}
+	})
+
+	t.Run("cascaded engine without TTS provider returns error", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+npcs:
+  - name: NoTTS
+    engine: cascaded
+providers:
+  llm:
+    name: openai
+`
+		_, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err == nil {
+			t.Fatal("expected error for cascaded without TTS")
+		}
+		if !strings.Contains(err.Error(), "TTS") {
+			t.Errorf("error = %q, expected to mention TTS", err.Error())
+		}
+	})
+
+	t.Run("s2s engine without S2S provider returns error", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+npcs:
+  - name: NoS2S
+    engine: s2s
+`
+		_, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err == nil {
+			t.Fatal("expected error for s2s without provider")
+		}
+		if !strings.Contains(err.Error(), "S2S") {
+			t.Errorf("error = %q, expected to mention S2S", err.Error())
+		}
+	})
+
+	t.Run("multiple GM helpers returns error", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+npcs:
+  - name: GM1
+    gm_helper: true
+    engine: cascaded
+  - name: GM2
+    gm_helper: true
+    engine: cascaded
+providers:
+  llm:
+    name: openai
+  tts:
+    name: elevenlabs
+`
+		_, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err == nil {
+			t.Fatal("expected error for multiple GM helpers")
+		}
+		if !strings.Contains(err.Error(), "gm_helper") {
+			t.Errorf("error = %q, expected to mention gm_helper", err.Error())
+		}
+	})
+
+	t.Run("GM helper gets AddressOnly default", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+npcs:
+  - name: GMHelper
+    gm_helper: true
+    engine: cascaded
+providers:
+  llm:
+    name: openai
+  tts:
+    name: elevenlabs
+`
+		cfg, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err != nil {
+			t.Fatalf("LoadFromReader: %v", err)
+		}
+		if !cfg.NPCs[0].AddressOnly {
+			t.Error("GM helper should have AddressOnly=true by default")
+		}
+	})
+
+	t.Run("invalid log level returns error", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+server:
+  log_level: verbose
+`
+		_, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err == nil {
+			t.Fatal("expected error for invalid log level")
+		}
+	})
+
+	t.Run("invalid budget tier returns error", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+npcs:
+  - name: BadBudget
+    engine: cascaded
+    budget_tier: premium
+providers:
+  llm:
+    name: openai
+  tts:
+    name: elevenlabs
+`
+		_, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err == nil {
+			t.Fatal("expected error for invalid budget tier")
+		}
+	})
+
+	t.Run("voice speed factor out of range returns error", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+npcs:
+  - name: FastNPC
+    engine: cascaded
+    voice:
+      speed_factor: 5.0
+providers:
+  llm:
+    name: openai
+  tts:
+    name: elevenlabs
+`
+		_, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err == nil {
+			t.Fatal("expected error for speed_factor out of range")
+		}
+	})
+
+	t.Run("MCP server validation", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+mcp:
+  servers:
+    - name: ""
+      transport: stdio
+`
+		_, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err == nil {
+			t.Fatal("expected error for MCP server without name")
+		}
+	})
+
+	t.Run("MCP stdio without command returns error", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+mcp:
+  servers:
+    - name: test-server
+      transport: stdio
+`
+		_, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err == nil {
+			t.Fatal("expected error for stdio transport without command")
+		}
+	})
+
+	t.Run("all valid engines accepted", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+providers:
+  llm:
+    name: openai
+  tts:
+    name: elevenlabs
+  s2s:
+    name: openai-realtime
+npcs:
+  - name: CascadedNPC
+    engine: cascaded
+  - name: S2SNPC
+    engine: s2s
+`
+		cfg, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err != nil {
+			t.Fatalf("LoadFromReader: %v", err)
+		}
+		if len(cfg.NPCs) != 2 {
+			t.Errorf("NPCs = %d, want 2", len(cfg.NPCs))
+		}
+	})
+
+	t.Run("empty config is valid", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `{}`
+		cfg, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err != nil {
+			t.Fatalf("LoadFromReader: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("config should not be nil")
+		}
+	})
+
+	t.Run("all valid provider names accepted", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+providers:
+  llm:
+    name: openai
+  stt:
+    name: deepgram
+  tts:
+    name: elevenlabs
+  s2s:
+    name: gemini-live
+  embeddings:
+    name: openai
+  vad:
+    name: silero
+  audio:
+    name: discord
+`
+		cfg, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err != nil {
+			t.Fatalf("LoadFromReader: %v", err)
+		}
+		if cfg.Providers.LLM.Name != "openai" {
+			t.Errorf("LLM name = %q", cfg.Providers.LLM.Name)
+		}
+	})
+}
+
+// TestIntegration_WebConfigValidation tests the web service config validation.
+func TestIntegration_WebConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing database DSN returns error", func(t *testing.T) {
+		t.Parallel()
+		// We test Validate directly since LoadConfig reads from env vars.
+		cfg := &config.Config{}
+		err := config.Validate(cfg)
+		// Config with no NPCs and no providers is valid (just empty).
+		if err != nil {
+			t.Fatalf("Validate empty config: %v", err)
+		}
+	})
+
+	t.Run("strict YAML rejects unknown fields", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+unknown_field: true
+`
+		_, err := config.LoadFromReader(strings.NewReader(yaml))
+		if err == nil {
+			t.Fatal("expected error for unknown YAML field")
+		}
+	})
+}

--- a/internal/gateway/grpctransport/integration_test.go
+++ b/internal/gateway/grpctransport/integration_test.go
@@ -1,0 +1,641 @@
+//go:build integration
+
+package grpctransport_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	pb "github.com/MrWong99/glyphoxa/gen/glyphoxa/v1"
+	"github.com/MrWong99/glyphoxa/internal/gateway"
+	"github.com/MrWong99/glyphoxa/internal/gateway/grpctransport"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// stubWorkerHandler is a minimal WorkerHandler that records calls for
+// verification.
+type stubWorkerHandler struct {
+	mu       sync.Mutex
+	started  []gateway.StartSessionRequest
+	stopped  []string
+	npcs     map[string][]gateway.NPCStatus
+	muted    map[string]bool
+	speakLog []speakEntry
+}
+
+type speakEntry struct {
+	SessionID string
+	NPCName   string
+	Text      string
+}
+
+func newStubWorkerHandler() *stubWorkerHandler {
+	return &stubWorkerHandler{
+		npcs:  make(map[string][]gateway.NPCStatus),
+		muted: make(map[string]bool),
+	}
+}
+
+func (h *stubWorkerHandler) StartSession(_ context.Context, req gateway.StartSessionRequest) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.started = append(h.started, req)
+	h.npcs[req.SessionID] = make([]gateway.NPCStatus, len(req.NPCConfigs))
+	for i, nc := range req.NPCConfigs {
+		h.npcs[req.SessionID][i] = gateway.NPCStatus{
+			ID:   fmt.Sprintf("npc-%d", i),
+			Name: nc.Name,
+		}
+	}
+	return nil
+}
+
+func (h *stubWorkerHandler) StopSession(_ context.Context, sessionID string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.stopped = append(h.stopped, sessionID)
+	return nil
+}
+
+func (h *stubWorkerHandler) GetStatus(_ context.Context) ([]gateway.SessionStatus, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var statuses []gateway.SessionStatus
+	for _, req := range h.started {
+		statuses = append(statuses, gateway.SessionStatus{
+			SessionID: req.SessionID,
+			State:     gateway.SessionActive,
+			StartedAt: time.Now(),
+		})
+	}
+	return statuses, nil
+}
+
+func (h *stubWorkerHandler) ListNPCs(_ context.Context, sessionID string) ([]gateway.NPCStatus, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.npcs[sessionID], nil
+}
+
+func (h *stubWorkerHandler) MuteNPC(_ context.Context, sessionID, npcName string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	key := sessionID + "/" + npcName
+	h.muted[key] = true
+	return nil
+}
+
+func (h *stubWorkerHandler) UnmuteNPC(_ context.Context, sessionID, npcName string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	key := sessionID + "/" + npcName
+	delete(h.muted, key)
+	return nil
+}
+
+func (h *stubWorkerHandler) MuteAllNPCs(_ context.Context, sessionID string) (int, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	count := 0
+	for _, n := range h.npcs[sessionID] {
+		key := sessionID + "/" + n.Name
+		h.muted[key] = true
+		count++
+	}
+	return count, nil
+}
+
+func (h *stubWorkerHandler) UnmuteAllNPCs(_ context.Context, sessionID string) (int, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	count := 0
+	for _, n := range h.npcs[sessionID] {
+		key := sessionID + "/" + n.Name
+		if h.muted[key] {
+			delete(h.muted, key)
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (h *stubWorkerHandler) SpeakNPC(_ context.Context, sessionID, npcName, text string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.speakLog = append(h.speakLog, speakEntry{sessionID, npcName, text})
+	return nil
+}
+
+// stubGatewayCallback records gateway callbacks for verification.
+type stubGatewayCallback struct {
+	mu         sync.Mutex
+	states     []stateReport
+	heartbeats []string
+}
+
+type stateReport struct {
+	SessionID string
+	State     gateway.SessionState
+	Error     string
+}
+
+func (g *stubGatewayCallback) ReportState(_ context.Context, sessionID string, state gateway.SessionState, errMsg string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.states = append(g.states, stateReport{sessionID, state, errMsg})
+	return nil
+}
+
+func (g *stubGatewayCallback) Heartbeat(_ context.Context, sessionID string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.heartbeats = append(g.heartbeats, sessionID)
+	return nil
+}
+
+// startWorkerServer creates a gRPC server, registers the worker service, and
+// starts listening on a random port. Returns the client and a cleanup function.
+func startWorkerServer(t *testing.T, handler grpctransport.WorkerHandler) (*grpctransport.Client, func()) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	gs := grpc.NewServer()
+	ws := grpctransport.NewWorkerServer(handler)
+	ws.Register(gs)
+
+	go func() {
+		if err := gs.Serve(lis); err != nil {
+			// Expected on graceful stop.
+		}
+	}()
+
+	client, err := grpctransport.NewClient(lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		gs.GracefulStop()
+		t.Fatalf("new client: %v", err)
+	}
+
+	return client, func() {
+		client.Close()
+		gs.GracefulStop()
+	}
+}
+
+// startGatewayServer creates a gRPC server with the gateway service and
+// returns a GatewayClient connected to it.
+func startGatewayServer(t *testing.T, callback gateway.GatewayCallback) (*grpctransport.GatewayClient, func()) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	gs := grpc.NewServer()
+	gwSrv := grpctransport.NewGatewayServer(callback)
+	gwSrv.Register(gs)
+
+	go func() {
+		if err := gs.Serve(lis); err != nil {
+			// Expected on graceful stop.
+		}
+	}()
+
+	conn, err := grpc.NewClient(lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		gs.GracefulStop()
+		t.Fatalf("new gateway client: %v", err)
+	}
+
+	gwClient := grpctransport.NewGatewayClient(conn)
+
+	return gwClient, func() {
+		conn.Close()
+		gs.GracefulStop()
+	}
+}
+
+// TestIntegration_GRPCWorkerSessionLifecycle tests the full session lifecycle
+// over a real gRPC connection: start → get status → list NPCs → mute/unmute →
+// speak → stop. Subtests run sequentially because they share the gRPC connection.
+func TestIntegration_GRPCWorkerSessionLifecycle(t *testing.T) {
+	t.Parallel()
+
+	handler := newStubWorkerHandler()
+	client, cleanup := startWorkerServer(t, handler)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	sessionID := "test-session-001"
+	req := gateway.StartSessionRequest{
+		SessionID:   sessionID,
+		TenantID:    "tenant-a",
+		CampaignID:  "campaign-x",
+		GuildID:     "guild-1",
+		ChannelID:   "channel-1",
+		LicenseTier: "dedicated",
+		NPCConfigs: []gateway.NPCConfigMsg{
+			{Name: "Grimjaw", Personality: "A gruff dwarf", Engine: "cascaded", VoiceID: "v1"},
+			{Name: "Elara", Personality: "A wise elf", Engine: "cascaded", VoiceID: "v2"},
+		},
+		BotToken: "test-bot-token",
+	}
+
+	// Sequential subtests — they share the same gRPC connection and handler state.
+	t.Run("start session over gRPC", func(t *testing.T) {
+		err := client.StartSession(ctx, req)
+		if err != nil {
+			t.Fatalf("StartSession: %v", err)
+		}
+
+		handler.mu.Lock()
+		defer handler.mu.Unlock()
+		if len(handler.started) != 1 {
+			t.Fatalf("expected 1 started session, got %d", len(handler.started))
+		}
+		if handler.started[0].SessionID != sessionID {
+			t.Errorf("session ID = %q, want %q", handler.started[0].SessionID, sessionID)
+		}
+		if len(handler.started[0].NPCConfigs) != 2 {
+			t.Errorf("NPC configs = %d, want 2", len(handler.started[0].NPCConfigs))
+		}
+	})
+
+	t.Run("get status returns active session", func(t *testing.T) {
+		statuses, err := client.GetStatus(ctx)
+		if err != nil {
+			t.Fatalf("GetStatus: %v", err)
+		}
+		if len(statuses) == 0 {
+			t.Fatal("expected at least 1 status")
+		}
+		found := false
+		for _, s := range statuses {
+			if s.SessionID == sessionID {
+				found = true
+				if s.State != gateway.SessionActive {
+					t.Errorf("state = %v, want SessionActive", s.State)
+				}
+			}
+		}
+		if !found {
+			t.Error("session not found in status list")
+		}
+	})
+
+	t.Run("list NPCs returns configured NPCs", func(t *testing.T) {
+		npcs, err := client.ListNPCs(ctx, sessionID)
+		if err != nil {
+			t.Fatalf("ListNPCs: %v", err)
+		}
+		if len(npcs) != 2 {
+			t.Fatalf("expected 2 NPCs, got %d", len(npcs))
+		}
+		names := map[string]bool{}
+		for _, n := range npcs {
+			names[n.Name] = true
+		}
+		if !names["Grimjaw"] || !names["Elara"] {
+			t.Errorf("expected Grimjaw and Elara, got %v", names)
+		}
+	})
+
+	t.Run("mute and unmute NPC", func(t *testing.T) {
+		if err := client.MuteNPC(ctx, sessionID, "Grimjaw"); err != nil {
+			t.Fatalf("MuteNPC: %v", err)
+		}
+		if err := client.UnmuteNPC(ctx, sessionID, "Grimjaw"); err != nil {
+			t.Fatalf("UnmuteNPC: %v", err)
+		}
+	})
+
+	t.Run("mute all and unmute all NPCs", func(t *testing.T) {
+		count, err := client.MuteAllNPCs(ctx, sessionID)
+		if err != nil {
+			t.Fatalf("MuteAllNPCs: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("muted count = %d, want 2", count)
+		}
+
+		count, err = client.UnmuteAllNPCs(ctx, sessionID)
+		if err != nil {
+			t.Fatalf("UnmuteAllNPCs: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("unmuted count = %d, want 2", count)
+		}
+	})
+
+	t.Run("speak NPC delivers text", func(t *testing.T) {
+		if err := client.SpeakNPC(ctx, sessionID, "Elara", "Greetings, adventurer!"); err != nil {
+			t.Fatalf("SpeakNPC: %v", err)
+		}
+
+		handler.mu.Lock()
+		defer handler.mu.Unlock()
+		found := false
+		for _, e := range handler.speakLog {
+			if e.SessionID == sessionID && e.NPCName == "Elara" && e.Text == "Greetings, adventurer!" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("speak entry not recorded")
+		}
+	})
+
+	t.Run("stop session", func(t *testing.T) {
+		if err := client.StopSession(ctx, sessionID); err != nil {
+			t.Fatalf("StopSession: %v", err)
+		}
+
+		handler.mu.Lock()
+		defer handler.mu.Unlock()
+		found := false
+		for _, id := range handler.stopped {
+			if id == sessionID {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("session not recorded as stopped")
+		}
+	})
+}
+
+// TestIntegration_GRPCGatewayCallbacks tests worker→gateway callbacks
+// (ReportState and Heartbeat) over a real gRPC connection. Sequential
+// subtests sharing the gRPC connection.
+func TestIntegration_GRPCGatewayCallbacks(t *testing.T) {
+	t.Parallel()
+
+	callback := &stubGatewayCallback{}
+	gwClient, cleanup := startGatewayServer(t, callback)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	sessionID := "test-session-gw-001"
+
+	t.Run("report pending state", func(t *testing.T) {
+		err := gwClient.ReportState(ctx, sessionID, gateway.SessionPending, "")
+		if err != nil {
+			t.Fatalf("ReportState(pending): %v", err)
+		}
+	})
+
+	t.Run("report active state", func(t *testing.T) {
+		err := gwClient.ReportState(ctx, sessionID, gateway.SessionActive, "")
+		if err != nil {
+			t.Fatalf("ReportState(active): %v", err)
+		}
+	})
+
+	t.Run("report ended state with error", func(t *testing.T) {
+		err := gwClient.ReportState(ctx, sessionID, gateway.SessionEnded, "pipeline crashed")
+		if err != nil {
+			t.Fatalf("ReportState(ended): %v", err)
+		}
+	})
+
+	t.Run("heartbeat", func(t *testing.T) {
+		err := gwClient.Heartbeat(ctx, sessionID)
+		if err != nil {
+			t.Fatalf("Heartbeat: %v", err)
+		}
+	})
+
+	// Verify all callbacks were received.
+	callback.mu.Lock()
+	defer callback.mu.Unlock()
+	if len(callback.states) != 3 {
+		t.Errorf("expected 3 state reports, got %d", len(callback.states))
+	}
+	if len(callback.heartbeats) != 1 {
+		t.Errorf("expected 1 heartbeat, got %d", len(callback.heartbeats))
+	}
+}
+
+// TestIntegration_GRPCBidirectionalCommunication tests both directions of
+// communication simultaneously: gateway→worker (WorkerClient) and
+// worker→gateway (GatewayCallback) using two separate gRPC servers.
+func TestIntegration_GRPCBidirectionalCommunication(t *testing.T) {
+	t.Parallel()
+
+	handler := newStubWorkerHandler()
+	callback := &stubGatewayCallback{}
+
+	// Start worker server (gateway→worker).
+	workerClient, cleanupWorker := startWorkerServer(t, handler)
+	t.Cleanup(cleanupWorker)
+
+	// Start gateway server (worker→gateway).
+	gwClient, cleanupGW := startGatewayServer(t, callback)
+	t.Cleanup(cleanupGW)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	sessionID := "bidir-session-001"
+
+	// Gateway starts session on worker.
+	err := workerClient.StartSession(ctx, gateway.StartSessionRequest{
+		SessionID:   sessionID,
+		TenantID:    "tenant-bidir",
+		CampaignID:  "campaign-bidir",
+		GuildID:     "guild-bidir",
+		ChannelID:   "channel-bidir",
+		LicenseTier: "shared",
+		NPCConfigs:  []gateway.NPCConfigMsg{{Name: "TestNPC", Engine: "cascaded"}},
+	})
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	// Worker reports active state to gateway.
+	err = gwClient.ReportState(ctx, sessionID, gateway.SessionActive, "")
+	if err != nil {
+		t.Fatalf("ReportState: %v", err)
+	}
+
+	// Worker sends heartbeats.
+	for range 3 {
+		if err := gwClient.Heartbeat(ctx, sessionID); err != nil {
+			t.Fatalf("Heartbeat: %v", err)
+		}
+	}
+
+	// Gateway stops session.
+	err = workerClient.StopSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("StopSession: %v", err)
+	}
+
+	// Worker reports ended state.
+	err = gwClient.ReportState(ctx, sessionID, gateway.SessionEnded, "")
+	if err != nil {
+		t.Fatalf("ReportState(ended): %v", err)
+	}
+
+	// Verify: worker received the session.
+	handler.mu.Lock()
+	if len(handler.started) != 1 || handler.started[0].SessionID != sessionID {
+		t.Errorf("worker didn't receive expected start request")
+	}
+	if len(handler.stopped) != 1 || handler.stopped[0] != sessionID {
+		t.Errorf("worker didn't receive expected stop request")
+	}
+	handler.mu.Unlock()
+
+	// Verify: gateway received the callbacks.
+	callback.mu.Lock()
+	if len(callback.states) != 2 {
+		t.Errorf("expected 2 state reports, got %d", len(callback.states))
+	}
+	if len(callback.heartbeats) != 3 {
+		t.Errorf("expected 3 heartbeats, got %d", len(callback.heartbeats))
+	}
+	callback.mu.Unlock()
+}
+
+// TestIntegration_GRPCNPCConfigSerialization verifies that NPC configuration
+// fields survive gRPC serialisation/deserialisation intact, including nested
+// fields like KnowledgeScope and BudgetTier.
+func TestIntegration_GRPCNPCConfigSerialization(t *testing.T) {
+	t.Parallel()
+
+	handler := newStubWorkerHandler()
+	client, cleanup := startWorkerServer(t, handler)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	req := gateway.StartSessionRequest{
+		SessionID:   "serialization-test",
+		TenantID:    "tenant-s",
+		CampaignID:  "campaign-s",
+		GuildID:     "guild-s",
+		ChannelID:   "ch-s",
+		LicenseTier: "dedicated",
+		NPCConfigs: []gateway.NPCConfigMsg{
+			{
+				Name:           "Heinrich",
+				Personality:    "A gruff dwarven blacksmith who speaks in short sentences",
+				Engine:         "cascaded",
+				VoiceID:        "voice-abc123",
+				KnowledgeScope: []string{"blacksmithing", "local_gossip", "dwarven_history"},
+				BudgetTier:     "standard",
+				GMHelper:       false,
+				AddressOnly:    true,
+			},
+		},
+		BotToken: "bot-token-xyz",
+	}
+
+	if err := client.StartSession(ctx, req); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+
+	if len(handler.started) != 1 {
+		t.Fatalf("expected 1 started session, got %d", len(handler.started))
+	}
+	got := handler.started[0]
+
+	if got.TenantID != "tenant-s" {
+		t.Errorf("TenantID = %q, want %q", got.TenantID, "tenant-s")
+	}
+	if got.BotToken != "bot-token-xyz" {
+		t.Errorf("BotToken = %q, want %q", got.BotToken, "bot-token-xyz")
+	}
+	if len(got.NPCConfigs) != 1 {
+		t.Fatalf("NPCConfigs = %d, want 1", len(got.NPCConfigs))
+	}
+
+	npc := got.NPCConfigs[0]
+	if npc.Name != "Heinrich" {
+		t.Errorf("NPC Name = %q, want %q", npc.Name, "Heinrich")
+	}
+	if npc.Engine != "cascaded" {
+		t.Errorf("NPC Engine = %q, want %q", npc.Engine, "cascaded")
+	}
+	if npc.VoiceID != "voice-abc123" {
+		t.Errorf("NPC VoiceID = %q, want %q", npc.VoiceID, "voice-abc123")
+	}
+	if len(npc.KnowledgeScope) != 3 {
+		t.Errorf("KnowledgeScope len = %d, want 3", len(npc.KnowledgeScope))
+	}
+	if npc.BudgetTier != "standard" {
+		t.Errorf("BudgetTier = %q, want %q", npc.BudgetTier, "standard")
+	}
+	if npc.AddressOnly != true {
+		t.Error("AddressOnly should be true")
+	}
+}
+
+// TestIntegration_GRPCProtobufStateConversion verifies the protobuf
+// SessionState enum round-trips correctly through gRPC for all valid states.
+func TestIntegration_GRPCProtobufStateConversion(t *testing.T) {
+	t.Parallel()
+
+	callback := &stubGatewayCallback{}
+	gwClient, cleanup := startGatewayServer(t, callback)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	states := []gateway.SessionState{
+		gateway.SessionPending,
+		gateway.SessionActive,
+		gateway.SessionEnded,
+	}
+
+	for _, state := range states {
+		sid := fmt.Sprintf("state-test-%s", state)
+		err := gwClient.ReportState(ctx, sid, state, "")
+		if err != nil {
+			t.Fatalf("ReportState(%v): %v", state, err)
+		}
+	}
+
+	callback.mu.Lock()
+	defer callback.mu.Unlock()
+
+	if len(callback.states) != 3 {
+		t.Fatalf("expected 3 state reports, got %d", len(callback.states))
+	}
+
+	for i, want := range states {
+		got := callback.states[i]
+		if got.State != want {
+			t.Errorf("state[%d] = %v, want %v", i, got.State, want)
+		}
+	}
+}
+
+// Ensure stubWorkerHandler implements WorkerHandler at compile time.
+var _ grpctransport.WorkerHandler = (*stubWorkerHandler)(nil)
+
+// Ensure we can check that the generated gRPC interface is present.
+var _ pb.SessionWorkerServiceServer = (*grpctransport.WorkerServer)(nil)

--- a/internal/gateway/sessionorch/integration_test.go
+++ b/internal/gateway/sessionorch/integration_test.go
@@ -1,0 +1,253 @@
+//go:build integration
+
+package sessionorch_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/glyphoxa/internal/config"
+	"github.com/MrWong99/glyphoxa/internal/gateway"
+	"github.com/MrWong99/glyphoxa/internal/gateway/sessionorch"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// testDSN reads the PostgreSQL DSN for integration tests.
+func testDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("GLYPHOXA_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("GLYPHOXA_TEST_POSTGRES_DSN not set; skipping integration test")
+	}
+	return dsn
+}
+
+// setupOrchestrator creates a PostgresOrchestrator connected to the test DB.
+func setupOrchestrator(t *testing.T) *sessionorch.PostgresOrchestrator {
+	t.Helper()
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, testDSN(t))
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	orch, err := sessionorch.NewPostgresOrchestrator(ctx, pool)
+	if err != nil {
+		t.Fatalf("NewPostgresOrchestrator: %v", err)
+	}
+	return orch
+}
+
+// TestIntegration_SessionOrchestrator_Lifecycle tests the full session
+// lifecycle through the PostgreSQL orchestrator: create → transition →
+// heartbeat → query → cleanup.
+func TestIntegration_SessionOrchestrator_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	orch := setupOrchestrator(t)
+	ctx := context.Background()
+
+	t.Run("create and get session", func(t *testing.T) {
+		t.Parallel()
+		orch := setupOrchestrator(t)
+
+		sessionID, err := orch.ValidateAndCreate(ctx, sessionorch.SessionRequest{
+			TenantID:    "test-lifecycle",
+			CampaignID:  "campaign-lc-" + time.Now().Format("150405.000"),
+			GuildID:     "guild-lc",
+			ChannelID:   "channel-lc",
+			LicenseTier: config.TierDedicated,
+		})
+		if err != nil {
+			t.Fatalf("ValidateAndCreate: %v", err)
+		}
+		if sessionID == "" {
+			t.Fatal("empty session ID")
+		}
+
+		session, err := orch.GetSession(ctx, sessionID)
+		if err != nil {
+			t.Fatalf("GetSession: %v", err)
+		}
+		if session.State != gateway.SessionPending {
+			t.Errorf("state = %v, want pending", session.State)
+		}
+		if session.TenantID != "test-lifecycle" {
+			t.Errorf("tenant = %q, want test-lifecycle", session.TenantID)
+		}
+	})
+
+	t.Run("transition pending to active to ended", func(t *testing.T) {
+		t.Parallel()
+		orch := setupOrchestrator(t)
+
+		sessionID, err := orch.ValidateAndCreate(ctx, sessionorch.SessionRequest{
+			TenantID:    "test-transition",
+			CampaignID:  "campaign-tr-" + time.Now().Format("150405.000"),
+			GuildID:     "guild-tr",
+			ChannelID:   "channel-tr",
+			LicenseTier: config.TierDedicated,
+		})
+		if err != nil {
+			t.Fatalf("ValidateAndCreate: %v", err)
+		}
+
+		// Transition to active.
+		if err := orch.Transition(ctx, sessionID, gateway.SessionActive, ""); err != nil {
+			t.Fatalf("Transition(active): %v", err)
+		}
+
+		session, _ := orch.GetSession(ctx, sessionID)
+		if session.State != gateway.SessionActive {
+			t.Errorf("state = %v, want active", session.State)
+		}
+
+		// Transition to ended.
+		if err := orch.Transition(ctx, sessionID, gateway.SessionEnded, "session complete"); err != nil {
+			t.Fatalf("Transition(ended): %v", err)
+		}
+
+		session, _ = orch.GetSession(ctx, sessionID)
+		if session.State != gateway.SessionEnded {
+			t.Errorf("state = %v, want ended", session.State)
+		}
+		if session.Error != "session complete" {
+			t.Errorf("error = %q, want 'session complete'", session.Error)
+		}
+		if session.EndedAt == nil {
+			t.Error("ended_at should be set")
+		}
+	})
+
+	t.Run("heartbeat updates timestamp", func(t *testing.T) {
+		t.Parallel()
+		orch := setupOrchestrator(t)
+
+		sessionID, err := orch.ValidateAndCreate(ctx, sessionorch.SessionRequest{
+			TenantID:    "test-heartbeat",
+			CampaignID:  "campaign-hb-" + time.Now().Format("150405.000"),
+			GuildID:     "guild-hb",
+			ChannelID:   "channel-hb",
+			LicenseTier: config.TierDedicated,
+		})
+		if err != nil {
+			t.Fatalf("ValidateAndCreate: %v", err)
+		}
+
+		if err := orch.Transition(ctx, sessionID, gateway.SessionActive, ""); err != nil {
+			t.Fatalf("Transition(active): %v", err)
+		}
+
+		if err := orch.RecordHeartbeat(ctx, sessionID); err != nil {
+			t.Fatalf("RecordHeartbeat: %v", err)
+		}
+
+		session, _ := orch.GetSession(ctx, sessionID)
+		if session.LastHeartbeat == nil {
+			t.Error("last_heartbeat should be set after heartbeat")
+		}
+	})
+
+	t.Run("active sessions query", func(t *testing.T) {
+		t.Parallel()
+		orch := setupOrchestrator(t)
+		tenantID := "test-active-query"
+
+		sessionID, _ := orch.ValidateAndCreate(ctx, sessionorch.SessionRequest{
+			TenantID:    tenantID,
+			CampaignID:  "campaign-aq-" + time.Now().Format("150405.000"),
+			GuildID:     "guild-aq",
+			ChannelID:   "channel-aq",
+			LicenseTier: config.TierDedicated,
+		})
+		orch.Transition(ctx, sessionID, gateway.SessionActive, "")
+
+		sessions, err := orch.ActiveSessions(ctx, tenantID)
+		if err != nil {
+			t.Fatalf("ActiveSessions: %v", err)
+		}
+		if len(sessions) == 0 {
+			t.Error("expected at least 1 active session")
+		}
+
+		found := false
+		for _, s := range sessions {
+			if s.ID == sessionID {
+				found = true
+				if s.State != gateway.SessionActive {
+					t.Errorf("state = %v, want active", s.State)
+				}
+			}
+		}
+		if !found {
+			t.Error("created session not found in active list")
+		}
+	})
+
+	t.Run("all non-ended sessions", func(t *testing.T) {
+		t.Parallel()
+		_ = orch
+
+		sessions, err := setupOrchestrator(t).AllNonEndedSessions(ctx)
+		if err != nil {
+			t.Fatalf("AllNonEndedSessions: %v", err)
+		}
+		// Just verify it doesn't error — count depends on other test state.
+		_ = sessions
+	})
+
+	t.Run("cleanup stale pending", func(t *testing.T) {
+		t.Parallel()
+		orch := setupOrchestrator(t)
+
+		// Create a session and leave it pending.
+		_, _ = orch.ValidateAndCreate(ctx, sessionorch.SessionRequest{
+			TenantID:    "test-stale",
+			CampaignID:  "campaign-stale-" + time.Now().Format("150405.000"),
+			GuildID:     "guild-stale",
+			ChannelID:   "channel-stale",
+			LicenseTier: config.TierDedicated,
+		})
+
+		// Cleanup with a very long maxAge — should not clean anything.
+		count, err := orch.CleanupStalePending(ctx, 24*time.Hour)
+		if err != nil {
+			t.Fatalf("CleanupStalePending: %v", err)
+		}
+		// We can't assert count == 0 because other tests might have stale sessions.
+		_ = count
+	})
+
+	t.Run("cleanup zombies", func(t *testing.T) {
+		t.Parallel()
+		orch := setupOrchestrator(t)
+
+		// Create a session with a heartbeat and make it active.
+		sessionID, _ := orch.ValidateAndCreate(ctx, sessionorch.SessionRequest{
+			TenantID:    "test-zombie",
+			CampaignID:  "campaign-zombie-" + time.Now().Format("150405.000"),
+			GuildID:     "guild-zombie",
+			ChannelID:   "channel-zombie",
+			LicenseTier: config.TierDedicated,
+		})
+		orch.Transition(ctx, sessionID, gateway.SessionActive, "")
+		orch.RecordHeartbeat(ctx, sessionID)
+
+		// Cleanup with a very long timeout — should not clean our session.
+		count, err := orch.CleanupZombies(ctx, 24*time.Hour)
+		if err != nil {
+			t.Fatalf("CleanupZombies: %v", err)
+		}
+		_ = count
+
+		// Verify our session is still active.
+		session, _ := orch.GetSession(ctx, sessionID)
+		if session.State != gateway.SessionActive {
+			t.Errorf("session should still be active, got %v", session.State)
+		}
+	})
+}

--- a/internal/health/integration_test.go
+++ b/internal/health/integration_test.go
@@ -1,0 +1,249 @@
+//go:build integration
+
+package health_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MrWong99/glyphoxa/internal/health"
+)
+
+// TestIntegration_HealthEndpoints tests the /healthz and /readyz endpoints
+// with various checker configurations.
+func TestIntegration_HealthEndpoints(t *testing.T) {
+	t.Parallel()
+
+	t.Run("healthz always returns 200", func(t *testing.T) {
+		t.Parallel()
+
+		h := health.New() // No checkers.
+		mux := http.NewServeMux()
+		h.Register(mux)
+
+		req := httptest.NewRequest("GET", "/healthz", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rec.Code)
+		}
+
+		var result map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if result["status"] != "ok" {
+			t.Errorf("status = %v, want ok", result["status"])
+		}
+	})
+
+	t.Run("readyz with all healthy checkers returns 200", func(t *testing.T) {
+		t.Parallel()
+
+		h := health.New(
+			health.Checker{
+				Name: "database",
+				Check: func(ctx context.Context) error {
+					return nil // Healthy.
+				},
+			},
+			health.Checker{
+				Name: "cache",
+				Check: func(ctx context.Context) error {
+					return nil // Healthy.
+				},
+			},
+		)
+		mux := http.NewServeMux()
+		h.Register(mux)
+
+		req := httptest.NewRequest("GET", "/readyz", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rec.Code)
+		}
+
+		var result map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if result["status"] != "ok" {
+			t.Errorf("status = %v, want ok", result["status"])
+		}
+
+		checks, ok := result["checks"].(map[string]any)
+		if !ok {
+			t.Fatal("missing checks in response")
+		}
+		if checks["database"] != "ok" {
+			t.Errorf("database = %v, want ok", checks["database"])
+		}
+		if checks["cache"] != "ok" {
+			t.Errorf("cache = %v, want ok", checks["cache"])
+		}
+	})
+
+	t.Run("readyz with failing checker returns 503", func(t *testing.T) {
+		t.Parallel()
+
+		h := health.New(
+			health.Checker{
+				Name: "database",
+				Check: func(ctx context.Context) error {
+					return nil
+				},
+			},
+			health.Checker{
+				Name: "redis",
+				Check: func(ctx context.Context) error {
+					return errors.New("connection refused")
+				},
+			},
+		)
+		mux := http.NewServeMux()
+		h.Register(mux)
+
+		req := httptest.NewRequest("GET", "/readyz", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503", rec.Code)
+		}
+
+		var result map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if result["status"] != "fail" {
+			t.Errorf("status = %v, want fail", result["status"])
+		}
+
+		checks, ok := result["checks"].(map[string]any)
+		if !ok {
+			t.Fatal("missing checks")
+		}
+		if checks["database"] != "ok" {
+			t.Errorf("database = %v, want ok", checks["database"])
+		}
+
+		redis, ok := checks["redis"].(string)
+		if !ok {
+			t.Fatal("redis check not a string")
+		}
+		if redis != "fail: connection refused" {
+			t.Errorf("redis = %q, want 'fail: connection refused'", redis)
+		}
+	})
+
+	t.Run("readyz with no checkers returns 200", func(t *testing.T) {
+		t.Parallel()
+
+		h := health.New()
+		mux := http.NewServeMux()
+		h.Register(mux)
+
+		req := httptest.NewRequest("GET", "/readyz", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rec.Code)
+		}
+	})
+
+	t.Run("readyz checks respect context cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		h := health.New(
+			health.Checker{
+				Name: "slow",
+				Check: func(ctx context.Context) error {
+					<-ctx.Done()
+					return ctx.Err()
+				},
+			},
+		)
+		mux := http.NewServeMux()
+		h.Register(mux)
+
+		// The handler uses a 5s timeout. We use a request with a shorter
+		// context to verify the checker respects cancellation.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately.
+
+		req := httptest.NewRequest("GET", "/readyz", nil).WithContext(ctx)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		// The checker will fail because the context was cancelled.
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503", rec.Code)
+		}
+	})
+
+	t.Run("response has correct content type", func(t *testing.T) {
+		t.Parallel()
+
+		h := health.New()
+		mux := http.NewServeMux()
+		h.Register(mux)
+
+		req := httptest.NewRequest("GET", "/healthz", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		ct := rec.Header().Get("Content-Type")
+		if ct != "application/json; charset=utf-8" {
+			t.Errorf("Content-Type = %q, want application/json; charset=utf-8", ct)
+		}
+	})
+}
+
+// TestIntegration_HealthWithRealDatabaseChecker simulates what happens in
+// production: the health handler includes a database ping checker.
+func TestIntegration_HealthWithRealDatabaseChecker(t *testing.T) {
+	t.Parallel()
+
+	// This test simulates a database checker using a mock function.
+	// The real database integration is covered in the web integration test.
+	dbHealthy := true
+
+	h := health.New(
+		health.Checker{
+			Name: "database",
+			Check: func(ctx context.Context) error {
+				if !dbHealthy {
+					return errors.New("database unreachable")
+				}
+				return nil
+			},
+		},
+		health.Checker{
+			Name: "providers",
+			Check: func(ctx context.Context) error {
+				return nil
+			},
+		},
+	)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	t.Run("all healthy", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest("GET", "/readyz", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rec.Code)
+		}
+	})
+}

--- a/internal/web/integration_test.go
+++ b/internal/web/integration_test.go
@@ -1,0 +1,857 @@
+//go:build integration
+
+package web_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/glyphoxa/internal/agent/npcstore"
+	"github.com/MrWong99/glyphoxa/internal/web"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// testDSN reads the PostgreSQL DSN for integration tests.
+// Tests are skipped when the env var is not set.
+func testDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("GLYPHOXA_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("GLYPHOXA_TEST_POSTGRES_DSN not set; skipping integration test")
+	}
+	return dsn
+}
+
+// sharedStore is initialized once per test binary to avoid concurrent
+// migration races on CREATE SCHEMA.
+var (
+	sharedStore     *web.Store
+	sharedPool      *pgxpool.Pool
+	sharedStoreOnce sync.Once
+	sharedStoreErr  error
+)
+
+// setupTestDB returns the shared pgxpool and web.Store. Migrations run
+// exactly once. The pool outlives individual tests (closed at process exit).
+func setupTestDB(t *testing.T) (*web.Store, *pgxpool.Pool) {
+	t.Helper()
+	testDSN(t) // skip if DSN not set
+
+	sharedStoreOnce.Do(func() {
+		ctx := context.Background()
+		dsn := os.Getenv("GLYPHOXA_TEST_POSTGRES_DSN")
+		sharedPool, sharedStoreErr = pgxpool.New(ctx, dsn)
+		if sharedStoreErr != nil {
+			return
+		}
+		sharedStore, sharedStoreErr = web.NewStore(ctx, sharedPool)
+	})
+	if sharedStoreErr != nil {
+		t.Fatalf("shared store init: %v", sharedStoreErr)
+	}
+	return sharedStore, sharedPool
+}
+
+// jwtSecret is the test secret for JWT signing (≥32 chars).
+const jwtSecret = "integration-test-jwt-secret-32ch"
+
+// testAdminKey is the admin API key for test auth.
+const testAdminKey = "test-admin-key-for-integration"
+
+// mockNPCStore is a minimal in-memory npcstore.Store for the web server.
+type mockNPCStore struct {
+	npcs map[string]*npcstore.NPCDefinition
+}
+
+var _ npcstore.Store = (*mockNPCStore)(nil)
+
+func newMockNPCStore() *mockNPCStore {
+	return &mockNPCStore{npcs: make(map[string]*npcstore.NPCDefinition)}
+}
+
+func (m *mockNPCStore) Create(_ context.Context, def *npcstore.NPCDefinition) error {
+	if def.ID == "" {
+		def.ID = "npc-" + def.Name
+	}
+	now := time.Now().UTC()
+	def.CreatedAt = now
+	def.UpdatedAt = now
+	m.npcs[def.ID] = def
+	return nil
+}
+
+func (m *mockNPCStore) Get(_ context.Context, id string) (*npcstore.NPCDefinition, error) {
+	def, ok := m.npcs[id]
+	if !ok {
+		return nil, nil
+	}
+	return def, nil
+}
+
+func (m *mockNPCStore) Update(_ context.Context, def *npcstore.NPCDefinition) error {
+	if _, ok := m.npcs[def.ID]; !ok {
+		return nil
+	}
+	def.UpdatedAt = time.Now().UTC()
+	m.npcs[def.ID] = def
+	return nil
+}
+
+func (m *mockNPCStore) Delete(_ context.Context, id string) error {
+	delete(m.npcs, id)
+	return nil
+}
+
+func (m *mockNPCStore) List(_ context.Context, campaignID string) ([]npcstore.NPCDefinition, error) {
+	var result []npcstore.NPCDefinition
+	for _, def := range m.npcs {
+		if campaignID == "" || def.CampaignID == campaignID {
+			result = append(result, *def)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockNPCStore) Upsert(_ context.Context, def *npcstore.NPCDefinition) error {
+	return m.Create(context.Background(), def)
+}
+
+// setupTestServer creates a full web.Server backed by a real PostgreSQL store.
+// Returns the httptest server and a cleanup function.
+func setupTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	store, _ := setupTestDB(t)
+
+	cfg := &web.Config{
+		DatabaseDSN: testDSN(t),
+		JWTSecret:   jwtSecret,
+		AdminAPIKey: testAdminKey,
+		ListenAddr:  ":0",
+	}
+
+	srv := web.NewServer(cfg, store, newMockNPCStore(), nil)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// authenticateAdmin logs in with the admin API key and returns a valid JWT.
+func authenticateAdmin(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+
+	body := `{"api_key":"` + testAdminKey + `"}`
+	resp, err := http.Post(ts.URL+"/api/v1/auth/apikey", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("POST /api/v1/auth/apikey: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apikey login: status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Data struct {
+			AccessToken string `json:"access_token"`
+			User        struct {
+				ID       string `json:"id"`
+				Role     string `json:"role"`
+				TenantID string `json:"tenant_id"`
+			} `json:"user"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode apikey response: %v", err)
+	}
+	if result.Data.AccessToken == "" {
+		t.Fatal("empty access token from apikey login")
+	}
+	return result.Data.AccessToken
+}
+
+// doRequest performs an authenticated HTTP request and returns the response.
+func doRequest(t *testing.T, method, url, token string, body any) *http.Response {
+	t.Helper()
+
+	var bodyReader *bytes.Buffer
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		bodyReader = bytes.NewBuffer(data)
+	} else {
+		bodyReader = &bytes.Buffer{}
+	}
+
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	return resp
+}
+
+// ---------- Auth Flow Integration Tests ----------
+
+// TestIntegration_APIKeyAuth verifies the API key login flow against a real
+// PostgreSQL database, including user creation and JWT issuance.
+func TestIntegration_APIKeyAuth(t *testing.T) {
+	t.Parallel()
+	ts := setupTestServer(t)
+
+	t.Run("valid API key returns JWT and user", func(t *testing.T) {
+		t.Parallel()
+
+		body := `{"api_key":"` + testAdminKey + `"}`
+		resp, err := http.Post(ts.URL+"/api/v1/auth/apikey", "application/json", bytes.NewBufferString(body))
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+
+		var result map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		data, ok := result["data"].(map[string]any)
+		if !ok {
+			t.Fatal("missing data in response")
+		}
+		if data["access_token"] == nil || data["access_token"] == "" {
+			t.Error("missing access_token")
+		}
+		if data["token_type"] != "Bearer" {
+			t.Errorf("token_type = %v, want Bearer", data["token_type"])
+		}
+
+		user, ok := data["user"].(map[string]any)
+		if !ok {
+			t.Fatal("missing user in response")
+		}
+		if user["role"] != "super_admin" {
+			t.Errorf("role = %v, want super_admin", user["role"])
+		}
+	})
+
+	t.Run("invalid API key returns 401", func(t *testing.T) {
+		t.Parallel()
+
+		body := `{"api_key":"wrong-key"}`
+		resp, err := http.Post(ts.URL+"/api/v1/auth/apikey", "application/json", bytes.NewBufferString(body))
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+
+	t.Run("missing API key in body returns 400", func(t *testing.T) {
+		t.Parallel()
+
+		body := `{}`
+		resp, err := http.Post(ts.URL+"/api/v1/auth/apikey", "application/json", bytes.NewBufferString(body))
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", resp.StatusCode)
+		}
+	})
+}
+
+// TestIntegration_JWTAuthMiddleware verifies JWT authentication middleware
+// against a real database, testing token verification and protected routes.
+func TestIntegration_JWTAuthMiddleware(t *testing.T) {
+	t.Parallel()
+	ts := setupTestServer(t)
+
+	t.Run("authenticated request to /auth/me succeeds", func(t *testing.T) {
+		t.Parallel()
+		token := authenticateAdmin(t, ts)
+
+		resp := doRequest(t, "GET", ts.URL+"/api/v1/auth/me", token, nil)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+
+		var result map[string]any
+		json.NewDecoder(resp.Body).Decode(&result)
+		data, _ := result["data"].(map[string]any)
+		if data == nil {
+			t.Fatal("missing data in /me response")
+		}
+		if data["role"] != "super_admin" {
+			t.Errorf("role = %v, want super_admin", data["role"])
+		}
+	})
+
+	t.Run("unauthenticated request returns 401", func(t *testing.T) {
+		t.Parallel()
+
+		resp := doRequest(t, "GET", ts.URL+"/api/v1/auth/me", "", nil)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+
+	t.Run("invalid token returns 401", func(t *testing.T) {
+		t.Parallel()
+
+		resp := doRequest(t, "GET", ts.URL+"/api/v1/auth/me", "invalid.token.here", nil)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+
+	t.Run("expired token returns 401", func(t *testing.T) {
+		t.Parallel()
+
+		expiredToken, err := web.SignJWT(jwtSecret, web.Claims{
+			Sub:      "test-user",
+			TenantID: "test-tenant",
+			Role:     "dm",
+			Expires:  time.Now().Add(-1 * time.Hour).Unix(),
+		})
+		if err != nil {
+			t.Fatalf("sign expired JWT: %v", err)
+		}
+
+		resp := doRequest(t, "GET", ts.URL+"/api/v1/auth/me", expiredToken, nil)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+}
+
+// TestIntegration_TokenRefresh verifies that token refresh works against a
+// real database, returning updated user info.
+func TestIntegration_TokenRefresh(t *testing.T) {
+	t.Parallel()
+	ts := setupTestServer(t)
+
+	token := authenticateAdmin(t, ts)
+	resp := doRequest(t, "POST", ts.URL+"/api/v1/auth/refresh", token, nil)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+	data, _ := result["data"].(map[string]any)
+	if data == nil || data["access_token"] == nil {
+		t.Fatal("missing access_token in refresh response")
+	}
+}
+
+// ---------- Campaign/NPC/Session Lifecycle Integration Tests ----------
+
+// TestIntegration_CampaignLifecycle tests creating, listing, updating, and
+// deleting campaigns through the API with a real PostgreSQL backend.
+func TestIntegration_CampaignLifecycle(t *testing.T) {
+	t.Parallel()
+	ts := setupTestServer(t)
+	token := authenticateAdmin(t, ts)
+
+	var campaignID string
+
+	t.Run("create campaign", func(t *testing.T) {
+		body := map[string]any{
+			"name":        "Curse of Strahd",
+			"game_system": "dnd5e",
+			"language":    "en",
+			"description": "A gothic horror campaign in Barovia",
+		}
+		resp := doRequest(t, "POST", ts.URL+"/api/v1/campaigns", token, body)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusCreated {
+			var errBody json.RawMessage
+			json.NewDecoder(resp.Body).Decode(&errBody)
+			t.Fatalf("create campaign: status %d, body: %s", resp.StatusCode, errBody)
+		}
+
+		var result map[string]any
+		json.NewDecoder(resp.Body).Decode(&result)
+		data, _ := result["data"].(map[string]any)
+		if data == nil {
+			t.Fatal("missing data in create response")
+		}
+		id, ok := data["id"].(string)
+		if !ok || id == "" {
+			t.Fatal("missing campaign ID")
+		}
+		campaignID = id
+	})
+
+	t.Run("get campaign", func(t *testing.T) {
+		if campaignID == "" {
+			t.Skip("no campaign created")
+		}
+
+		resp := doRequest(t, "GET", ts.URL+"/api/v1/campaigns/"+campaignID, token, nil)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("get campaign: status %d", resp.StatusCode)
+		}
+
+		var result map[string]any
+		json.NewDecoder(resp.Body).Decode(&result)
+		data, _ := result["data"].(map[string]any)
+		if data == nil {
+			t.Fatal("missing data in get response")
+		}
+		if data["name"] != "Curse of Strahd" {
+			t.Errorf("name = %v, want 'Curse of Strahd'", data["name"])
+		}
+	})
+
+	t.Run("list campaigns", func(t *testing.T) {
+		resp := doRequest(t, "GET", ts.URL+"/api/v1/campaigns", token, nil)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("list campaigns: status %d", resp.StatusCode)
+		}
+
+		var result map[string]any
+		json.NewDecoder(resp.Body).Decode(&result)
+		data, ok := result["data"].([]any)
+		if !ok {
+			t.Fatal("data is not an array")
+		}
+		if len(data) == 0 {
+			t.Error("expected at least 1 campaign")
+		}
+	})
+
+	t.Run("update campaign", func(t *testing.T) {
+		if campaignID == "" {
+			t.Skip("no campaign created")
+		}
+
+		body := map[string]any{
+			"name":        "Curse of Strahd (Updated)",
+			"game_system": "dnd5e",
+			"description": "Updated description",
+		}
+		resp := doRequest(t, "PUT", ts.URL+"/api/v1/campaigns/"+campaignID, token, body)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("update campaign: status %d", resp.StatusCode)
+		}
+
+		// Verify update.
+		resp2 := doRequest(t, "GET", ts.URL+"/api/v1/campaigns/"+campaignID, token, nil)
+		defer resp2.Body.Close()
+
+		var result map[string]any
+		json.NewDecoder(resp2.Body).Decode(&result)
+		data, _ := result["data"].(map[string]any)
+		if data["name"] != "Curse of Strahd (Updated)" {
+			t.Errorf("name after update = %v", data["name"])
+		}
+	})
+
+	t.Run("delete campaign", func(t *testing.T) {
+		if campaignID == "" {
+			t.Skip("no campaign created")
+		}
+
+		resp := doRequest(t, "DELETE", ts.URL+"/api/v1/campaigns/"+campaignID, token, nil)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("delete campaign: status %d", resp.StatusCode)
+		}
+
+		// Verify it's gone (or soft-deleted).
+		resp2 := doRequest(t, "GET", ts.URL+"/api/v1/campaigns/"+campaignID, token, nil)
+		defer resp2.Body.Close()
+
+		if resp2.StatusCode != http.StatusNotFound {
+			t.Errorf("get after delete: status %d, want 404", resp2.StatusCode)
+		}
+	})
+}
+
+// TestIntegration_LoreDocumentLifecycle tests CRUD operations for lore
+// documents through the API with a real PostgreSQL backend.
+func TestIntegration_LoreDocumentLifecycle(t *testing.T) {
+	t.Parallel()
+	ts := setupTestServer(t)
+	token := authenticateAdmin(t, ts)
+
+	// Create a campaign first.
+	campaignBody := map[string]any{"name": "Lore Test Campaign", "game_system": "pf2e"}
+	resp := doRequest(t, "POST", ts.URL+"/api/v1/campaigns", token, campaignBody)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create campaign: status %d", resp.StatusCode)
+	}
+
+	var campaignResult map[string]any
+	json.NewDecoder(resp.Body).Decode(&campaignResult)
+	campaignData, _ := campaignResult["data"].(map[string]any)
+	campaignID, _ := campaignData["id"].(string)
+	if campaignID == "" {
+		t.Fatal("missing campaign ID")
+	}
+
+	var loreID string
+
+	t.Run("create lore document", func(t *testing.T) {
+		body := map[string]any{
+			"title":            "The History of Barovia",
+			"content_markdown": "# Barovia\n\nBarovia is a land of darkness...",
+			"sort_order":       1,
+		}
+		resp := doRequest(t, "POST", fmt.Sprintf("%s/api/v1/campaigns/%s/lore", ts.URL, campaignID), token, body)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusCreated {
+			var errBody json.RawMessage
+			json.NewDecoder(resp.Body).Decode(&errBody)
+			t.Fatalf("create lore: status %d, body: %s", resp.StatusCode, errBody)
+		}
+
+		var result map[string]any
+		json.NewDecoder(resp.Body).Decode(&result)
+		data, _ := result["data"].(map[string]any)
+		if id, ok := data["id"].(string); ok {
+			loreID = id
+		}
+	})
+
+	t.Run("list lore documents", func(t *testing.T) {
+		resp := doRequest(t, "GET", fmt.Sprintf("%s/api/v1/campaigns/%s/lore", ts.URL, campaignID), token, nil)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("list lore: status %d", resp.StatusCode)
+		}
+
+		var result map[string]any
+		json.NewDecoder(resp.Body).Decode(&result)
+		data, ok := result["data"].([]any)
+		if !ok || len(data) == 0 {
+			t.Error("expected at least 1 lore document")
+		}
+	})
+
+	t.Run("update and get lore document", func(t *testing.T) {
+		if loreID == "" {
+			t.Skip("no lore document created")
+		}
+
+		body := map[string]any{
+			"title":            "The Complete History of Barovia",
+			"content_markdown": "# Barovia (Updated)\n\nMore details...",
+			"sort_order":       2,
+		}
+		resp := doRequest(t, "PUT", fmt.Sprintf("%s/api/v1/campaigns/%s/lore/%s", ts.URL, campaignID, loreID), token, body)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("update lore: status %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("delete lore document", func(t *testing.T) {
+		if loreID == "" {
+			t.Skip("no lore document created")
+		}
+
+		resp := doRequest(t, "DELETE", fmt.Sprintf("%s/api/v1/campaigns/%s/lore/%s", ts.URL, campaignID, loreID), token, nil)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("delete lore: status %d", resp.StatusCode)
+		}
+	})
+}
+
+// TestIntegration_RoleBasedAccessControl verifies that role-based access
+// control works correctly with real database users.
+func TestIntegration_RoleBasedAccessControl(t *testing.T) {
+	t.Parallel()
+	ts := setupTestServer(t)
+
+	t.Run("viewer cannot create campaigns", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a viewer-level JWT.
+		viewerToken, err := web.SignJWT(jwtSecret, web.Claims{
+			Sub:      "viewer-user-id",
+			TenantID: "test-tenant",
+			Role:     "viewer",
+		})
+		if err != nil {
+			t.Fatalf("sign viewer JWT: %v", err)
+		}
+
+		body := map[string]any{"name": "Forbidden Campaign"}
+		resp := doRequest(t, "POST", ts.URL+"/api/v1/campaigns", viewerToken, body)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", resp.StatusCode)
+		}
+	})
+
+	t.Run("dm can create campaigns", func(t *testing.T) {
+		t.Parallel()
+
+		// Use admin token (super_admin ≥ dm).
+		token := authenticateAdmin(t, ts)
+
+		body := map[string]any{"name": "DM Campaign", "game_system": "dnd5e"}
+		resp := doRequest(t, "POST", ts.URL+"/api/v1/campaigns", token, body)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusCreated {
+			t.Errorf("status = %d, want 201", resp.StatusCode)
+		}
+	})
+
+	t.Run("viewer cannot access users list", func(t *testing.T) {
+		t.Parallel()
+
+		viewerToken, _ := web.SignJWT(jwtSecret, web.Claims{
+			Sub:      "viewer-user-id",
+			TenantID: "test-tenant",
+			Role:     "viewer",
+		})
+
+		resp := doRequest(t, "GET", ts.URL+"/api/v1/users", viewerToken, nil)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", resp.StatusCode)
+		}
+	})
+}
+
+// TestIntegration_WebStoreDirectOperations tests the WebStore implementation
+// directly against PostgreSQL to verify SQL correctness.
+func TestIntegration_WebStoreDirectOperations(t *testing.T) {
+	t.Parallel()
+	store, _ := setupTestDB(t)
+
+	ctx := context.Background()
+
+	t.Run("ping", func(t *testing.T) {
+		t.Parallel()
+		if err := store.Ping(ctx); err != nil {
+			t.Fatalf("Ping: %v", err)
+		}
+	})
+
+	t.Run("ensure admin user idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		user1, err := store.EnsureAdminUser(ctx, "test-direct")
+		if err != nil {
+			t.Fatalf("EnsureAdminUser (first): %v", err)
+		}
+		if user1.Role != "super_admin" {
+			t.Errorf("role = %q, want super_admin", user1.Role)
+		}
+
+		// Second call should succeed without duplicate key error.
+		user2, err := store.EnsureAdminUser(ctx, "test-direct")
+		if err != nil {
+			t.Fatalf("EnsureAdminUser (second): %v", err)
+		}
+		if user1.ID != user2.ID {
+			t.Errorf("IDs differ: %q vs %q", user1.ID, user2.ID)
+		}
+	})
+
+	t.Run("upsert discord user", func(t *testing.T) {
+		t.Parallel()
+
+		discordID := fmt.Sprintf("discord-%d", time.Now().UnixNano())
+		user, err := store.UpsertDiscordUser(ctx, discordID, "test@example.com", "TestUser", "", "tenant-upsert")
+		if err != nil {
+			t.Fatalf("UpsertDiscordUser: %v", err)
+		}
+		if user.DisplayName != "TestUser" {
+			t.Errorf("DisplayName = %q, want TestUser", user.DisplayName)
+		}
+
+		// Update the display name.
+		user2, err := store.UpsertDiscordUser(ctx, discordID, "test@example.com", "UpdatedUser", "", "tenant-upsert")
+		if err != nil {
+			t.Fatalf("UpsertDiscordUser (update): %v", err)
+		}
+		if user2.DisplayName != "UpdatedUser" {
+			t.Errorf("DisplayName after update = %q, want UpdatedUser", user2.DisplayName)
+		}
+		if user.ID != user2.ID {
+			t.Errorf("user IDs differ on upsert: %q vs %q", user.ID, user2.ID)
+		}
+	})
+
+	t.Run("campaign CRUD", func(t *testing.T) {
+		t.Parallel()
+
+		campaign := &web.Campaign{
+			TenantID:    "tenant-campaign-crud",
+			Name:        "Test Campaign",
+			System:      "dnd5e",
+			Description: "A test campaign",
+		}
+		if err := store.CreateCampaign(ctx, campaign); err != nil {
+			t.Fatalf("CreateCampaign: %v", err)
+		}
+		if campaign.ID == "" {
+			t.Fatal("campaign ID not set after create")
+		}
+
+		got, err := store.GetCampaign(ctx, campaign.TenantID, campaign.ID)
+		if err != nil {
+			t.Fatalf("GetCampaign: %v", err)
+		}
+		if got.Name != "Test Campaign" {
+			t.Errorf("Name = %q, want 'Test Campaign'", got.Name)
+		}
+
+		campaign.Name = "Updated Campaign"
+		if err := store.UpdateCampaign(ctx, campaign); err != nil {
+			t.Fatalf("UpdateCampaign: %v", err)
+		}
+
+		got2, _ := store.GetCampaign(ctx, campaign.TenantID, campaign.ID)
+		if got2.Name != "Updated Campaign" {
+			t.Errorf("Name after update = %q", got2.Name)
+		}
+
+		if err := store.DeleteCampaign(ctx, campaign.TenantID, campaign.ID); err != nil {
+			t.Fatalf("DeleteCampaign: %v", err)
+		}
+
+		got3, err := store.GetCampaign(ctx, campaign.TenantID, campaign.ID)
+		if err != nil {
+			t.Fatalf("GetCampaign after delete: %v", err)
+		}
+		if got3 != nil {
+			t.Error("campaign should be nil after deletion")
+		}
+	})
+
+	t.Run("lore document CRUD", func(t *testing.T) {
+		t.Parallel()
+
+		campaign := &web.Campaign{
+			TenantID: "tenant-lore-crud",
+			Name:     "Lore Campaign",
+		}
+		if err := store.CreateCampaign(ctx, campaign); err != nil {
+			t.Fatalf("CreateCampaign: %v", err)
+		}
+
+		doc := &web.LoreDocument{
+			CampaignID:      campaign.ID,
+			Title:           "Ancient History",
+			ContentMarkdown: "# History\nSome content",
+			SortOrder:       1,
+		}
+		if err := store.CreateLoreDocument(ctx, doc); err != nil {
+			t.Fatalf("CreateLoreDocument: %v", err)
+		}
+		if doc.ID == "" {
+			t.Fatal("lore document ID not set")
+		}
+
+		got, err := store.GetLoreDocument(ctx, campaign.ID, doc.ID)
+		if err != nil {
+			t.Fatalf("GetLoreDocument: %v", err)
+		}
+		if got.Title != "Ancient History" {
+			t.Errorf("Title = %q", got.Title)
+		}
+
+		docs, err := store.ListLoreDocuments(ctx, campaign.ID)
+		if err != nil {
+			t.Fatalf("ListLoreDocuments: %v", err)
+		}
+		if len(docs) == 0 {
+			t.Error("expected at least 1 lore document")
+		}
+
+		if err := store.DeleteLoreDocument(ctx, campaign.ID, doc.ID); err != nil {
+			t.Fatalf("DeleteLoreDocument: %v", err)
+		}
+	})
+}
+
+// TestIntegration_CORSHeaders verifies CORS middleware behaves correctly.
+func TestIntegration_CORSHeaders(t *testing.T) {
+	t.Parallel()
+	ts := setupTestServer(t)
+
+	t.Run("preflight request returns CORS headers", func(t *testing.T) {
+		t.Parallel()
+
+		req, _ := http.NewRequest("OPTIONS", ts.URL+"/api/v1/campaigns", nil)
+		req.Header.Set("Origin", "http://localhost:3000")
+		req.Header.Set("Access-Control-Request-Method", "POST")
+		req.Header.Set("Access-Control-Request-Headers", "Authorization, Content-Type")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("OPTIONS: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNoContent {
+			t.Errorf("status = %d, want 204", resp.StatusCode)
+		}
+		if got := resp.Header.Get("Access-Control-Allow-Methods"); got == "" {
+			t.Error("missing Access-Control-Allow-Methods")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **gRPC transport**: Tests gateway↔worker session lifecycle, bidirectional callbacks, NPC config serialization, and protobuf state enum round-trips over real gRPC connections
- **Web API + PostgreSQL**: Tests API key auth, JWT middleware, token refresh, CORS, campaign/lore CRUD, role-based access control, and direct WebStore SQL operations against a real database
- **Session orchestrator + PostgreSQL**: Tests session creation, state transitions, heartbeats, active session queries, and zombie/stale-pending cleanup
- **Config validation**: Tests cross-field validation (engine↔provider), duplicate NPCs, GM helper constraints, MCP servers, strict YAML rejection
- **Health endpoints**: Tests /healthz, /readyz with healthy/failing/no checkers, context cancellation

All tests use `//go:build integration` build tag. PostgreSQL tests skip when `GLYPHOXA_TEST_POSTGRES_DSN` is unset.

**2,395 lines** of new test coverage across 5 files.

## Test plan

- [x] `go test -tags integration -race -count=1 ./internal/gateway/grpctransport/...` — PASS
- [x] `go test -tags integration -race -count=1 ./internal/config/...` — PASS
- [x] `go test -tags integration -race -count=1 ./internal/health/...` — PASS
- [x] `GLYPHOXA_TEST_POSTGRES_DSN=... go test -tags integration -race -count=1 ./internal/web/...` — PASS
- [x] `GLYPHOXA_TEST_POSTGRES_DSN=... go test -tags integration -race -count=1 ./internal/gateway/sessionorch/...` — PASS
- [x] Regular tests (no integration tag) still pass — no regressions