### PR TITLE
feat(web): Phase 3 — OAuth providers, audit log, rate limiting, admin dashboard

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -211,3 +211,194 @@ func FetchDiscordUser(ctx context.Context, accessToken string) (*DiscordUser, er
 	}
 	return &user, nil
 }
+
+// --- Google OAuth2 ---
+
+// oauthHTTPClient is shared for all outbound OAuth HTTP calls.
+var oauthHTTPClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
+
+// GoogleOAuthConfig holds Google OAuth2 configuration.
+type GoogleOAuthConfig struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+}
+
+// GoogleUser represents the user profile returned by Google's userinfo endpoint.
+type GoogleUser struct {
+	Sub        string `json:"sub"`
+	Email      string `json:"email"`
+	Name       string `json:"name"`
+	Picture    string `json:"picture"`
+	GivenName  string `json:"given_name"`
+	FamilyName string `json:"family_name"`
+}
+
+// DisplayName returns the best display name for the Google user.
+func (u GoogleUser) DisplayName() string {
+	if u.Name != "" {
+		return u.Name
+	}
+	if u.GivenName != "" {
+		return u.GivenName
+	}
+	return u.Email
+}
+
+// ExchangeGoogleCode exchanges an authorization code for a Google access token.
+func ExchangeGoogleCode(ctx context.Context, cfg GoogleOAuthConfig, code string) (string, error) {
+	data := url.Values{
+		"client_id":     {cfg.ClientID},
+		"client_secret": {cfg.ClientSecret},
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {cfg.RedirectURI},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("web: create google token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := oauthHTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("web: exchange google code: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("web: google token exchange returned %d", resp.StatusCode)
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("web: decode google token response: %w", err)
+	}
+	return result.AccessToken, nil
+}
+
+// FetchGoogleUser fetches the authenticated user's profile from Google's userinfo endpoint.
+func FetchGoogleUser(ctx context.Context, accessToken string) (*GoogleUser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.googleapis.com/oauth2/v3/userinfo", nil)
+	if err != nil {
+		return nil, fmt.Errorf("web: create google user request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := oauthHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("web: fetch google user: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("web: google userinfo endpoint returned %d", resp.StatusCode)
+	}
+
+	var user GoogleUser
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return nil, fmt.Errorf("web: decode google user: %w", err)
+	}
+	return &user, nil
+}
+
+// --- GitHub OAuth2 ---
+
+// GitHubOAuthConfig holds GitHub OAuth2 configuration.
+type GitHubOAuthConfig struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+}
+
+// GitHubUser represents the user profile returned by the GitHub API.
+type GitHubUser struct {
+	ID        int64  `json:"id"`
+	Login     string `json:"login"`
+	Name      string `json:"name"`
+	Email     string `json:"email"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+// DisplayName returns the best display name for the GitHub user.
+func (u GitHubUser) DisplayName() string {
+	if u.Name != "" {
+		return u.Name
+	}
+	return u.Login
+}
+
+// GitHubID returns the string representation of the numeric GitHub user ID.
+func (u GitHubUser) GitHubID() string {
+	return fmt.Sprintf("%d", u.ID)
+}
+
+// ExchangeGitHubCode exchanges an authorization code for a GitHub access token.
+func ExchangeGitHubCode(ctx context.Context, cfg GitHubOAuthConfig, code string) (string, error) {
+	data := url.Values{
+		"client_id":     {cfg.ClientID},
+		"client_secret": {cfg.ClientSecret},
+		"code":          {code},
+		"redirect_uri":  {cfg.RedirectURI},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://github.com/login/oauth/access_token", strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("web: create github token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := oauthHTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("web: exchange github code: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("web: github token exchange returned %d", resp.StatusCode)
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("web: decode github token response: %w", err)
+	}
+	if result.Error != "" {
+		return "", fmt.Errorf("web: github token exchange error: %s", result.Error)
+	}
+	return result.AccessToken, nil
+}
+
+// FetchGitHubUser fetches the authenticated user's profile from the GitHub API.
+func FetchGitHubUser(ctx context.Context, accessToken string) (*GitHubUser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user", nil)
+	if err != nil {
+		return nil, fmt.Errorf("web: create github user request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := oauthHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("web: fetch github user: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("web: github user endpoint returned %d", resp.StatusCode)
+	}
+
+	var user GitHubUser
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return nil, fmt.Errorf("web: decode github user: %w", err)
+	}
+	return &user, nil
+}

--- a/internal/web/config.go
+++ b/internal/web/config.go
@@ -34,6 +34,24 @@ type Config struct {
 	// Optional when AdminAPIKey is set.
 	DiscordRedirectURI string
 
+	// GoogleClientID is the Google OAuth2 application client ID.
+	GoogleClientID string
+
+	// GoogleClientSecret is the Google OAuth2 application client secret.
+	GoogleClientSecret string
+
+	// GoogleRedirectURI is the OAuth2 callback URL registered with Google.
+	GoogleRedirectURI string
+
+	// GitHubClientID is the GitHub OAuth2 application client ID.
+	GitHubClientID string
+
+	// GitHubClientSecret is the GitHub OAuth2 application client secret.
+	GitHubClientSecret string
+
+	// GitHubRedirectURI is the OAuth2 callback URL registered with GitHub.
+	GitHubRedirectURI string
+
 	// AdminAPIKey is the shared admin key that can be used as a login
 	// fallback when Discord OAuth2 is not configured. Loaded from
 	// GLYPHOXA_WEB_ADMIN_KEY or GLYPHOXA_ADMIN_API_KEY.
@@ -88,6 +106,12 @@ func LoadConfig() (*Config, error) {
 		DiscordClientID:     os.Getenv("GLYPHOXA_WEB_DISCORD_CLIENT_ID"),
 		DiscordClientSecret: os.Getenv("GLYPHOXA_WEB_DISCORD_CLIENT_SECRET"),
 		DiscordRedirectURI:  os.Getenv("GLYPHOXA_WEB_DISCORD_REDIRECT_URI"),
+		GoogleClientID:      os.Getenv("GLYPHOXA_WEB_GOOGLE_CLIENT_ID"),
+		GoogleClientSecret:  os.Getenv("GLYPHOXA_WEB_GOOGLE_CLIENT_SECRET"),
+		GoogleRedirectURI:   os.Getenv("GLYPHOXA_WEB_GOOGLE_REDIRECT_URI"),
+		GitHubClientID:      os.Getenv("GLYPHOXA_WEB_GITHUB_CLIENT_ID"),
+		GitHubClientSecret:  os.Getenv("GLYPHOXA_WEB_GITHUB_CLIENT_SECRET"),
+		GitHubRedirectURI:   os.Getenv("GLYPHOXA_WEB_GITHUB_REDIRECT_URI"),
 		AdminAPIKey:         adminKey,
 		GatewayURL:          os.Getenv("GLYPHOXA_WEB_GATEWAY_URL"),
 		GatewayGRPCAddr:     os.Getenv("GLYPHOXA_WEB_GATEWAY_GRPC_ADDR"),
@@ -130,12 +154,14 @@ func (c *Config) Validate() error {
 		errs = append(errs, fmt.Errorf("GLYPHOXA_WEB_JWT_SECRET must be at least 32 characters"))
 	}
 
-	// Discord OAuth is only required when no API key fallback is configured.
+	// At least one auth method must be configured.
 	hasDiscord := c.DiscordClientID != "" && c.DiscordClientSecret != "" && c.DiscordRedirectURI != ""
+	hasGoogle := c.GoogleClientID != "" && c.GoogleClientSecret != "" && c.GoogleRedirectURI != ""
+	hasGitHub := c.GitHubClientID != "" && c.GitHubClientSecret != "" && c.GitHubRedirectURI != ""
 	hasAPIKey := c.AdminAPIKey != ""
 
-	if !hasDiscord && !hasAPIKey {
-		errs = append(errs, fmt.Errorf("at least one auth method required: set Discord OAuth2 vars or GLYPHOXA_WEB_ADMIN_KEY / GLYPHOXA_ADMIN_API_KEY"))
+	if !hasDiscord && !hasGoogle && !hasGitHub && !hasAPIKey {
+		errs = append(errs, fmt.Errorf("at least one auth method required: set Discord/Google/GitHub OAuth2 vars or GLYPHOXA_WEB_ADMIN_KEY / GLYPHOXA_ADMIN_API_KEY"))
 	}
 
 	// mTLS: if any TLS field is set, all three must be set.

--- a/internal/web/handlers_admin.go
+++ b/internal/web/handlers_admin.go
@@ -1,0 +1,65 @@
+package web
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+)
+
+// handleAdminDashboardStats returns system-wide aggregate stats for super admins.
+func (s *Server) handleAdminDashboardStats(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	stats, err := s.store.GetAdminDashboardStats(r.Context())
+	if err != nil {
+		slog.Error("web: admin dashboard stats", "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to load admin stats")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": stats})
+}
+
+// handleAdminListUsers lists all users across all tenants (super_admin only).
+func (s *Server) handleAdminListUsers(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+
+	users, total, err := s.store.ListAllTenantUsers(r.Context(), limit, offset)
+	if err != nil {
+		slog.Error("web: admin list users", "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to list users")
+		return
+	}
+
+	if users == nil {
+		users = []User{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data":  users,
+		"total": total,
+	})
+}
+
+// handleAuthProviders returns which auth providers are configured.
+// This is used by the frontend login page to show available login options.
+func (s *Server) handleAuthProviders(w http.ResponseWriter, _ *http.Request) {
+	providers := map[string]bool{
+		"discord": s.cfg.DiscordClientID != "" && s.cfg.DiscordClientSecret != "",
+		"google":  s.cfg.GoogleClientID != "" && s.cfg.GoogleClientSecret != "",
+		"github":  s.cfg.GitHubClientID != "" && s.cfg.GitHubClientSecret != "",
+		"apikey":  s.cfg.AdminAPIKey != "",
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": providers})
+}

--- a/internal/web/handlers_admin_test.go
+++ b/internal/web/handlers_admin_test.go
@@ -1,0 +1,123 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleAdminDashboardStats(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/admin/stats", auth(RequireRole("super_admin")(http.HandlerFunc(srv.handleAdminDashboardStats))))
+
+	userID := "admin-1"
+	tenantID := "default"
+	ws.users[userID] = &User{ID: userID, TenantID: tenantID, DisplayName: "Admin", Role: "super_admin"}
+	ws.campaigns["camp-1"] = &Campaign{ID: "camp-1", TenantID: tenantID, Name: "Test Campaign"}
+
+	t.Run("returns stats for super_admin", func(t *testing.T) {
+		t.Parallel()
+
+		req := authReq(t, http.MethodGet, "/api/v1/admin/stats", nil, secret, userID, tenantID, "super_admin")
+		rr := httptest.NewRecorder()
+		srv.mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d, body = %s", rr.Code, http.StatusOK, rr.Body.String())
+		}
+
+		var resp struct {
+			Data AdminDashboardStats `json:"data"`
+		}
+		if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Data.TotalUsers != 1 {
+			t.Errorf("total_users = %d, want 1", resp.Data.TotalUsers)
+		}
+		if resp.Data.TotalCampaigns != 1 {
+			t.Errorf("total_campaigns = %d, want 1", resp.Data.TotalCampaigns)
+		}
+	})
+
+	t.Run("requires super_admin role", func(t *testing.T) {
+		t.Parallel()
+
+		req := authReq(t, http.MethodGet, "/api/v1/admin/stats", nil, secret, userID, tenantID, "tenant_admin")
+		rr := httptest.NewRecorder()
+		srv.mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want %d", rr.Code, http.StatusForbidden)
+		}
+	})
+}
+
+func TestHandleAdminListUsers(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/admin/users", auth(RequireRole("super_admin")(http.HandlerFunc(srv.handleAdminListUsers))))
+
+	ws.users["u1"] = &User{ID: "u1", TenantID: "t1", DisplayName: "User1", Role: "dm"}
+	ws.users["u2"] = &User{ID: "u2", TenantID: "t2", DisplayName: "User2", Role: "dm"}
+	ws.users["admin"] = &User{ID: "admin", TenantID: "default", DisplayName: "Admin", Role: "super_admin"}
+
+	req := authReq(t, http.MethodGet, "/api/v1/admin/users", nil, secret, "admin", "default", "super_admin")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	var resp struct {
+		Data  []User `json:"data"`
+		Total int    `json:"total"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 3 {
+		t.Errorf("total = %d, want 3", resp.Total)
+	}
+}
+
+func TestHandleAuthProviders(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	srv.mux.HandleFunc("GET /api/v1/auth/providers", srv.handleAuthProviders)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/providers", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var resp struct {
+		Data map[string]bool `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Discord is configured in test config.
+	if !resp.Data["discord"] {
+		t.Error("discord should be true")
+	}
+	// Google and GitHub are not configured.
+	if resp.Data["google"] {
+		t.Error("google should be false")
+	}
+	if resp.Data["github"] {
+		t.Error("github should be false")
+	}
+}

--- a/internal/web/handlers_audit.go
+++ b/internal/web/handlers_audit.go
@@ -1,0 +1,80 @@
+package web
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+)
+
+// handleListAuditLogs returns audit log entries for the current tenant,
+// or for all tenants if the user is a super_admin.
+func (s *Server) handleListAuditLogs(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	tenantID := claims.TenantID
+	// Super admins can view all tenants' audit logs.
+	if claims.Role == "super_admin" {
+		if qTenant := r.URL.Query().Get("tenant_id"); qTenant != "" {
+			tenantID = qTenant
+		} else {
+			tenantID = "" // Empty means all tenants.
+		}
+	}
+
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	resourceType := r.URL.Query().Get("resource_type")
+	action := r.URL.Query().Get("action")
+
+	entries, total, err := s.store.ListAuditLogs(r.Context(), tenantID, limit, offset, resourceType, action)
+	if err != nil {
+		slog.Error("web: list audit logs", "tenant_id", tenantID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to load audit logs")
+		return
+	}
+
+	if entries == nil {
+		entries = []AuditLogEntry{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data":  entries,
+		"total": total,
+	})
+}
+
+// auditLog is a helper to record an audit log entry from a handler.
+func (s *Server) auditLog(r *http.Request, action, resourceType, resourceID string, changes any) {
+	claims := ClaimsFromContext(r.Context())
+	entry := &AuditLogEntry{
+		Action:       action,
+		ResourceType: resourceType,
+		ResourceID:   resourceID,
+	}
+
+	ip := clientIP(r)
+	entry.IPAddress = &ip
+	ua := r.UserAgent()
+	entry.UserAgent = &ua
+
+	if claims != nil {
+		entry.UserID = &claims.Sub
+		if claims.TenantID != "" {
+			entry.TenantID = &claims.TenantID
+		}
+	}
+
+	if changes != nil {
+		if raw, ok := changes.([]byte); ok {
+			entry.Changes = raw
+		}
+	}
+
+	if err := s.store.CreateAuditLog(r.Context(), entry); err != nil {
+		slog.Warn("web: failed to write audit log", "action", action, "resource", resourceType+"/"+resourceID, "err", err)
+	}
+}

--- a/internal/web/handlers_audit_test.go
+++ b/internal/web/handlers_audit_test.go
@@ -1,0 +1,144 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHandleListAuditLogs(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+	srv.mux.Handle("GET /api/v1/audit-logs", auth(RequireRole("tenant_admin")(http.HandlerFunc(srv.handleListAuditLogs))))
+
+	tenantID := "test-tenant"
+	userID := "user-1"
+
+	// Seed some audit log entries.
+	ws.auditLogs = append(ws.auditLogs,
+		AuditLogEntry{
+			ID:           1,
+			TenantID:     &tenantID,
+			UserID:       &userID,
+			Action:       "campaign.create",
+			ResourceType: "campaign",
+			ResourceID:   "camp-1",
+			CreatedAt:    time.Now().UTC(),
+		},
+		AuditLogEntry{
+			ID:           2,
+			TenantID:     &tenantID,
+			UserID:       &userID,
+			Action:       "npc.update",
+			ResourceType: "npc",
+			ResourceID:   "npc-1",
+			CreatedAt:    time.Now().UTC(),
+		},
+	)
+	ws.users[userID] = &User{ID: userID, TenantID: tenantID, DisplayName: "Test", Role: "tenant_admin"}
+
+	t.Run("returns audit logs for tenant admin", func(t *testing.T) {
+		t.Parallel()
+
+		req := authReq(t, http.MethodGet, "/api/v1/audit-logs", nil, secret, userID, tenantID, "tenant_admin")
+		rr := httptest.NewRecorder()
+		srv.mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d, body = %s", rr.Code, http.StatusOK, rr.Body.String())
+		}
+
+		var resp struct {
+			Data  []AuditLogEntry `json:"data"`
+			Total int             `json:"total"`
+		}
+		if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Total != 2 {
+			t.Errorf("total = %d, want 2", resp.Total)
+		}
+		if len(resp.Data) != 2 {
+			t.Errorf("len(data) = %d, want 2", len(resp.Data))
+		}
+	})
+
+	t.Run("filters by resource type", func(t *testing.T) {
+		t.Parallel()
+
+		req := authReq(t, http.MethodGet, "/api/v1/audit-logs?resource_type=campaign", nil, secret, userID, tenantID, "tenant_admin")
+		rr := httptest.NewRecorder()
+		srv.mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+
+		var resp struct {
+			Data  []AuditLogEntry `json:"data"`
+			Total int             `json:"total"`
+		}
+		if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Total != 1 {
+			t.Errorf("total = %d, want 1", resp.Total)
+		}
+	})
+
+	t.Run("requires tenant_admin role", func(t *testing.T) {
+		t.Parallel()
+
+		req := authReq(t, http.MethodGet, "/api/v1/audit-logs", nil, secret, userID, tenantID, "dm")
+		rr := httptest.NewRecorder()
+		srv.mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want %d", rr.Code, http.StatusForbidden)
+		}
+	})
+}
+
+func TestAuditLogHelper(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	auth := AuthMiddleware(secret)
+
+	// Create a dummy handler that logs an audit entry.
+	srv.mux.Handle("POST /api/v1/test-audit", auth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv.auditLog(r, "test.action", "test_resource", "res-123", nil)
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	userID := "audit-user"
+	tenantID := "audit-tenant"
+	ws.users[userID] = &User{ID: userID, TenantID: tenantID, DisplayName: "Auditor", Role: "dm"}
+
+	req := authReq(t, http.MethodPost, "/api/v1/test-audit", nil, secret, userID, tenantID, "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	if len(ws.auditLogs) != 1 {
+		t.Fatalf("audit log count = %d, want 1", len(ws.auditLogs))
+	}
+
+	entry := ws.auditLogs[0]
+	if entry.Action != "test.action" {
+		t.Errorf("action = %q, want %q", entry.Action, "test.action")
+	}
+	if entry.ResourceType != "test_resource" {
+		t.Errorf("resource_type = %q, want %q", entry.ResourceType, "test_resource")
+	}
+	if entry.UserID == nil || *entry.UserID != userID {
+		t.Errorf("user_id = %v, want %q", entry.UserID, userID)
+	}
+}

--- a/internal/web/handlers_dashboard_test.go
+++ b/internal/web/handlers_dashboard_test.go
@@ -239,7 +239,7 @@ func TestHandleDashboardActiveSessions_NoGateway(t *testing.T) {
 
 	srv, _, _, secret := testServerWithStores(t)
 	auth := AuthMiddleware(secret)
-	srv.mux.Handle("GET /api/v1/dashboard/active-sessions", auth(http.HandlerFunc(srv.handleDashboardActiveSessions)))
+	srv.mux.Handle("GET /api/v1/dashboard/active-sessions", auth(http.HandlerFunc(srv.handleListActiveSessions)))
 
 	req := authReq(t, http.MethodGet, "/api/v1/dashboard/active-sessions", nil, secret, "user-1", "tenant-1", "dm")
 	rr := httptest.NewRecorder()
@@ -288,7 +288,7 @@ func TestHandleDashboardActiveSessions_WithGateway(t *testing.T) {
 	srv.gwClient = newMockMgmtClient()
 
 	auth := AuthMiddleware(secret)
-	srv.mux.Handle("GET /api/v1/dashboard/active-sessions", auth(http.HandlerFunc(srv.handleDashboardActiveSessions)))
+	srv.mux.Handle("GET /api/v1/dashboard/active-sessions", auth(http.HandlerFunc(srv.handleListActiveSessions)))
 
 	req := authReq(t, http.MethodGet, "/api/v1/dashboard/active-sessions", nil, secret, "user-1", "tenant-1", "dm")
 	rr := httptest.NewRecorder()
@@ -314,7 +314,7 @@ func TestHandleDashboardActiveSessions_Unauthenticated(t *testing.T) {
 
 	srv, secret := testServer(t)
 	auth := AuthMiddleware(secret)
-	srv.mux.Handle("GET /api/v1/dashboard/active-sessions", auth(http.HandlerFunc(srv.handleDashboardActiveSessions)))
+	srv.mux.Handle("GET /api/v1/dashboard/active-sessions", auth(http.HandlerFunc(srv.handleListActiveSessions)))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/dashboard/active-sessions", nil)
 	rr := httptest.NewRecorder()

--- a/internal/web/handlers_knowledge.go
+++ b/internal/web/handlers_knowledge.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 )
@@ -68,6 +69,89 @@ func (s *Server) handleDeleteKnowledgeEntity(w http.ResponseWriter, r *http.Requ
 
 	slog.Info("web: knowledge entity deleted", "entity_id", entityID, "campaign_id", campaignID)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// KnowledgeGraphData represents the full graph structure for frontend visualization.
+type KnowledgeGraphData struct {
+	Entities      []KnowledgeEntity       `json:"entities"`
+	Relationships []KnowledgeRelationship `json:"relationships"`
+}
+
+// KnowledgeRelationship represents a relationship between two knowledge entities.
+type KnowledgeRelationship struct {
+	SourceID   string         `json:"source_id"`
+	TargetID   string         `json:"target_id"`
+	SourceName string         `json:"source_name"`
+	TargetName string         `json:"target_name"`
+	RelType    string         `json:"rel_type"`
+	Attributes map[string]any `json:"attributes,omitempty"`
+}
+
+// handleGetKnowledgeGraph returns the full knowledge graph for a campaign,
+// formatted for force-directed graph visualization.
+func (s *Server) handleGetKnowledgeGraph(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	campaignID := r.PathValue("id")
+	campaign, err := s.store.GetCampaign(r.Context(), claims.TenantID, campaignID)
+	if err != nil || campaign == nil {
+		writeError(w, http.StatusNotFound, "not_found", "campaign not found")
+		return
+	}
+
+	// Get all entities (no pagination for graph view).
+	entities, err := s.store.ListKnowledgeEntities(r.Context(), claims.TenantID, campaignID, CursorPage{Limit: 500})
+	if err != nil {
+		slog.Error("web: get knowledge graph entities", "campaign_id", campaignID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to load knowledge graph")
+		return
+	}
+	if entities == nil {
+		entities = []KnowledgeEntity{}
+	}
+
+	// Build a name lookup and generate synthetic relationships from entity attributes.
+	nameMap := make(map[string]string, len(entities))
+	for _, e := range entities {
+		nameMap[e.ID] = e.Name
+	}
+
+	var relationships []KnowledgeRelationship
+	for _, e := range entities {
+		if relations, ok := e.Attributes["relationships"]; ok {
+			if relsJSON, err := json.Marshal(relations); err == nil {
+				var rels []struct {
+					TargetID string `json:"target_id"`
+					RelType  string `json:"rel_type"`
+				}
+				if err := json.Unmarshal(relsJSON, &rels); err == nil {
+					for _, rel := range rels {
+						relationships = append(relationships, KnowledgeRelationship{
+							SourceID:   e.ID,
+							TargetID:   rel.TargetID,
+							SourceName: e.Name,
+							TargetName: nameMap[rel.TargetID],
+							RelType:    rel.RelType,
+						})
+					}
+				}
+			}
+		}
+	}
+	if relationships == nil {
+		relationships = []KnowledgeRelationship{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": KnowledgeGraphData{
+			Entities:      entities,
+			Relationships: relationships,
+		},
+	})
 }
 
 func (s *Server) handleRebuildKnowledgeGraph(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/handlers_knowledge_test.go
+++ b/internal/web/handlers_knowledge_test.go
@@ -116,6 +116,68 @@ func TestHandleRebuildKnowledgeGraph(t *testing.T) {
 	}
 }
 
+func TestHandleGetKnowledgeGraph(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	srv.registerRoutes()
+
+	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
+	ws.knowledgeEntities["c1"] = []KnowledgeEntity{
+		{CampaignID: "c1", ID: "e1", Type: "npc", Name: "Heinrich", CreatedAt: time.Now().UTC(), Attributes: map[string]any{"occupation": "guard"}},
+		{CampaignID: "c1", ID: "e2", Type: "location", Name: "Rabenheim", CreatedAt: time.Now().UTC(), Attributes: map[string]any{}},
+	}
+
+	req := authReq(t, http.MethodGet, "/api/v1/campaigns/c1/knowledge/graph", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	var resp struct {
+		Data KnowledgeGraphData `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Data.Entities) != 2 {
+		t.Errorf("entities = %d, want 2", len(resp.Data.Entities))
+	}
+	// No relationships without explicit relationship attributes.
+	if resp.Data.Relationships == nil {
+		t.Error("relationships should not be nil (should be empty array)")
+	}
+}
+
+func TestHandleGetKnowledgeGraph_EmptyCampaign(t *testing.T) {
+	t.Parallel()
+
+	srv, ws, _, secret := testServerWithStores(t)
+	srv.registerRoutes()
+
+	ws.campaigns["c2"] = &Campaign{ID: "c2", TenantID: "tenant-1", Name: "EmptyCampaign"}
+
+	req := authReq(t, http.MethodGet, "/api/v1/campaigns/c2/knowledge/graph", nil, secret, "user-1", "tenant-1", "dm")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var resp struct {
+		Data KnowledgeGraphData `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Data.Entities) != 0 {
+		t.Errorf("entities = %d, want 0", len(resp.Data.Entities))
+	}
+}
+
 func TestHandleKnowledge_WrongCampaign(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/handlers_oauth.go
+++ b/internal/web/handlers_oauth.go
@@ -1,0 +1,347 @@
+package web
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+)
+
+// handleGoogleLogin initiates the Google OAuth2 flow.
+func (s *Server) handleGoogleLogin(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.GoogleClientID == "" {
+		writeError(w, http.StatusNotFound, "not_configured", "Google login is not enabled")
+		return
+	}
+
+	state, err := GenerateState()
+	if err != nil {
+		slog.Error("web: generate google oauth state", "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to generate state")
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     "glyphoxa_oauth_state",
+		Value:    state,
+		Path:     "/",
+		MaxAge:   300,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	if inviteToken := r.URL.Query().Get("invite"); inviteToken != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "glyphoxa_invite",
+			Value:    inviteToken,
+			Path:     "/",
+			MaxAge:   300,
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+
+	params := url.Values{
+		"client_id":     {s.cfg.GoogleClientID},
+		"redirect_uri":  {s.cfg.GoogleRedirectURI},
+		"response_type": {"code"},
+		"scope":         {"openid email profile"},
+		"state":         {state},
+		"access_type":   {"offline"},
+	}
+
+	target := "https://accounts.google.com/o/oauth2/v2/auth?" + params.Encode()
+	http.Redirect(w, r, target, http.StatusFound)
+}
+
+// handleGoogleCallback handles the Google OAuth2 callback.
+func (s *Server) handleGoogleCallback(w http.ResponseWriter, r *http.Request) {
+	stateCookie, err := r.Cookie("glyphoxa_oauth_state")
+	if err != nil || stateCookie.Value == "" {
+		writeError(w, http.StatusBadRequest, "invalid_state", "missing OAuth state cookie")
+		return
+	}
+	if r.URL.Query().Get("state") != stateCookie.Value {
+		writeError(w, http.StatusBadRequest, "invalid_state", "state mismatch")
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{Name: "glyphoxa_oauth_state", Value: "", Path: "/", MaxAge: -1})
+
+	var inviteToken string
+	if ic, err := r.Cookie("glyphoxa_invite"); err == nil {
+		inviteToken = ic.Value
+	}
+	http.SetCookie(w, &http.Cookie{Name: "glyphoxa_invite", Value: "", Path: "/", MaxAge: -1})
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		writeError(w, http.StatusBadRequest, "missing_code", "authorization code required")
+		return
+	}
+
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		desc := r.URL.Query().Get("error_description")
+		slog.Warn("web: google oauth error", "error", errParam, "description", desc)
+		writeError(w, http.StatusBadRequest, "google_error", fmt.Sprintf("google: %s", desc))
+		return
+	}
+
+	oauthCfg := GoogleOAuthConfig{
+		ClientID:     s.cfg.GoogleClientID,
+		ClientSecret: s.cfg.GoogleClientSecret,
+		RedirectURI:  s.cfg.GoogleRedirectURI,
+	}
+
+	accessToken, err := ExchangeGoogleCode(r.Context(), oauthCfg, code)
+	if err != nil {
+		slog.Error("web: google token exchange", "err", err)
+		writeError(w, http.StatusBadGateway, "google_error", "failed to exchange authorization code")
+		return
+	}
+
+	googleUser, err := FetchGoogleUser(r.Context(), accessToken)
+	if err != nil {
+		slog.Error("web: fetch google user", "err", err)
+		writeError(w, http.StatusBadGateway, "google_error", "failed to fetch user profile")
+		return
+	}
+
+	tenantID := ""
+	var invite *Invite
+	if inviteToken != "" {
+		invite, err = s.store.GetInviteByToken(r.Context(), inviteToken)
+		if err != nil {
+			slog.Warn("web: get invite by token", "err", err)
+		}
+		if invite != nil {
+			tenantID = invite.TenantID
+		}
+	}
+
+	user, err := s.store.UpsertGoogleUser(
+		r.Context(),
+		googleUser.Sub,
+		googleUser.Email,
+		googleUser.DisplayName(),
+		googleUser.Picture,
+		tenantID,
+	)
+	if err != nil {
+		slog.Error("web: upsert google user", "google_id", googleUser.Sub, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to create user")
+		return
+	}
+
+	s.processInvite(r, user, invite)
+
+	token, err := SignJWT(s.cfg.JWTSecret, Claims{
+		Sub:      user.ID,
+		TenantID: user.TenantID,
+		Role:     user.Role,
+	})
+	if err != nil {
+		slog.Error("web: sign jwt", "user_id", user.ID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to issue token")
+		return
+	}
+
+	slog.Info("web: user authenticated via google",
+		"user_id", user.ID,
+		"google_id", googleUser.Sub,
+		"display_name", user.DisplayName,
+		"tenant_id", user.TenantID,
+	)
+
+	redirect := "/auth/callback?token=" + url.QueryEscape(token)
+	if user.TenantID == "" {
+		redirect += "&onboarding=true"
+	}
+	http.Redirect(w, r, redirect, http.StatusFound)
+}
+
+// handleGitHubLogin initiates the GitHub OAuth2 flow.
+func (s *Server) handleGitHubLogin(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.GitHubClientID == "" {
+		writeError(w, http.StatusNotFound, "not_configured", "GitHub login is not enabled")
+		return
+	}
+
+	state, err := GenerateState()
+	if err != nil {
+		slog.Error("web: generate github oauth state", "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to generate state")
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     "glyphoxa_oauth_state",
+		Value:    state,
+		Path:     "/",
+		MaxAge:   300,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	if inviteToken := r.URL.Query().Get("invite"); inviteToken != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "glyphoxa_invite",
+			Value:    inviteToken,
+			Path:     "/",
+			MaxAge:   300,
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+
+	params := url.Values{
+		"client_id":    {s.cfg.GitHubClientID},
+		"redirect_uri": {s.cfg.GitHubRedirectURI},
+		"scope":        {"read:user user:email"},
+		"state":        {state},
+	}
+
+	target := "https://github.com/login/oauth/authorize?" + params.Encode()
+	http.Redirect(w, r, target, http.StatusFound)
+}
+
+// handleGitHubCallback handles the GitHub OAuth2 callback.
+func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
+	stateCookie, err := r.Cookie("glyphoxa_oauth_state")
+	if err != nil || stateCookie.Value == "" {
+		writeError(w, http.StatusBadRequest, "invalid_state", "missing OAuth state cookie")
+		return
+	}
+	if r.URL.Query().Get("state") != stateCookie.Value {
+		writeError(w, http.StatusBadRequest, "invalid_state", "state mismatch")
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{Name: "glyphoxa_oauth_state", Value: "", Path: "/", MaxAge: -1})
+
+	var inviteToken string
+	if ic, err := r.Cookie("glyphoxa_invite"); err == nil {
+		inviteToken = ic.Value
+	}
+	http.SetCookie(w, &http.Cookie{Name: "glyphoxa_invite", Value: "", Path: "/", MaxAge: -1})
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		writeError(w, http.StatusBadRequest, "missing_code", "authorization code required")
+		return
+	}
+
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		desc := r.URL.Query().Get("error_description")
+		slog.Warn("web: github oauth error", "error", errParam, "description", desc)
+		writeError(w, http.StatusBadRequest, "github_error", fmt.Sprintf("github: %s", desc))
+		return
+	}
+
+	oauthCfg := GitHubOAuthConfig{
+		ClientID:     s.cfg.GitHubClientID,
+		ClientSecret: s.cfg.GitHubClientSecret,
+		RedirectURI:  s.cfg.GitHubRedirectURI,
+	}
+
+	accessToken, err := ExchangeGitHubCode(r.Context(), oauthCfg, code)
+	if err != nil {
+		slog.Error("web: github token exchange", "err", err)
+		writeError(w, http.StatusBadGateway, "github_error", "failed to exchange authorization code")
+		return
+	}
+
+	githubUser, err := FetchGitHubUser(r.Context(), accessToken)
+	if err != nil {
+		slog.Error("web: fetch github user", "err", err)
+		writeError(w, http.StatusBadGateway, "github_error", "failed to fetch user profile")
+		return
+	}
+
+	tenantID := ""
+	var invite *Invite
+	if inviteToken != "" {
+		invite, err = s.store.GetInviteByToken(r.Context(), inviteToken)
+		if err != nil {
+			slog.Warn("web: get invite by token", "err", err)
+		}
+		if invite != nil {
+			tenantID = invite.TenantID
+		}
+	}
+
+	user, err := s.store.UpsertGitHubUser(
+		r.Context(),
+		githubUser.GitHubID(),
+		githubUser.Email,
+		githubUser.DisplayName(),
+		githubUser.AvatarURL,
+		tenantID,
+	)
+	if err != nil {
+		slog.Error("web: upsert github user", "github_id", githubUser.GitHubID(), "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to create user")
+		return
+	}
+
+	s.processInvite(r, user, invite)
+
+	token, err := SignJWT(s.cfg.JWTSecret, Claims{
+		Sub:      user.ID,
+		TenantID: user.TenantID,
+		Role:     user.Role,
+	})
+	if err != nil {
+		slog.Error("web: sign jwt", "user_id", user.ID, "err", err)
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to issue token")
+		return
+	}
+
+	slog.Info("web: user authenticated via github",
+		"user_id", user.ID,
+		"github_id", githubUser.GitHubID(),
+		"display_name", user.DisplayName,
+		"tenant_id", user.TenantID,
+	)
+
+	redirect := "/auth/callback?token=" + url.QueryEscape(token)
+	if user.TenantID == "" {
+		redirect += "&onboarding=true"
+	}
+	http.Redirect(w, r, redirect, http.StatusFound)
+}
+
+// processInvite handles invite acceptance logic shared by all OAuth providers.
+func (s *Server) processInvite(r *http.Request, user *User, invite *Invite) {
+	if invite == nil {
+		return
+	}
+
+	switch {
+	case user.TenantID != "" && user.TenantID != invite.TenantID:
+		slog.Warn("web: invite ignored, user already in tenant", "user_id", user.ID, "user_tenant", user.TenantID, "invite_tenant", invite.TenantID)
+	case user.TenantID == "":
+		if err := s.store.UpdateUserTenant(r.Context(), user.ID, invite.TenantID, invite.Role); err != nil {
+			slog.Error("web: assign user to invite tenant", "err", err)
+			return
+		}
+		user.TenantID = invite.TenantID
+		user.Role = invite.Role
+		fallthrough
+	default:
+		if user.Role != invite.Role {
+			if err := s.store.UpdateUser(r.Context(), &User{ID: user.ID, Role: invite.Role}); err != nil {
+				slog.Warn("web: update invite role", "err", err)
+			} else {
+				user.Role = invite.Role
+			}
+		}
+		if err := s.store.UseInvite(r.Context(), invite.ID, user.ID); err != nil {
+			slog.Warn("web: mark invite used", "invite_id", invite.ID, "err", err)
+		}
+	}
+}

--- a/internal/web/handlers_oauth_test.go
+++ b/internal/web/handlers_oauth_test.go
@@ -1,0 +1,174 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleGoogleLogin_NotConfigured(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	srv.mux.HandleFunc("GET /api/v1/auth/google", srv.handleGoogleLogin)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/google", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (Google not configured)", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleGoogleLogin_Configured(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	srv.cfg.GoogleClientID = "google-test-id"
+	srv.cfg.GoogleClientSecret = "google-test-secret"
+	srv.cfg.GoogleRedirectURI = "http://localhost/callback/google"
+	srv.mux.HandleFunc("GET /api/v1/auth/google", srv.handleGoogleLogin)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/google", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusFound)
+	}
+
+	loc := rr.Header().Get("Location")
+	if loc == "" {
+		t.Fatal("missing Location header")
+	}
+	if want := "accounts.google.com"; !contains(loc, want) {
+		t.Errorf("Location = %q, should contain %q", loc, want)
+	}
+	if want := "client_id=google-test-id"; !contains(loc, want) {
+		t.Errorf("Location = %q, should contain %q", loc, want)
+	}
+
+	// Should set state cookie.
+	var stateCookie *http.Cookie
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == "glyphoxa_oauth_state" {
+			stateCookie = c
+			break
+		}
+	}
+	if stateCookie == nil {
+		t.Fatal("missing glyphoxa_oauth_state cookie")
+	}
+	if stateCookie.Value == "" {
+		t.Fatal("empty state cookie")
+	}
+}
+
+func TestHandleGitHubLogin_NotConfigured(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	srv.mux.HandleFunc("GET /api/v1/auth/github", srv.handleGitHubLogin)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/github", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (GitHub not configured)", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleGitHubLogin_Configured(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	srv.cfg.GitHubClientID = "github-test-id"
+	srv.cfg.GitHubClientSecret = "github-test-secret"
+	srv.cfg.GitHubRedirectURI = "http://localhost/callback/github"
+	srv.mux.HandleFunc("GET /api/v1/auth/github", srv.handleGitHubLogin)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/github", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusFound)
+	}
+
+	loc := rr.Header().Get("Location")
+	if loc == "" {
+		t.Fatal("missing Location header")
+	}
+	if want := "github.com/login/oauth/authorize"; !contains(loc, want) {
+		t.Errorf("Location = %q, should contain %q", loc, want)
+	}
+	if want := "client_id=github-test-id"; !contains(loc, want) {
+		t.Errorf("Location = %q, should contain %q", loc, want)
+	}
+}
+
+func TestHandleGoogleCallback_MissingState(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	srv.cfg.GoogleClientID = "google-test-id"
+	srv.cfg.GoogleClientSecret = "google-test-secret"
+	srv.cfg.GoogleRedirectURI = "http://localhost/callback/google"
+	srv.mux.HandleFunc("GET /api/v1/auth/google/callback", srv.handleGoogleCallback)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/google/callback?code=test-code&state=abc", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (missing state cookie)", rr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleGitHubCallback_MissingState(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	srv.cfg.GitHubClientID = "github-test-id"
+	srv.cfg.GitHubClientSecret = "github-test-secret"
+	srv.cfg.GitHubRedirectURI = "http://localhost/callback/github"
+	srv.mux.HandleFunc("GET /api/v1/auth/github/callback", srv.handleGitHubCallback)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/github/callback?code=test-code&state=abc", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (missing state cookie)", rr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestProcessInvite_NilInvite(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, _ := testServerWithStores(t)
+	user := &User{ID: "u1", TenantID: "t1", Role: "dm"}
+
+	// Should not panic with nil invite.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	srv.processInvite(req, user, nil)
+
+	if user.TenantID != "t1" {
+		t.Errorf("tenant should be unchanged, got %q", user.TenantID)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsImpl(s, substr))
+}
+
+func containsImpl(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/web/handlers_providers.go
+++ b/internal/web/handlers_providers.go
@@ -1,0 +1,215 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// ProviderConfig represents a configured provider and its test status.
+type ProviderConfig struct {
+	Type     string `json:"type"`
+	Provider string `json:"provider"`
+	Status   string `json:"status"`
+	Latency  int    `json:"latency_ms,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+// handleTestProvider tests a provider connection by making a minimal API call.
+// This is a lightweight check — it validates API key / connectivity, not full functionality.
+func (s *Server) handleTestProvider(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "no_auth", "authentication required")
+		return
+	}
+
+	var body struct {
+		Type     string `json:"type"`
+		Provider string `json:"provider"`
+		APIKey   string `json:"api_key"`
+		BaseURL  string `json:"base_url,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", "expected JSON body")
+		return
+	}
+	if body.Type == "" || body.Provider == "" {
+		writeError(w, http.StatusBadRequest, "missing_fields", "type and provider are required")
+		return
+	}
+
+	start := time.Now()
+	testErr := testProviderConnection(r, body.Type, body.Provider, body.APIKey, body.BaseURL)
+	latency := time.Since(start).Milliseconds()
+
+	result := ProviderConfig{
+		Type:     body.Type,
+		Provider: body.Provider,
+		Status:   "ok",
+		Latency:  int(latency),
+	}
+	if testErr != nil {
+		result.Status = "error"
+		result.Error = testErr.Error()
+	}
+
+	s.auditLog(r, "provider.test", "provider", body.Type+"/"+body.Provider, nil)
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": result})
+}
+
+// testProviderConnection performs a lightweight connectivity test for a provider.
+func testProviderConnection(r *http.Request, providerType, provider, apiKey, baseURL string) error {
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	switch providerType {
+	case "llm":
+		return testLLMProvider(r, client, provider, apiKey, baseURL)
+	case "stt":
+		return testSTTProvider(r, client, provider, apiKey, baseURL)
+	case "tts":
+		return testTTSProvider(r, client, provider, apiKey, baseURL)
+	default:
+		return fmt.Errorf("unsupported provider type: %s", providerType)
+	}
+}
+
+func testLLMProvider(r *http.Request, client *http.Client, provider, apiKey, baseURL string) error {
+	var url string
+	var authHeader string
+
+	switch provider {
+	case "openai":
+		url = "https://api.openai.com/v1/models"
+		if baseURL != "" {
+			url = baseURL + "/v1/models"
+		}
+		authHeader = "Bearer " + apiKey
+	case "anthropic":
+		url = "https://api.anthropic.com/v1/models"
+		if baseURL != "" {
+			url = baseURL + "/v1/models"
+		}
+		authHeader = apiKey // Anthropic uses x-api-key header
+	case "google", "gemini":
+		url = fmt.Sprintf("https://generativelanguage.googleapis.com/v1/models?key=%s", apiKey)
+	default:
+		return fmt.Errorf("unsupported LLM provider: %s", provider)
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if provider == "anthropic" {
+		req.Header.Set("x-api-key", authHeader)
+		req.Header.Set("anthropic-version", "2023-06-01")
+	} else if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("connection failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("authentication failed (HTTP %d)", resp.StatusCode)
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("provider returned HTTP %d", resp.StatusCode)
+	}
+
+	slog.Info("web: provider test ok", "type", "llm", "provider", provider, "status", resp.StatusCode)
+	return nil
+}
+
+func testSTTProvider(r *http.Request, client *http.Client, provider, apiKey, baseURL string) error {
+	var url string
+	switch provider {
+	case "deepgram":
+		url = "https://api.deepgram.com/v1/projects"
+		if baseURL != "" {
+			url = baseURL + "/v1/projects"
+		}
+	case "whisper", "openai":
+		url = "https://api.openai.com/v1/models"
+		if baseURL != "" {
+			url = baseURL + "/v1/models"
+		}
+	default:
+		return fmt.Errorf("unsupported STT provider: %s", provider)
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if provider == "deepgram" {
+		req.Header.Set("Authorization", "Token "+apiKey)
+	} else {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("connection failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("authentication failed (HTTP %d)", resp.StatusCode)
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("provider returned HTTP %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func testTTSProvider(r *http.Request, client *http.Client, provider, apiKey, baseURL string) error {
+	var url string
+	switch provider {
+	case "elevenlabs":
+		url = "https://api.elevenlabs.io/v1/voices"
+		if baseURL != "" {
+			url = baseURL + "/v1/voices"
+		}
+	case "openai":
+		url = "https://api.openai.com/v1/models"
+		if baseURL != "" {
+			url = baseURL + "/v1/models"
+		}
+	default:
+		return fmt.Errorf("unsupported TTS provider: %s", provider)
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if provider == "elevenlabs" {
+		req.Header.Set("xi-api-key", apiKey)
+	} else {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("connection failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("authentication failed (HTTP %d)", resp.StatusCode)
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("provider returned HTTP %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -97,6 +97,7 @@ type mockWebStore struct {
 	loreDocs          map[string]*LoreDocument
 	campaignNPCLinks  map[string][]CampaignNPCLink // keyed by campaign_id
 	knowledgeEntities map[string][]KnowledgeEntity // keyed by campaign_id
+	auditLogs         []AuditLogEntry
 }
 
 func newMockWebStore() *mockWebStore {
@@ -119,6 +120,20 @@ func strPtr(s string) *string { return &s }
 func (m *mockWebStore) UpsertDiscordUser(_ context.Context, discordID, email, displayName, avatarURL, tenantID string) (*User, error) {
 	id := "user-" + discordID
 	u := &User{ID: id, TenantID: tenantID, DiscordID: strPtr(discordID), Email: strPtr(email), DisplayName: displayName, AvatarURL: strPtr(avatarURL), Role: "dm"}
+	m.users[id] = u
+	return u, nil
+}
+
+func (m *mockWebStore) UpsertGoogleUser(_ context.Context, googleID, email, displayName, avatarURL, tenantID string) (*User, error) {
+	id := "user-google-" + googleID
+	u := &User{ID: id, TenantID: tenantID, GoogleID: strPtr(googleID), Email: strPtr(email), DisplayName: displayName, AvatarURL: strPtr(avatarURL), Role: "dm"}
+	m.users[id] = u
+	return u, nil
+}
+
+func (m *mockWebStore) UpsertGitHubUser(_ context.Context, githubID, email, displayName, avatarURL, tenantID string) (*User, error) {
+	id := "user-github-" + githubID
+	u := &User{ID: id, TenantID: tenantID, GitHubID: strPtr(githubID), Email: strPtr(email), DisplayName: displayName, AvatarURL: strPtr(avatarURL), Role: "dm"}
 	m.users[id] = u
 	return u, nil
 }
@@ -476,6 +491,71 @@ func (m *mockWebStore) GetRecentActivity(_ context.Context, tenantID string, lim
 		items = items[:limit]
 	}
 	return items, nil
+}
+
+// Audit log mocks.
+
+func (m *mockWebStore) CreateAuditLog(_ context.Context, entry *AuditLogEntry) error {
+	m.auditLogs = append(m.auditLogs, *entry)
+	return nil
+}
+
+func (m *mockWebStore) ListAuditLogs(_ context.Context, tenantID string, limit, offset int, resourceType, action string) ([]AuditLogEntry, int, error) {
+	var filtered []AuditLogEntry
+	for _, e := range m.auditLogs {
+		if tenantID != "" && (e.TenantID == nil || *e.TenantID != tenantID) {
+			continue
+		}
+		if resourceType != "" && e.ResourceType != resourceType {
+			continue
+		}
+		if action != "" && e.Action != action {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	total := len(filtered)
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+	if offset >= len(filtered) {
+		return nil, total, nil
+	}
+	end := offset + limit
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	return filtered[offset:end], total, nil
+}
+
+func (m *mockWebStore) GetAdminDashboardStats(_ context.Context) (*AdminDashboardStats, error) {
+	return &AdminDashboardStats{
+		TotalTenants:      1,
+		TotalUsers:        len(m.users),
+		TotalCampaigns:    len(m.campaigns),
+		ActiveSessions:    0,
+		TotalSessionHours: 0,
+		AuditLogCount:     len(m.auditLogs),
+	}, nil
+}
+
+func (m *mockWebStore) ListAllTenantUsers(_ context.Context, limit, offset int) ([]User, int, error) {
+	var all []User
+	for _, u := range m.users {
+		all = append(all, *u)
+	}
+	total := len(all)
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+	if offset >= len(all) {
+		return nil, total, nil
+	}
+	end := offset + limit
+	if end > len(all) {
+		end = len(all)
+	}
+	return all[offset:end], total, nil
 }
 
 // testServer creates a Server with mock stores for testing.

--- a/internal/web/migrations/004_phase3_audit_oauth.sql
+++ b/internal/web/migrations/004_phase3_audit_oauth.sql
@@ -1,0 +1,37 @@
+-- Phase 3: Audit log + Google/GitHub OAuth support
+
+-- Add Google and GitHub OAuth columns to users.
+ALTER TABLE mgmt.users ADD COLUMN IF NOT EXISTS google_id TEXT;
+ALTER TABLE mgmt.users ADD COLUMN IF NOT EXISTS github_id TEXT;
+
+-- Create unique indexes (only if they don't exist).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_google ON mgmt.users(google_id) WHERE google_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_github ON mgmt.users(github_id) WHERE github_id IS NOT NULL;
+
+-- Audit log: append-only log of all write operations.
+CREATE TABLE IF NOT EXISTS mgmt.audit_log (
+    id              BIGSERIAL   PRIMARY KEY,
+    tenant_id       TEXT,
+    user_id         TEXT,
+    action          TEXT        NOT NULL,
+    resource_type   TEXT        NOT NULL,
+    resource_id     TEXT        NOT NULL,
+    changes         JSONB,
+    ip_address      INET,
+    user_agent      TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_resource
+    ON mgmt.audit_log(resource_type, resource_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_user
+    ON mgmt.audit_log(user_id, created_at DESC)
+    WHERE user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_tenant
+    ON mgmt.audit_log(tenant_id, created_at DESC)
+    WHERE tenant_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_created
+    ON mgmt.audit_log(created_at DESC);

--- a/internal/web/ratelimit.go
+++ b/internal/web/ratelimit.go
@@ -1,0 +1,179 @@
+package web
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// RateLimiter provides in-memory per-key rate limiting using a token bucket.
+// Safe for concurrent use.
+type RateLimiter struct {
+	mu      sync.Mutex
+	buckets map[string]*tokenBucket
+	rate    int           // tokens added per interval
+	burst   int           // max tokens
+	window  time.Duration // refill interval
+}
+
+type tokenBucket struct {
+	tokens    float64
+	lastCheck time.Time
+}
+
+// NewRateLimiter creates a rate limiter that allows rate requests per window
+// with a burst capacity of burst.
+func NewRateLimiter(rate, burst int, window time.Duration) *RateLimiter {
+	rl := &RateLimiter{
+		buckets: make(map[string]*tokenBucket),
+		rate:    rate,
+		burst:   burst,
+		window:  window,
+	}
+	// Start background cleanup goroutine.
+	go rl.cleanup()
+	return rl
+}
+
+// Allow checks if a request with the given key is allowed.
+// Returns true if the request is within limits.
+func (rl *RateLimiter) Allow(key string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	b, ok := rl.buckets[key]
+	if !ok {
+		b = &tokenBucket{
+			tokens:    float64(rl.burst) - 1,
+			lastCheck: now,
+		}
+		rl.buckets[key] = b
+		return true
+	}
+
+	// Refill tokens based on elapsed time.
+	elapsed := now.Sub(b.lastCheck)
+	tokensToAdd := elapsed.Seconds() / rl.window.Seconds() * float64(rl.rate)
+	b.tokens += tokensToAdd
+	if b.tokens > float64(rl.burst) {
+		b.tokens = float64(rl.burst)
+	}
+	b.lastCheck = now
+
+	if b.tokens >= 1 {
+		b.tokens--
+		return true
+	}
+	return false
+}
+
+// Remaining returns the number of tokens remaining for the key.
+func (rl *RateLimiter) Remaining(key string) int {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	b, ok := rl.buckets[key]
+	if !ok {
+		return rl.burst
+	}
+
+	now := time.Now()
+	elapsed := now.Sub(b.lastCheck)
+	tokensToAdd := elapsed.Seconds() / rl.window.Seconds() * float64(rl.rate)
+	tokens := b.tokens + tokensToAdd
+	if tokens > float64(rl.burst) {
+		tokens = float64(rl.burst)
+	}
+	return int(tokens)
+}
+
+func (rl *RateLimiter) cleanup() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		rl.mu.Lock()
+		cutoff := time.Now().Add(-10 * time.Minute)
+		for key, b := range rl.buckets {
+			if b.lastCheck.Before(cutoff) {
+				delete(rl.buckets, key)
+			}
+		}
+		rl.mu.Unlock()
+	}
+}
+
+// rateLimitTiers defines rate limits per role tier.
+var rateLimitTiers = map[string]struct{ read, write int }{
+	"viewer":       {60, 30},
+	"dm":           {60, 30},
+	"tenant_admin": {120, 60},
+	"super_admin":  {300, 120},
+}
+
+// RateLimitMiddleware applies per-user rate limiting based on JWT claims.
+// Uses the user ID as the rate limit key for authenticated requests,
+// and the client IP for unauthenticated requests.
+func RateLimitMiddleware(readLimiter, writeLimiter *RateLimiter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var key string
+			var limiter *RateLimiter
+
+			claims := ClaimsFromContext(r.Context())
+			if claims != nil {
+				key = "user:" + claims.Sub
+			} else {
+				key = "ip:" + clientIP(r)
+			}
+
+			// Select limiter based on method.
+			switch r.Method {
+			case http.MethodGet, http.MethodHead, http.MethodOptions:
+				limiter = readLimiter
+			default:
+				limiter = writeLimiter
+			}
+
+			if !limiter.Allow(key) {
+				remaining := limiter.Remaining(key)
+				w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
+				w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Minute).Unix(), 10))
+				w.Header().Set("Retry-After", "60")
+				writeError(w, http.StatusTooManyRequests, "rate_limited", "too many requests")
+				return
+			}
+
+			remaining := limiter.Remaining(key)
+			w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// clientIP extracts the client IP from the request, respecting X-Forwarded-For.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// Take the first IP in the chain.
+		if i := 0; i < len(xff) {
+			for j, c := range xff {
+				if c == ',' {
+					return xff[:j]
+				}
+				_ = j
+			}
+			return xff
+		}
+	}
+	if xff := r.Header.Get("X-Real-IP"); xff != "" {
+		return xff
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/internal/web/ratelimit.go
+++ b/internal/web/ratelimit.go
@@ -105,14 +105,6 @@ func (rl *RateLimiter) cleanup() {
 	}
 }
 
-// rateLimitTiers defines rate limits per role tier.
-var rateLimitTiers = map[string]struct{ read, write int }{
-	"viewer":       {60, 30},
-	"dm":           {60, 30},
-	"tenant_admin": {120, 60},
-	"super_admin":  {300, 120},
-}
-
 // RateLimitMiddleware applies per-user rate limiting based on JWT claims.
 // Uses the user ID as the rate limit key for authenticated requests,
 // and the client IP for unauthenticated requests.

--- a/internal/web/ratelimit_test.go
+++ b/internal/web/ratelimit_test.go
@@ -1,0 +1,180 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRateLimiter_Allow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		rate      int
+		burst     int
+		requests  int
+		wantAllow int // how many should be allowed
+	}{
+		{
+			name:      "all within burst",
+			rate:      10,
+			burst:     10,
+			requests:  5,
+			wantAllow: 5,
+		},
+		{
+			name:      "exceeds burst",
+			rate:      3,
+			burst:     3,
+			requests:  5,
+			wantAllow: 3,
+		},
+		{
+			name:      "single request always allowed",
+			rate:      1,
+			burst:     1,
+			requests:  1,
+			wantAllow: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rl := NewRateLimiter(tt.rate, tt.burst, time.Minute)
+			var allowed int
+			for i := 0; i < tt.requests; i++ {
+				if rl.Allow("test-key") {
+					allowed++
+				}
+			}
+
+			if allowed != tt.wantAllow {
+				t.Errorf("allowed = %d, want %d", allowed, tt.wantAllow)
+			}
+		})
+	}
+}
+
+func TestRateLimiter_DifferentKeys(t *testing.T) {
+	t.Parallel()
+
+	rl := NewRateLimiter(2, 2, time.Minute)
+
+	// Key A should get its own bucket.
+	if !rl.Allow("a") {
+		t.Error("key a first request should be allowed")
+	}
+	if !rl.Allow("a") {
+		t.Error("key a second request should be allowed")
+	}
+	if rl.Allow("a") {
+		t.Error("key a third request should be denied")
+	}
+
+	// Key B has a separate bucket.
+	if !rl.Allow("b") {
+		t.Error("key b first request should be allowed")
+	}
+}
+
+func TestRateLimiter_Remaining(t *testing.T) {
+	t.Parallel()
+
+	rl := NewRateLimiter(5, 5, time.Minute)
+
+	rem := rl.Remaining("new-key")
+	if rem != 5 {
+		t.Errorf("remaining for new key = %d, want 5", rem)
+	}
+
+	rl.Allow("new-key")
+	rem = rl.Remaining("new-key")
+	if rem != 4 {
+		t.Errorf("remaining after 1 request = %d, want 4", rem)
+	}
+}
+
+func TestRateLimitMiddleware_Blocks(t *testing.T) {
+	t.Parallel()
+
+	readRL := NewRateLimiter(2, 2, time.Minute)
+	writeRL := NewRateLimiter(1, 1, time.Minute)
+
+	handler := RateLimitMiddleware(readRL, writeRL)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First 2 GET requests should pass.
+	for i := 0; i < 2; i++ {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = "192.168.1.1:1234"
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("request %d: status = %d, want %d", i, rr.Code, http.StatusOK)
+		}
+	}
+
+	// Third GET should be rate limited.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.RemoteAddr = "192.168.1.1:1234"
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusTooManyRequests {
+		t.Errorf("third request: status = %d, want %d", rr.Code, http.StatusTooManyRequests)
+	}
+}
+
+func TestClientIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		xff    string
+		xri    string
+		remote string
+		wantIP string
+	}{
+		{
+			name:   "remote addr",
+			remote: "10.0.0.1:8080",
+			wantIP: "10.0.0.1",
+		},
+		{
+			name:   "x-forwarded-for",
+			xff:    "203.0.113.50, 70.41.3.18",
+			remote: "10.0.0.1:8080",
+			wantIP: "203.0.113.50",
+		},
+		{
+			name:   "x-real-ip",
+			xri:    "203.0.113.100",
+			remote: "10.0.0.1:8080",
+			wantIP: "203.0.113.100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remote
+			if tt.xff != "" {
+				req.Header.Set("X-Forwarded-For", tt.xff)
+			}
+			if tt.xri != "" {
+				req.Header.Set("X-Real-IP", tt.xri)
+			}
+
+			got := clientIP(req)
+			if got != tt.wantIP {
+				t.Errorf("clientIP = %q, want %q", got, tt.wantIP)
+			}
+		})
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -10,6 +10,12 @@ import (
 	"github.com/MrWong99/glyphoxa/internal/health"
 )
 
+// defaultReadLimit is the default read rate limit (requests per minute).
+const defaultReadLimit = 60
+
+// defaultWriteLimit is the default write rate limit (requests per minute).
+const defaultWriteLimit = 30
+
 type Server struct {
 	mux            *http.ServeMux
 	cfg            *Config
@@ -18,6 +24,8 @@ type Server struct {
 	gwClient       pb.ManagementServiceClient
 	voicePreview   VoicePreviewProvider
 	voicePreviewRL *voicePreviewRateLimiter
+	readLimiter    *RateLimiter
+	writeLimiter   *RateLimiter
 }
 
 // ServerOption configures optional Server dependencies.
@@ -33,7 +41,15 @@ func WithVoicePreview(vp VoicePreviewProvider) ServerOption {
 
 // NewServer creates a Server and registers all routes.
 func NewServer(cfg *Config, store WebStore, npcs npcstore.Store, gwClient pb.ManagementServiceClient, opts ...ServerOption) *Server {
-	s := &Server{mux: http.NewServeMux(), cfg: cfg, store: store, npcs: npcs, gwClient: gwClient}
+	s := &Server{
+		mux:          http.NewServeMux(),
+		cfg:          cfg,
+		store:        store,
+		npcs:         npcs,
+		gwClient:     gwClient,
+		readLimiter:  NewRateLimiter(defaultReadLimit, defaultReadLimit, time.Minute),
+		writeLimiter: NewRateLimiter(defaultWriteLimit, defaultWriteLimit, time.Minute),
+	}
 	for _, opt := range opts {
 		opt(s)
 	}
@@ -44,6 +60,7 @@ func NewServer(cfg *Config, store WebStore, npcs npcstore.Store, gwClient pb.Man
 func (s *Server) Handler() http.Handler {
 	var h http.Handler = s.mux
 	h = MaxBytesMiddleware(h)
+	h = RateLimitMiddleware(s.readLimiter, s.writeLimiter)(h)
 	h = CORSMiddleware(s.cfg.AllowedOrigins)(h)
 	h = LoggingMiddleware(h)
 	return h
@@ -52,9 +69,16 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) registerRoutes() {
 	hc := health.New(health.Checker{Name: "database", Check: s.store.Ping})
 	hc.Register(s.mux)
+
+	// Public auth routes.
 	s.mux.HandleFunc("GET /api/v1/auth/discord", s.handleDiscordLogin)
 	s.mux.HandleFunc("GET /api/v1/auth/discord/callback", s.handleDiscordCallback)
+	s.mux.HandleFunc("GET /api/v1/auth/google", s.handleGoogleLogin)
+	s.mux.HandleFunc("GET /api/v1/auth/google/callback", s.handleGoogleCallback)
+	s.mux.HandleFunc("GET /api/v1/auth/github", s.handleGitHubLogin)
+	s.mux.HandleFunc("GET /api/v1/auth/github/callback", s.handleGitHubCallback)
 	s.mux.HandleFunc("POST /api/v1/auth/apikey", s.handleAPIKeyLogin)
+	s.mux.HandleFunc("GET /api/v1/auth/providers", s.handleAuthProviders)
 	s.mux.HandleFunc("GET /api/v1/invites/validate", s.handleValidateInvite)
 	auth := AuthMiddleware(s.cfg.JWTSecret)
 	s.mux.Handle("POST /api/v1/onboarding/complete", auth(http.HandlerFunc(s.handleOnboardingComplete)))
@@ -96,6 +120,7 @@ func (s *Server) registerRoutes() {
 
 	// Knowledge management.
 	s.mux.Handle("GET /api/v1/campaigns/{id}/knowledge", auth(http.HandlerFunc(s.handleListKnowledgeEntities)))
+	s.mux.Handle("GET /api/v1/campaigns/{id}/knowledge/graph", auth(http.HandlerFunc(s.handleGetKnowledgeGraph)))
 	s.mux.Handle("DELETE /api/v1/campaigns/{id}/knowledge/{entity_id}", auth(RequireRole("dm")(http.HandlerFunc(s.handleDeleteKnowledgeEntity))))
 	s.mux.Handle("POST /api/v1/campaigns/{id}/knowledge/rebuild", auth(RequireRole("dm")(http.HandlerFunc(s.handleRebuildKnowledgeGraph))))
 
@@ -117,6 +142,16 @@ func (s *Server) registerRoutes() {
 	s.mux.Handle("PUT /api/v1/tenants/{id}", auth(RequireRole("tenant_admin")(http.HandlerFunc(s.handleUpdateTenant))))
 	s.mux.Handle("DELETE /api/v1/tenants/{id}", auth(RequireRole("super_admin")(http.HandlerFunc(s.handleDeleteTenant))))
 	s.mux.Handle("GET /api/v1/usage", auth(RequireRole("tenant_admin")(http.HandlerFunc(s.handleGetUsage))))
+
+	// Audit log.
+	s.mux.Handle("GET /api/v1/audit-logs", auth(RequireRole("tenant_admin")(http.HandlerFunc(s.handleListAuditLogs))))
+
+	// Provider config test.
+	s.mux.Handle("POST /api/v1/providers/test", auth(RequireRole("tenant_admin")(http.HandlerFunc(s.handleTestProvider))))
+
+	// Super admin dashboard.
+	s.mux.Handle("GET /api/v1/admin/stats", auth(RequireRole("super_admin")(http.HandlerFunc(s.handleAdminDashboardStats))))
+	s.mux.Handle("GET /api/v1/admin/users", auth(RequireRole("super_admin")(http.HandlerFunc(s.handleAdminListUsers))))
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/web/store.go
+++ b/internal/web/store.go
@@ -29,6 +29,8 @@ type User struct {
 	ID          string          `json:"id"`
 	TenantID    string          `json:"tenant_id"`
 	DiscordID   *string         `json:"discord_id,omitempty"`
+	GoogleID    *string         `json:"google_id,omitempty"`
+	GitHubID    *string         `json:"github_id,omitempty"`
 	Email       *string         `json:"email,omitempty"`
 	DisplayName string          `json:"display_name"`
 	AvatarURL   *string         `json:"avatar_url,omitempty"`
@@ -101,11 +103,37 @@ type KnowledgeEntity struct {
 	UpdatedAt  time.Time      `json:"updated_at"`
 }
 
+// AuditLogEntry represents a single audit log record.
+type AuditLogEntry struct {
+	ID           int64           `json:"id"`
+	TenantID     *string         `json:"tenant_id,omitempty"`
+	UserID       *string         `json:"user_id,omitempty"`
+	Action       string          `json:"action"`
+	ResourceType string          `json:"resource_type"`
+	ResourceID   string          `json:"resource_id"`
+	Changes      json.RawMessage `json:"changes,omitempty"`
+	IPAddress    *string         `json:"ip_address,omitempty"`
+	UserAgent    *string         `json:"user_agent,omitempty"`
+	CreatedAt    time.Time       `json:"created_at"`
+}
+
+// AdminDashboardStats holds system-wide stats for the super admin dashboard.
+type AdminDashboardStats struct {
+	TotalTenants      int     `json:"total_tenants"`
+	TotalUsers        int     `json:"total_users"`
+	TotalCampaigns    int     `json:"total_campaigns"`
+	ActiveSessions    int     `json:"active_sessions"`
+	TotalSessionHours float64 `json:"total_session_hours"`
+	AuditLogCount     int     `json:"audit_log_count"`
+}
+
 // WebStore defines the data operations required by the web management handlers.
 // Implementations must be safe for concurrent use.
 type WebStore interface {
 	Ping(ctx context.Context) error
 	UpsertDiscordUser(ctx context.Context, discordID, email, displayName, avatarURL, tenantID string) (*User, error)
+	UpsertGoogleUser(ctx context.Context, googleID, email, displayName, avatarURL, tenantID string) (*User, error)
+	UpsertGitHubUser(ctx context.Context, githubID, email, displayName, avatarURL, tenantID string) (*User, error)
 	EnsureAdminUser(ctx context.Context, tenantID string) (*User, error)
 	GetUser(ctx context.Context, id string) (*User, error)
 	ListUsers(ctx context.Context, tenantID, role string, limit, offset int) ([]User, int, error)
@@ -145,6 +173,14 @@ type WebStore interface {
 	// Dashboard.
 	GetDashboardStats(ctx context.Context, tenantID string) (*DashboardStats, error)
 	GetRecentActivity(ctx context.Context, tenantID string, limit int) ([]ActivityItem, error)
+
+	// Audit log.
+	CreateAuditLog(ctx context.Context, entry *AuditLogEntry) error
+	ListAuditLogs(ctx context.Context, tenantID string, limit, offset int, resourceType, action string) ([]AuditLogEntry, int, error)
+
+	// Admin dashboard.
+	GetAdminDashboardStats(ctx context.Context) (*AdminDashboardStats, error)
+	ListAllTenantUsers(ctx context.Context, limit, offset int) ([]User, int, error)
 }
 
 // Compile-time assertion that *Store implements WebStore.
@@ -1026,4 +1062,199 @@ func (s *Store) GetRecentActivity(ctx context.Context, tenantID string, limit in
 	}
 
 	return items, nil
+}
+
+// UpsertGoogleUser creates or updates a user based on their Google ID.
+func (s *Store) UpsertGoogleUser(ctx context.Context, googleID, email, displayName, avatarURL, tenantID string) (*User, error) {
+	id := uuid.NewString()
+	now := time.Now().UTC()
+
+	var user User
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO mgmt.users (id, tenant_id, google_id, email, display_name, avatar_url, role, last_login_at, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, 'dm', $7, $7, $7)
+		ON CONFLICT (google_id) DO UPDATE SET
+			email = COALESCE(EXCLUDED.email, mgmt.users.email),
+			display_name = EXCLUDED.display_name,
+			avatar_url = EXCLUDED.avatar_url,
+			last_login_at = EXCLUDED.last_login_at,
+			updated_at = EXCLUDED.updated_at
+		RETURNING id, tenant_id, google_id, email, display_name, avatar_url, role, last_login_at, created_at, updated_at
+	`, id, tenantID, googleID, email, displayName, avatarURL, now).Scan(
+		&user.ID, &user.TenantID, &user.GoogleID, &user.Email,
+		&user.DisplayName, &user.AvatarURL, &user.Role, &user.LastLoginAt,
+		&user.CreatedAt, &user.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("web: upsert google user: %w", err)
+	}
+	return &user, nil
+}
+
+// UpsertGitHubUser creates or updates a user based on their GitHub ID.
+func (s *Store) UpsertGitHubUser(ctx context.Context, githubID, email, displayName, avatarURL, tenantID string) (*User, error) {
+	id := uuid.NewString()
+	now := time.Now().UTC()
+
+	var user User
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO mgmt.users (id, tenant_id, github_id, email, display_name, avatar_url, role, last_login_at, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, 'dm', $7, $7, $7)
+		ON CONFLICT (github_id) DO UPDATE SET
+			email = COALESCE(EXCLUDED.email, mgmt.users.email),
+			display_name = EXCLUDED.display_name,
+			avatar_url = EXCLUDED.avatar_url,
+			last_login_at = EXCLUDED.last_login_at,
+			updated_at = EXCLUDED.updated_at
+		RETURNING id, tenant_id, github_id, email, display_name, avatar_url, role, last_login_at, created_at, updated_at
+	`, id, tenantID, githubID, email, displayName, avatarURL, now).Scan(
+		&user.ID, &user.TenantID, &user.GitHubID, &user.Email,
+		&user.DisplayName, &user.AvatarURL, &user.Role, &user.LastLoginAt,
+		&user.CreatedAt, &user.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("web: upsert github user: %w", err)
+	}
+	return &user, nil
+}
+
+// CreateAuditLog inserts a new audit log entry.
+func (s *Store) CreateAuditLog(ctx context.Context, entry *AuditLogEntry) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO mgmt.audit_log (tenant_id, user_id, action, resource_type, resource_id, changes, ip_address, user_agent, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7::INET, $8, COALESCE($9, now()))
+	`, entry.TenantID, entry.UserID, entry.Action, entry.ResourceType, entry.ResourceID,
+		entry.Changes, entry.IPAddress, entry.UserAgent, entry.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("web: create audit log: %w", err)
+	}
+	return nil
+}
+
+// ListAuditLogs returns audit log entries with pagination and optional filtering.
+func (s *Store) ListAuditLogs(ctx context.Context, tenantID string, limit, offset int, resourceType, action string) ([]AuditLogEntry, int, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+
+	// Build WHERE clause dynamically.
+	where := "WHERE 1=1"
+	args := []any{}
+	argIdx := 1
+
+	if tenantID != "" {
+		where += fmt.Sprintf(" AND tenant_id = $%d", argIdx)
+		args = append(args, tenantID)
+		argIdx++
+	}
+	if resourceType != "" {
+		where += fmt.Sprintf(" AND resource_type = $%d", argIdx)
+		args = append(args, resourceType)
+		argIdx++
+	}
+	if action != "" {
+		where += fmt.Sprintf(" AND action = $%d", argIdx)
+		args = append(args, action)
+		argIdx++
+	}
+
+	// Count total.
+	var total int
+	countQuery := "SELECT COUNT(*) FROM mgmt.audit_log " + where
+	if err := s.pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("web: count audit logs: %w", err)
+	}
+
+	// Fetch entries.
+	query := fmt.Sprintf(`SELECT id, tenant_id, user_id, action, resource_type, resource_id, changes, ip_address::TEXT, user_agent, created_at
+		FROM mgmt.audit_log %s ORDER BY created_at DESC LIMIT $%d OFFSET $%d`, where, argIdx, argIdx+1)
+	args = append(args, limit, offset)
+
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("web: list audit logs: %w", err)
+	}
+	defer rows.Close()
+
+	var entries []AuditLogEntry
+	for rows.Next() {
+		var e AuditLogEntry
+		if err := rows.Scan(&e.ID, &e.TenantID, &e.UserID, &e.Action, &e.ResourceType, &e.ResourceID, &e.Changes, &e.IPAddress, &e.UserAgent, &e.CreatedAt); err != nil {
+			return nil, 0, fmt.Errorf("web: scan audit log entry: %w", err)
+		}
+		entries = append(entries, e)
+	}
+	return entries, total, nil
+}
+
+// GetAdminDashboardStats returns system-wide aggregate stats for the super admin dashboard.
+func (s *Store) GetAdminDashboardStats(ctx context.Context) (*AdminDashboardStats, error) {
+	stats := &AdminDashboardStats{}
+
+	// Count tenants.
+	if err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.tenants`).Scan(&stats.TotalTenants); err != nil {
+		slog.Warn("web: admin stats count tenants", "err", err)
+	}
+
+	// Count users.
+	if err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM mgmt.users WHERE deleted_at IS NULL`).Scan(&stats.TotalUsers); err != nil {
+		slog.Warn("web: admin stats count users", "err", err)
+	}
+
+	// Count campaigns.
+	if err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM mgmt.campaigns WHERE deleted_at IS NULL`).Scan(&stats.TotalCampaigns); err != nil {
+		slog.Warn("web: admin stats count campaigns", "err", err)
+	}
+
+	// Active sessions.
+	if err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.sessions WHERE state = 'running'`).Scan(&stats.ActiveSessions); err != nil {
+		slog.Warn("web: admin stats active sessions", "err", err)
+	}
+
+	// Total session hours this month.
+	now := time.Now().UTC()
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	if err := s.pool.QueryRow(ctx, `SELECT COALESCE(SUM(session_hours), 0) FROM public.usage_records WHERE period >= $1`, monthStart).Scan(&stats.TotalSessionHours); err != nil {
+		slog.Warn("web: admin stats session hours", "err", err)
+	}
+
+	// Audit log count.
+	if err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM mgmt.audit_log`).Scan(&stats.AuditLogCount); err != nil {
+		slog.Warn("web: admin stats audit count", "err", err)
+	}
+
+	return stats, nil
+}
+
+// ListAllTenantUsers returns all users across all tenants (super_admin use).
+func (s *Store) ListAllTenantUsers(ctx context.Context, limit, offset int) ([]User, int, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+
+	var total int
+	if err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM mgmt.users WHERE deleted_at IS NULL`).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("web: count all users: %w", err)
+	}
+
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, tenant_id, discord_id, email, display_name, avatar_url, role, last_login_at, created_at, updated_at
+		FROM mgmt.users WHERE deleted_at IS NULL
+		ORDER BY created_at DESC
+		LIMIT $1 OFFSET $2
+	`, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("web: list all users: %w", err)
+	}
+	defer rows.Close()
+
+	var users []User
+	for rows.Next() {
+		var u User
+		if err := rows.Scan(&u.ID, &u.TenantID, &u.DiscordID, &u.Email, &u.DisplayName, &u.AvatarURL, &u.Role, &u.LastLoginAt, &u.CreatedAt, &u.UpdatedAt); err != nil {
+			return nil, 0, fmt.Errorf("web: scan user: %w", err)
+		}
+		users = append(users, u)
+	}
+	return users, total, nil
 }

--- a/web/src/app/(app)/admin/audit-log/page.tsx
+++ b/web/src/app/(app)/admin/audit-log/page.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { useAuditLogs, useHasRole } from "@/lib/hooks";
+import { formatDate } from "@/lib/utils";
+import { ChevronLeft, ChevronRight, ShieldAlert, ScrollText } from "lucide-react";
+
+const RESOURCE_TYPES = [
+  { value: "", label: "All Resources" },
+  { value: "campaign", label: "Campaign" },
+  { value: "npc", label: "NPC" },
+  { value: "user", label: "User" },
+  { value: "tenant", label: "Tenant" },
+  { value: "session", label: "Session" },
+  { value: "provider", label: "Provider" },
+];
+
+export default function AuditLogPage() {
+  const isAdmin = useHasRole("tenant_admin");
+  const [offset, setOffset] = useState(0);
+  const [resourceType, setResourceType] = useState("");
+  const [actionFilter, setActionFilter] = useState("");
+  const limit = 25;
+
+  const { data, isLoading } = useAuditLogs({
+    limit,
+    offset,
+    resource_type: resourceType || undefined,
+    action: actionFilter || undefined,
+  });
+
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-20">
+        <ShieldAlert className="h-12 w-12 text-muted-foreground/40" />
+        <h2 className="text-xl font-semibold">Access Denied</h2>
+        <p className="text-muted-foreground">
+          This page requires at least tenant admin access.
+        </p>
+      </div>
+    );
+  }
+
+  const entries = data?.data ?? [];
+  const total = data?.total ?? 0;
+  const hasNext = offset + limit < total;
+  const hasPrev = offset > 0;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Audit Log</h1>
+        <p className="text-muted-foreground">
+          Track all changes made across your tenant
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3">
+        <Select
+          value={resourceType}
+          onValueChange={(v) => {
+            setResourceType(v ?? "");
+            setOffset(0);
+          }}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="All Resources" />
+          </SelectTrigger>
+          <SelectContent>
+            {RESOURCE_TYPES.map((rt) => (
+              <SelectItem key={rt.value} value={rt.value}>
+                {rt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Input
+          placeholder="Filter by action..."
+          value={actionFilter}
+          onChange={(e) => {
+            setActionFilter(e.target.value);
+            setOffset(0);
+          }}
+          className="w-[220px]"
+        />
+      </div>
+
+      {/* Audit Log Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ScrollText className="h-5 w-5" />
+            Entries ({total})
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Time</TableHead>
+                <TableHead>Action</TableHead>
+                <TableHead>Resource</TableHead>
+                <TableHead>User</TableHead>
+                <TableHead>IP</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                Array.from({ length: 5 }).map((_, i) => (
+                  <TableRow key={i}>
+                    {Array.from({ length: 5 }).map((_, j) => (
+                      <TableCell key={j}>
+                        <span className="inline-block h-4 w-20 animate-pulse rounded bg-muted" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : entries.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={5}
+                    className="text-center text-muted-foreground"
+                  >
+                    No audit log entries found
+                  </TableCell>
+                </TableRow>
+              ) : (
+                entries.map((entry) => (
+                  <TableRow key={entry.id}>
+                    <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+                      {formatDate(entry.created_at)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className="font-mono text-xs">
+                        {entry.action}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <span className="font-mono text-xs">
+                        {entry.resource_type}/{entry.resource_id.slice(0, 8)}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {entry.user_id?.slice(0, 8) ?? "system"}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {entry.ip_address ?? "—"}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+
+          {/* Pagination */}
+          {total > limit && (
+            <div className="flex items-center justify-between pt-4">
+              <p className="text-sm text-muted-foreground">
+                Showing {offset + 1}–{Math.min(offset + limit, total)} of{" "}
+                {total}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!hasPrev}
+                  onClick={() => setOffset(Math.max(0, offset - limit))}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!hasNext}
+                  onClick={() => setOffset(offset + limit)}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/app/(app)/admin/page.tsx
+++ b/web/src/app/(app)/admin/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { useAdminStats, useAdminUsers, useHasRole } from "@/lib/hooks";
+import { formatRelativeTime } from "@/lib/utils";
+import {
+  Building2,
+  Users,
+  Swords,
+  Radio,
+  Clock,
+  ScrollText,
+  ShieldAlert,
+} from "lucide-react";
+import Link from "next/link";
+
+export default function AdminDashboardPage() {
+  const isAdmin = useHasRole("super_admin");
+  const { data: stats, isLoading: statsLoading } = useAdminStats();
+  const { data: usersResp } = useAdminUsers({ limit: 10 });
+
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-20">
+        <ShieldAlert className="h-12 w-12 text-muted-foreground/40" />
+        <h2 className="text-xl font-semibold">Access Denied</h2>
+        <p className="text-muted-foreground">
+          This page is restricted to super administrators.
+        </p>
+      </div>
+    );
+  }
+
+  const statCards = [
+    {
+      label: "Total Tenants",
+      value: stats?.total_tenants ?? 0,
+      icon: Building2,
+    },
+    {
+      label: "Total Users",
+      value: stats?.total_users ?? 0,
+      icon: Users,
+    },
+    {
+      label: "Total Campaigns",
+      value: stats?.total_campaigns ?? 0,
+      icon: Swords,
+    },
+    {
+      label: "Active Sessions",
+      value: stats?.active_sessions ?? 0,
+      icon: Radio,
+    },
+    {
+      label: "Session Hours (Month)",
+      value: stats?.total_session_hours?.toFixed(1) ?? "0",
+      icon: Clock,
+    },
+    {
+      label: "Audit Log Entries",
+      value: stats?.audit_log_count ?? 0,
+      icon: ScrollText,
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          Admin Dashboard
+        </h1>
+        <p className="text-muted-foreground">
+          System-wide overview for super administrators
+        </p>
+      </div>
+
+      {/* Stats Grid */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {statCards.map((card) => (
+          <Card key={card.label}>
+            <CardContent className="flex items-center gap-4 p-6">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                <card.icon className="h-5 w-5 text-primary" />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">{card.label}</p>
+                <p className="text-2xl font-bold">
+                  {statsLoading ? (
+                    <span className="inline-block h-7 w-12 animate-pulse rounded bg-muted" />
+                  ) : (
+                    card.value
+                  )}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Recent Users */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Recent Users</CardTitle>
+          <Link
+            href="/admin/audit-log"
+            className="text-sm text-primary hover:underline"
+          >
+            View Audit Log
+          </Link>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Tenant</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Joined</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {usersResp?.data?.map((user) => (
+                <TableRow key={user.id}>
+                  <TableCell className="font-medium">
+                    {user.display_name}
+                  </TableCell>
+                  <TableCell>
+                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                      {user.tenant_id || "—"}
+                    </code>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={user.role === "super_admin" ? "default" : "secondary"}>
+                      {user.role}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {formatRelativeTime(user.created_at)}
+                  </TableCell>
+                </TableRow>
+              ))}
+              {(!usersResp?.data || usersResp.data.length === 0) && (
+                <TableRow>
+                  <TableCell
+                    colSpan={4}
+                    className="text-center text-muted-foreground"
+                  >
+                    No users found
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/app/(app)/campaigns/[id]/knowledge/knowledge-graph.tsx
+++ b/web/src/app/(app)/campaigns/[id]/knowledge/knowledge-graph.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import type { KnowledgeEntity, KnowledgeRelationship } from "@/lib/types";
+
+// Color palette for entity types.
+const TYPE_COLORS: Record<string, string> = {
+  npc: "#60a5fa",     // blue
+  player: "#34d399",  // green
+  location: "#fbbf24", // yellow
+  item: "#a78bfa",    // purple
+  faction: "#f87171", // red
+  event: "#fb923c",   // orange
+  quest: "#2dd4bf",   // teal
+  concept: "#e879f9", // pink
+};
+
+function getColor(type: string): string {
+  return TYPE_COLORS[type] ?? "#94a3b8"; // gray fallback
+}
+
+interface Node {
+  id: string;
+  name: string;
+  type: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+}
+
+interface Edge {
+  source: string;
+  target: string;
+  label: string;
+}
+
+interface Props {
+  entities: KnowledgeEntity[];
+  relationships: KnowledgeRelationship[];
+}
+
+export function KnowledgeGraphVisualization({ entities, relationships }: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [nodes, setNodes] = useState<Node[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [hoveredNode, setHoveredNode] = useState<string | null>(null);
+  const [draggedNode, setDraggedNode] = useState<string | null>(null);
+  const animFrameRef = useRef<number>(0);
+  const nodesRef = useRef<Node[]>([]);
+
+  const width = 800;
+  const height = 500;
+
+  // Initialize nodes with random positions.
+  useEffect(() => {
+    const newNodes: Node[] = entities.map((e, i) => {
+      const angle = (2 * Math.PI * i) / entities.length;
+      const radius = Math.min(width, height) * 0.3;
+      return {
+        id: e.id,
+        name: e.name,
+        type: e.type,
+        x: width / 2 + radius * Math.cos(angle) + (Math.random() - 0.5) * 40,
+        y: height / 2 + radius * Math.sin(angle) + (Math.random() - 0.5) * 40,
+        vx: 0,
+        vy: 0,
+      };
+    });
+
+    const newEdges: Edge[] = relationships.map((r) => ({
+      source: r.source_id,
+      target: r.target_id,
+      label: r.rel_type,
+    }));
+
+    nodesRef.current = newNodes;
+    setNodes(newNodes);
+    setEdges(newEdges);
+  }, [entities, relationships]);
+
+  // Simple force simulation.
+  const simulate = useCallback(() => {
+    const ns = nodesRef.current;
+    if (ns.length === 0) return;
+
+    const alpha = 0.1;
+    const repulsion = 2000;
+    const attraction = 0.005;
+    const centerForce = 0.01;
+
+    // Repulsion between all node pairs.
+    for (let i = 0; i < ns.length; i++) {
+      for (let j = i + 1; j < ns.length; j++) {
+        const dx = ns[i].x - ns[j].x;
+        const dy = ns[i].y - ns[j].y;
+        const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+        const force = repulsion / (dist * dist);
+        const fx = (dx / dist) * force * alpha;
+        const fy = (dy / dist) * force * alpha;
+        ns[i].vx += fx;
+        ns[i].vy += fy;
+        ns[j].vx -= fx;
+        ns[j].vy -= fy;
+      }
+    }
+
+    // Attraction along edges.
+    const nodeMap = new Map(ns.map((n) => [n.id, n]));
+    for (const edge of edges) {
+      const s = nodeMap.get(edge.source);
+      const t = nodeMap.get(edge.target);
+      if (!s || !t) continue;
+      const dx = t.x - s.x;
+      const dy = t.y - s.y;
+      const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+      const force = dist * attraction * alpha;
+      s.vx += (dx / dist) * force;
+      s.vy += (dy / dist) * force;
+      t.vx -= (dx / dist) * force;
+      t.vy -= (dy / dist) * force;
+    }
+
+    // Center gravity + velocity decay.
+    for (const n of ns) {
+      if (n.id === draggedNode) continue;
+      n.vx += (width / 2 - n.x) * centerForce * alpha;
+      n.vy += (height / 2 - n.y) * centerForce * alpha;
+      n.vx *= 0.85;
+      n.vy *= 0.85;
+      n.x += n.vx;
+      n.y += n.vy;
+      // Clamp to bounds.
+      n.x = Math.max(30, Math.min(width - 30, n.x));
+      n.y = Math.max(30, Math.min(height - 30, n.y));
+    }
+
+    setNodes([...ns]);
+    animFrameRef.current = requestAnimationFrame(simulate);
+  }, [edges, draggedNode]);
+
+  useEffect(() => {
+    animFrameRef.current = requestAnimationFrame(simulate);
+    return () => cancelAnimationFrame(animFrameRef.current);
+  }, [simulate]);
+
+  const nodeMap = new Map(nodes.map((n) => [n.id, n]));
+
+  function handleMouseDown(nodeId: string) {
+    setDraggedNode(nodeId);
+  }
+
+  function handleMouseMove(e: React.MouseEvent<SVGSVGElement>) {
+    if (!draggedNode || !svgRef.current) return;
+    const rect = svgRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const node = nodesRef.current.find((n) => n.id === draggedNode);
+    if (node) {
+      node.x = x;
+      node.y = y;
+      node.vx = 0;
+      node.vy = 0;
+    }
+  }
+
+  function handleMouseUp() {
+    setDraggedNode(null);
+  }
+
+  return (
+    <svg
+      ref={svgRef}
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full rounded-lg border border-border/50 bg-background"
+      style={{ minHeight: 400 }}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+    >
+      <defs>
+        <marker
+          id="arrowhead"
+          markerWidth="6"
+          markerHeight="4"
+          refX="6"
+          refY="2"
+          orient="auto"
+        >
+          <polygon points="0 0, 6 2, 0 4" fill="currentColor" className="text-muted-foreground/40" />
+        </marker>
+      </defs>
+
+      {/* Edges */}
+      {edges.map((edge, i) => {
+        const s = nodeMap.get(edge.source);
+        const t = nodeMap.get(edge.target);
+        if (!s || !t) return null;
+        const isHighlighted =
+          hoveredNode === edge.source || hoveredNode === edge.target;
+
+        return (
+          <g key={i}>
+            <line
+              x1={s.x}
+              y1={s.y}
+              x2={t.x}
+              y2={t.y}
+              stroke={isHighlighted ? "currentColor" : "currentColor"}
+              className={
+                isHighlighted
+                  ? "text-primary/60"
+                  : "text-muted-foreground/20"
+              }
+              strokeWidth={isHighlighted ? 2 : 1}
+              markerEnd="url(#arrowhead)"
+            />
+            {isHighlighted && (
+              <text
+                x={(s.x + t.x) / 2}
+                y={(s.y + t.y) / 2 - 6}
+                fill="currentColor"
+                className="text-muted-foreground"
+                fontSize="10"
+                textAnchor="middle"
+              >
+                {edge.label}
+              </text>
+            )}
+          </g>
+        );
+      })}
+
+      {/* Nodes */}
+      {nodes.map((node) => {
+        const isHovered = hoveredNode === node.id;
+        const color = getColor(node.type);
+        const r = isHovered ? 10 : 7;
+
+        return (
+          <g
+            key={node.id}
+            onMouseEnter={() => setHoveredNode(node.id)}
+            onMouseLeave={() => setHoveredNode(null)}
+            onMouseDown={() => handleMouseDown(node.id)}
+            style={{ cursor: draggedNode === node.id ? "grabbing" : "grab" }}
+          >
+            <circle
+              cx={node.x}
+              cy={node.y}
+              r={r + 2}
+              fill={color}
+              opacity={0.15}
+            />
+            <circle cx={node.x} cy={node.y} r={r} fill={color} />
+            <text
+              x={node.x}
+              y={node.y + r + 14}
+              fill="currentColor"
+              className="text-foreground"
+              fontSize="11"
+              fontWeight={isHovered ? "bold" : "normal"}
+              textAnchor="middle"
+            >
+              {node.name.length > 18
+                ? node.name.slice(0, 16) + "..."
+                : node.name}
+            </text>
+            {isHovered && (
+              <text
+                x={node.x}
+                y={node.y - r - 6}
+                fill={color}
+                fontSize="9"
+                textAnchor="middle"
+              >
+                {node.type}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/web/src/app/(app)/campaigns/[id]/knowledge/knowledge-graph.tsx
+++ b/web/src/app/(app)/campaigns/[id]/knowledge/knowledge-graph.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { KnowledgeEntity, KnowledgeRelationship } from "@/lib/types";
 
 // Color palette for entity types.
@@ -29,120 +29,117 @@ interface Node {
   vy: number;
 }
 
-interface Edge {
-  source: string;
-  target: string;
-  label: string;
-}
-
 interface Props {
   entities: KnowledgeEntity[];
   relationships: KnowledgeRelationship[];
 }
 
+const W = 800;
+const H = 500;
+
+function initNodes(ents: KnowledgeEntity[]): Node[] {
+  return ents.map((e, i) => {
+    const angle = (2 * Math.PI * i) / ents.length;
+    const radius = Math.min(W, H) * 0.3;
+    return {
+      id: e.id,
+      name: e.name,
+      type: e.type,
+      x: W / 2 + radius * Math.cos(angle) + (Math.random() - 0.5) * 40,
+      y: H / 2 + radius * Math.sin(angle) + (Math.random() - 0.5) * 40,
+      vx: 0,
+      vy: 0,
+    };
+  });
+}
+
 export function KnowledgeGraphVisualization({ entities, relationships }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
-  const [nodes, setNodes] = useState<Node[]>([]);
-  const [edges, setEdges] = useState<Edge[]>([]);
   const [hoveredNode, setHoveredNode] = useState<string | null>(null);
   const [draggedNode, setDraggedNode] = useState<string | null>(null);
-  const animFrameRef = useRef<number>(0);
-  const nodesRef = useRef<Node[]>([]);
 
-  const width = 800;
-  const height = 500;
+  // Derive edges from relationships (no mutation needed).
+  const edges = useMemo(
+    () => relationships.map((r) => ({ source: r.source_id, target: r.target_id, label: r.rel_type })),
+    [relationships],
+  );
 
-  // Initialize nodes with random positions.
+  // Reset nodes when entities change.
+  const [nodes, setNodes] = useState<Node[]>(() => initNodes(entities));
+  const [prevEntities, setPrevEntities] = useState(entities);
+  if (entities !== prevEntities) {
+    setPrevEntities(entities);
+    setNodes(initNodes(entities));
+  }
+
+  // Force simulation via requestAnimationFrame.
   useEffect(() => {
-    const newNodes: Node[] = entities.map((e, i) => {
-      const angle = (2 * Math.PI * i) / entities.length;
-      const radius = Math.min(width, height) * 0.3;
-      return {
-        id: e.id,
-        name: e.name,
-        type: e.type,
-        x: width / 2 + radius * Math.cos(angle) + (Math.random() - 0.5) * 40,
-        y: height / 2 + radius * Math.sin(angle) + (Math.random() - 0.5) * 40,
-        vx: 0,
-        vy: 0,
-      };
-    });
+    let frameId: number;
 
-    const newEdges: Edge[] = relationships.map((r) => ({
-      source: r.source_id,
-      target: r.target_id,
-      label: r.rel_type,
-    }));
+    function tick() {
+      setNodes((prev) => {
+        if (prev.length === 0) return prev;
+        const ns = prev.map((n) => ({ ...n }));
 
-    nodesRef.current = newNodes;
-    setNodes(newNodes);
-    setEdges(newEdges);
-  }, [entities, relationships]);
+        const alpha = 0.1;
+        const repulsion = 2000;
+        const attraction = 0.005;
+        const centerForce = 0.01;
 
-  // Simple force simulation.
-  const simulate = useCallback(() => {
-    const ns = nodesRef.current;
-    if (ns.length === 0) return;
+        // Repulsion between all node pairs.
+        for (let i = 0; i < ns.length; i++) {
+          for (let j = i + 1; j < ns.length; j++) {
+            const dx = ns[i].x - ns[j].x;
+            const dy = ns[i].y - ns[j].y;
+            const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+            const force = repulsion / (dist * dist);
+            const fx = (dx / dist) * force * alpha;
+            const fy = (dy / dist) * force * alpha;
+            ns[i].vx += fx;
+            ns[i].vy += fy;
+            ns[j].vx -= fx;
+            ns[j].vy -= fy;
+          }
+        }
 
-    const alpha = 0.1;
-    const repulsion = 2000;
-    const attraction = 0.005;
-    const centerForce = 0.01;
+        // Attraction along edges.
+        const nodeMap = new Map(ns.map((n) => [n.id, n]));
+        for (const edge of edges) {
+          const s = nodeMap.get(edge.source);
+          const t = nodeMap.get(edge.target);
+          if (!s || !t) continue;
+          const dx = t.x - s.x;
+          const dy = t.y - s.y;
+          const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+          const force = dist * attraction * alpha;
+          s.vx += (dx / dist) * force;
+          s.vy += (dy / dist) * force;
+          t.vx -= (dx / dist) * force;
+          t.vy -= (dy / dist) * force;
+        }
 
-    // Repulsion between all node pairs.
-    for (let i = 0; i < ns.length; i++) {
-      for (let j = i + 1; j < ns.length; j++) {
-        const dx = ns[i].x - ns[j].x;
-        const dy = ns[i].y - ns[j].y;
-        const dist = Math.sqrt(dx * dx + dy * dy) || 1;
-        const force = repulsion / (dist * dist);
-        const fx = (dx / dist) * force * alpha;
-        const fy = (dy / dist) * force * alpha;
-        ns[i].vx += fx;
-        ns[i].vy += fy;
-        ns[j].vx -= fx;
-        ns[j].vy -= fy;
-      }
+        // Center gravity + velocity decay.
+        for (const n of ns) {
+          if (n.id === draggedNode) continue;
+          n.vx += (W / 2 - n.x) * centerForce * alpha;
+          n.vy += (H / 2 - n.y) * centerForce * alpha;
+          n.vx *= 0.85;
+          n.vy *= 0.85;
+          n.x += n.vx;
+          n.y += n.vy;
+          // Clamp to bounds.
+          n.x = Math.max(30, Math.min(W - 30, n.x));
+          n.y = Math.max(30, Math.min(H - 30, n.y));
+        }
+
+        return ns;
+      });
+      frameId = requestAnimationFrame(tick);
     }
 
-    // Attraction along edges.
-    const nodeMap = new Map(ns.map((n) => [n.id, n]));
-    for (const edge of edges) {
-      const s = nodeMap.get(edge.source);
-      const t = nodeMap.get(edge.target);
-      if (!s || !t) continue;
-      const dx = t.x - s.x;
-      const dy = t.y - s.y;
-      const dist = Math.sqrt(dx * dx + dy * dy) || 1;
-      const force = dist * attraction * alpha;
-      s.vx += (dx / dist) * force;
-      s.vy += (dy / dist) * force;
-      t.vx -= (dx / dist) * force;
-      t.vy -= (dy / dist) * force;
-    }
-
-    // Center gravity + velocity decay.
-    for (const n of ns) {
-      if (n.id === draggedNode) continue;
-      n.vx += (width / 2 - n.x) * centerForce * alpha;
-      n.vy += (height / 2 - n.y) * centerForce * alpha;
-      n.vx *= 0.85;
-      n.vy *= 0.85;
-      n.x += n.vx;
-      n.y += n.vy;
-      // Clamp to bounds.
-      n.x = Math.max(30, Math.min(width - 30, n.x));
-      n.y = Math.max(30, Math.min(height - 30, n.y));
-    }
-
-    setNodes([...ns]);
-    animFrameRef.current = requestAnimationFrame(simulate);
+    frameId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frameId);
   }, [edges, draggedNode]);
-
-  useEffect(() => {
-    animFrameRef.current = requestAnimationFrame(simulate);
-    return () => cancelAnimationFrame(animFrameRef.current);
-  }, [simulate]);
 
   const nodeMap = new Map(nodes.map((n) => [n.id, n]));
 
@@ -155,13 +152,9 @@ export function KnowledgeGraphVisualization({ entities, relationships }: Props) 
     const rect = svgRef.current.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
-    const node = nodesRef.current.find((n) => n.id === draggedNode);
-    if (node) {
-      node.x = x;
-      node.y = y;
-      node.vx = 0;
-      node.vy = 0;
-    }
+    setNodes((prev) =>
+      prev.map((n) => (n.id === draggedNode ? { ...n, x, y, vx: 0, vy: 0 } : n)),
+    );
   }
 
   function handleMouseUp() {
@@ -171,7 +164,7 @@ export function KnowledgeGraphVisualization({ entities, relationships }: Props) 
   return (
     <svg
       ref={svgRef}
-      viewBox={`0 0 ${width} ${height}`}
+      viewBox={`0 0 ${W} ${H}`}
       className="w-full rounded-lg border border-border/50 bg-background"
       style={{ minHeight: 400 }}
       onMouseMove={handleMouseMove}

--- a/web/src/app/(app)/campaigns/[id]/knowledge/page.tsx
+++ b/web/src/app/(app)/campaigns/[id]/knowledge/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { useCampaign, useKnowledgeGraph } from "@/lib/hooks";
+import { Loader2, Network, AlertTriangle } from "lucide-react";
+import { KnowledgeGraphVisualization } from "./knowledge-graph";
+
+export default function KnowledgeGraphPage() {
+  const { id } = useParams<{ id: string }>();
+  const { data: campaign, isLoading: campaignLoading } = useCampaign(id);
+  const { data: graphData, isLoading: graphLoading } = useKnowledgeGraph(id);
+
+  if (campaignLoading || graphLoading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!campaign) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-20">
+        <AlertTriangle className="h-12 w-12 text-muted-foreground/40" />
+        <h2 className="text-xl font-semibold">Campaign not found</h2>
+      </div>
+    );
+  }
+
+  const entities = graphData?.entities ?? [];
+  const relationships = graphData?.relationships ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          Knowledge Graph
+        </h1>
+        <p className="text-muted-foreground">
+          {campaign.name} — {entities.length} entities, {relationships.length}{" "}
+          relationships
+        </p>
+      </div>
+
+      {/* Entity Type Legend */}
+      <div className="flex flex-wrap gap-2">
+        {Array.from(new Set(entities.map((e) => e.type))).map((type) => (
+          <Badge key={type} variant="outline">
+            {type} ({entities.filter((e) => e.type === type).length})
+          </Badge>
+        ))}
+      </div>
+
+      {/* Graph Visualization */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Network className="h-5 w-5" />
+            Entity Relationships
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {entities.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-4 py-16">
+              <Network className="h-12 w-12 text-muted-foreground/30" />
+              <p className="text-muted-foreground">
+                No knowledge entities yet. Run a session to start building the
+                knowledge graph.
+              </p>
+            </div>
+          ) : (
+            <KnowledgeGraphVisualization
+              entities={entities}
+              relationships={relationships}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Entity List */}
+      <Card>
+        <CardHeader>
+          <CardTitle>All Entities</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {entities.map((entity) => (
+              <div
+                key={entity.id}
+                className="rounded-lg border border-border/50 p-3 space-y-1"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-sm">{entity.name}</span>
+                  <Badge variant="secondary" className="text-xs">
+                    {entity.type}
+                  </Badge>
+                </div>
+                {entity.attributes &&
+                  Object.keys(entity.attributes).length > 0 && (
+                    <div className="text-xs text-muted-foreground">
+                      {Object.entries(entity.attributes)
+                        .filter(([k]) => k !== "relationships")
+                        .slice(0, 3)
+                        .map(([k, v]) => (
+                          <span key={k} className="mr-2">
+                            {k}: {String(v)}
+                          </span>
+                        ))}
+                    </div>
+                  )}
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/app/(app)/campaigns/[id]/npcs/new/page.tsx
+++ b/web/src/app/(app)/campaigns/[id]/npcs/new/page.tsx
@@ -2,7 +2,6 @@
 
 import { use } from "react";
 import { useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Save, Plus, X, Volume2, ImagePlus, Wand2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/web/src/app/(app)/settings/providers/page.tsx
+++ b/web/src/app/(app)/settings/providers/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { useTestProvider, useHasRole } from "@/lib/hooks";
+import type { ProviderTestResult } from "@/lib/types";
+import {
+  Zap,
+  Mic,
+  Volume2,
+  CheckCircle,
+  XCircle,
+  Loader2,
+  ShieldAlert,
+} from "lucide-react";
+
+const PROVIDER_TYPES = [
+  {
+    type: "llm",
+    label: "LLM (Language Model)",
+    icon: Zap,
+    providers: ["openai", "anthropic", "google"],
+  },
+  {
+    type: "stt",
+    label: "STT (Speech-to-Text)",
+    icon: Mic,
+    providers: ["deepgram", "whisper"],
+  },
+  {
+    type: "tts",
+    label: "TTS (Text-to-Speech)",
+    icon: Volume2,
+    providers: ["elevenlabs", "openai"],
+  },
+];
+
+function ProviderTestCard({
+  type,
+  label,
+  icon: Icon,
+  providers,
+}: {
+  type: string;
+  label: string;
+  icon: typeof Zap;
+  providers: string[];
+}) {
+  const [provider, setProvider] = useState(providers[0]);
+  const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [result, setResult] = useState<ProviderTestResult | null>(null);
+  const testMutation = useTestProvider();
+
+  async function handleTest() {
+    setResult(null);
+    const res = await testMutation.mutateAsync({
+      type,
+      provider,
+      api_key: apiKey,
+      base_url: baseUrl || undefined,
+    });
+    setResult(res);
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Icon className="h-5 w-5 text-primary" />
+          {label}
+        </CardTitle>
+        <CardDescription>
+          Test your {label.toLowerCase()} provider connection
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label>Provider</Label>
+            <Select value={provider} onValueChange={(v) => setProvider(v ?? providers[0])}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {providers.map((p) => (
+                  <SelectItem key={p} value={p}>
+                    {p.charAt(0).toUpperCase() + p.slice(1)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>API Key</Label>
+            <Input
+              type="password"
+              placeholder="Enter API key"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label>
+            Base URL{" "}
+            <span className="text-muted-foreground">(optional)</span>
+          </Label>
+          <Input
+            placeholder="Custom endpoint URL"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+          />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Button
+            onClick={handleTest}
+            disabled={!apiKey || testMutation.isPending}
+          >
+            {testMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Testing...
+              </>
+            ) : (
+              "Test Connection"
+            )}
+          </Button>
+
+          {result && (
+            <div className="flex items-center gap-2">
+              {result.status === "ok" ? (
+                <>
+                  <CheckCircle className="h-4 w-4 text-green-500" />
+                  <Badge variant="outline" className="border-green-500/30 text-green-500">
+                    Connected ({result.latency_ms}ms)
+                  </Badge>
+                </>
+              ) : (
+                <>
+                  <XCircle className="h-4 w-4 text-destructive" />
+                  <Badge variant="destructive">
+                    {result.error || "Connection failed"}
+                  </Badge>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function ProvidersPage() {
+  const isAdmin = useHasRole("tenant_admin");
+
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-20">
+        <ShieldAlert className="h-12 w-12 text-muted-foreground/40" />
+        <h2 className="text-xl font-semibold">Access Denied</h2>
+        <p className="text-muted-foreground">
+          Provider configuration requires admin access.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          Provider Configuration
+        </h1>
+        <p className="text-muted-foreground">
+          Test your AI provider connections. API keys are not stored — they are
+          only used for the test request.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {PROVIDER_TYPES.map((pt) => (
+          <ProviderTestCard key={pt.type} {...pt} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(app)/users/page.tsx
+++ b/web/src/app/(app)/users/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { Users as UsersIcon, AlertTriangle, Copy, Plus, Trash2, ShieldAlert } from "lucide-react";
+import { Users as UsersIcon, AlertTriangle, Plus, Trash2, ShieldAlert } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/web/src/app/(public)/login/page.tsx
+++ b/web/src/app/(public)/login/page.tsx
@@ -8,11 +8,31 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Sparkles } from "lucide-react";
 import { api } from "@/lib/api";
+import { useAuthProviders } from "@/lib/hooks";
 
 function DiscordIcon({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor">
       <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+    </svg>
+  );
+}
+
+function GoogleIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </svg>
+  );
+}
+
+function GitHubIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z" />
     </svg>
   );
 }
@@ -31,8 +51,8 @@ function LoginForm() {
   const [apiKey, setApiKey] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const { data: authProviders } = useAuthProviders();
 
-  // If there's an invite token in the URL, pass it through to Discord OAuth.
   const inviteToken = searchParams.get("invite") ?? undefined;
 
   async function handleApiKeyLogin(e: React.FormEvent) {
@@ -50,6 +70,11 @@ function LoginForm() {
       setLoading(false);
     }
   }
+
+  const showDiscord = !authProviders || authProviders.discord;
+  const showGoogle = authProviders?.google ?? false;
+  const showGitHub = authProviders?.github ?? false;
+  const showApiKey = !inviteToken && (!authProviders || authProviders.apikey);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
@@ -77,19 +102,49 @@ function LoginForm() {
               {inviteToken ? "Accept Invite" : "Welcome back"}
             </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-4">
-            <Button
-              className="w-full gap-2"
-              size="lg"
-              onClick={() => {
-                window.location.href = api.auth.discordUrl(inviteToken);
-              }}
-            >
-              <DiscordIcon className="h-5 w-5" />
-              Continue with Discord
-            </Button>
+          <CardContent className="space-y-3">
+            {showDiscord && (
+              <Button
+                className="w-full gap-2"
+                size="lg"
+                onClick={() => {
+                  window.location.href = api.auth.discordUrl(inviteToken);
+                }}
+              >
+                <DiscordIcon className="h-5 w-5" />
+                Continue with Discord
+              </Button>
+            )}
 
-            {!inviteToken && (
+            {showGoogle && (
+              <Button
+                className="w-full gap-2"
+                size="lg"
+                variant="outline"
+                onClick={() => {
+                  window.location.href = api.auth.googleUrl(inviteToken);
+                }}
+              >
+                <GoogleIcon className="h-5 w-5" />
+                Continue with Google
+              </Button>
+            )}
+
+            {showGitHub && (
+              <Button
+                className="w-full gap-2"
+                size="lg"
+                variant="outline"
+                onClick={() => {
+                  window.location.href = api.auth.githubUrl(inviteToken);
+                }}
+              >
+                <GitHubIcon className="h-5 w-5" />
+                Continue with GitHub
+              </Button>
+            )}
+
+            {showApiKey && (
               <>
                 <div className="relative">
                   <div className="absolute inset-0 flex items-center">

--- a/web/src/components/cookie-notice.tsx
+++ b/web/src/components/cookie-notice.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -8,15 +8,10 @@ import { Button } from "@/components/ui/button";
 const COOKIE_NOTICE_KEY = "glyphoxa_cookie_notice_dismissed";
 
 export function CookieNotice() {
-  const [dismissed, setDismissed] = useState(true);
-
-  useEffect(() => {
-    const stored = localStorage.getItem(COOKIE_NOTICE_KEY);
-    if (!stored) {
-      // Use rAF to avoid synchronous setState in effect body
-      requestAnimationFrame(() => setDismissed(false));
-    }
-  }, []);
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof window === "undefined") return true;
+    return !!localStorage.getItem(COOKIE_NOTICE_KEY);
+  });
 
   function dismiss() {
     localStorage.setItem(COOKIE_NOTICE_KEY, "1");

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -10,6 +10,8 @@ import {
   Users,
   X,
   Sparkles,
+  Shield,
+  FileText,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -29,7 +31,9 @@ const navItems: NavItem[] = [
   { href: "/campaigns", label: "Campaigns", icon: Swords },
   { href: "/sessions", label: "Sessions", icon: ScrollText },
   { href: "/users", label: "Users", icon: Users, minRole: "tenant_admin" },
+  { href: "/admin/audit-log", label: "Audit Log", icon: FileText, minRole: "tenant_admin" },
   { href: "/settings", label: "Settings", icon: Settings },
+  { href: "/admin", label: "Admin", icon: Shield, minRole: "super_admin" },
 ];
 
 interface SidebarProps {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -10,6 +10,11 @@ import type {
   UserRole,
   UserPreferences,
   PaginatedResponse,
+  AuditLogEntry,
+  AdminDashboardStats,
+  ProviderTestResult,
+  KnowledgeGraphData,
+  AuthProviders,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "/api/v1";
@@ -104,10 +109,19 @@ export const auth = {
       // Logout endpoint may not exist; clearing token is sufficient.
     });
   },
+  providers: () => requestData<AuthProviders>("/auth/providers"),
   discordUrl: (invite?: string) =>
     invite
       ? `${API_BASE}/auth/discord?invite=${encodeURIComponent(invite)}`
       : `${API_BASE}/auth/discord`,
+  googleUrl: (invite?: string) =>
+    invite
+      ? `${API_BASE}/auth/google?invite=${encodeURIComponent(invite)}`
+      : `${API_BASE}/auth/google`,
+  githubUrl: (invite?: string) =>
+    invite
+      ? `${API_BASE}/auth/github?invite=${encodeURIComponent(invite)}`
+      : `${API_BASE}/auth/github`,
   loginApiKey: async (apiKey: string): Promise<AuthResponse> => {
     const res = await request<AuthResponse>("/auth/apikey", {
       method: "POST",
@@ -252,6 +266,64 @@ export const invites = {
     ),
 };
 
+// Audit logs
+export const auditLogs = {
+  list: (params?: {
+    limit?: number;
+    offset?: number;
+    resource_type?: string;
+    action?: string;
+    tenant_id?: string;
+  }) => {
+    const q = new URLSearchParams();
+    if (params?.limit) q.set("limit", String(params.limit));
+    if (params?.offset) q.set("offset", String(params.offset));
+    if (params?.resource_type) q.set("resource_type", params.resource_type);
+    if (params?.action) q.set("action", params.action);
+    if (params?.tenant_id) q.set("tenant_id", params.tenant_id);
+    const qs = q.toString();
+    return request<{ data: AuditLogEntry[]; total: number }>(
+      `/audit-logs${qs ? `?${qs}` : ""}`,
+    );
+  },
+};
+
+// Admin (super_admin only)
+export const admin = {
+  stats: () => requestData<AdminDashboardStats>("/admin/stats"),
+  users: (params?: { limit?: number; offset?: number }) => {
+    const q = new URLSearchParams();
+    if (params?.limit) q.set("limit", String(params.limit));
+    if (params?.offset) q.set("offset", String(params.offset));
+    const qs = q.toString();
+    return request<{ data: User[]; total: number }>(
+      `/admin/users${qs ? `?${qs}` : ""}`,
+    );
+  },
+};
+
+// Providers
+export const providers = {
+  test: (data: {
+    type: string;
+    provider: string;
+    api_key: string;
+    base_url?: string;
+  }) =>
+    requestData<ProviderTestResult>("/providers/test", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+};
+
+// Knowledge graph
+export const knowledge = {
+  graph: (campaignId: string) =>
+    requestData<KnowledgeGraphData>(
+      `/campaigns/${campaignId}/knowledge/graph`,
+    ),
+};
+
 export const api = {
   auth,
   dashboard,
@@ -261,4 +333,8 @@ export const api = {
   users,
   onboarding,
   invites,
+  auditLogs,
+  admin,
+  providers,
+  knowledge,
 };

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "./api";
 import { hasMinRole } from "./rbac";
-import type { Campaign, NPC, UserRole, UserPreferences } from "./types";
+import type { Campaign, NPC, UserRole, UserPreferences, ProviderTestResult } from "./types";
 
 // Auth
 export function useUser() {
@@ -257,5 +257,76 @@ export function useUpdatePreferences() {
       toast.success("Preferences saved");
     },
     onError: (err) => toast.error("Failed to save preferences", { description: err.message }),
+  });
+}
+
+// Audit Logs
+export function useAuditLogs(params?: {
+  limit?: number;
+  offset?: number;
+  resource_type?: string;
+  action?: string;
+}) {
+  return useQuery({
+    queryKey: ["audit-logs", params],
+    queryFn: () => api.auditLogs.list(params),
+  });
+}
+
+// Admin
+export function useAdminStats() {
+  return useQuery({
+    queryKey: ["admin", "stats"],
+    queryFn: api.admin.stats,
+  });
+}
+
+export function useAdminUsers(params?: { limit?: number; offset?: number }) {
+  return useQuery({
+    queryKey: ["admin", "users", params],
+    queryFn: () => api.admin.users(params),
+  });
+}
+
+// Provider Testing
+export function useTestProvider() {
+  return useMutation({
+    mutationFn: (data: {
+      type: string;
+      provider: string;
+      api_key: string;
+      base_url?: string;
+    }) => api.providers.test(data),
+    onSuccess: (result: ProviderTestResult) => {
+      if (result.status === "ok") {
+        toast.success(`${result.provider} connected`, {
+          description: `Latency: ${result.latency_ms}ms`,
+        });
+      } else {
+        toast.error(`${result.provider} failed`, {
+          description: result.error,
+        });
+      }
+    },
+    onError: (err) => toast.error("Provider test failed", { description: err.message }),
+  });
+}
+
+// Knowledge Graph
+export function useKnowledgeGraph(campaignId: string) {
+  return useQuery({
+    queryKey: ["campaigns", campaignId, "knowledge", "graph"],
+    queryFn: () => api.knowledge.graph(campaignId),
+    enabled: !!campaignId,
+  });
+}
+
+// Auth Providers
+export function useAuthProviders() {
+  return useQuery({
+    queryKey: ["auth", "providers"],
+    queryFn: api.auth.providers,
+    staleTime: 60 * 60 * 1000, // Cache for 1 hour
+    retry: false,
   });
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -111,6 +111,67 @@ export interface DashboardStats {
   hours_limit: number;
 }
 
+export interface AuditLogEntry {
+  id: number;
+  tenant_id: string | null;
+  user_id: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string;
+  changes: Record<string, unknown> | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  created_at: string;
+}
+
+export interface AdminDashboardStats {
+  total_tenants: number;
+  total_users: number;
+  total_campaigns: number;
+  active_sessions: number;
+  total_session_hours: number;
+  audit_log_count: number;
+}
+
+export interface ProviderTestResult {
+  type: string;
+  provider: string;
+  status: "ok" | "error";
+  latency_ms: number;
+  error?: string;
+}
+
+export interface KnowledgeEntity {
+  id: string;
+  campaign_id: string;
+  type: string;
+  name: string;
+  attributes: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface KnowledgeRelationship {
+  source_id: string;
+  target_id: string;
+  source_name: string;
+  target_name: string;
+  rel_type: string;
+  attributes?: Record<string, unknown>;
+}
+
+export interface KnowledgeGraphData {
+  entities: KnowledgeEntity[];
+  relationships: KnowledgeRelationship[];
+}
+
+export interface AuthProviders {
+  discord: boolean;
+  google: boolean;
+  github: boolean;
+  apikey: boolean;
+}
+
 export type GameSystem =
   | "D&D 5e"
   | "D&D 5e (2024)"


### PR DESCRIPTION
## Summary

Implements Phase 3 of the Glyphoxa Web Management plan: Scale + Polish features for production-ready SaaS.

### Backend (Go)
- **Google OAuth2 + GitHub OAuth2** login with full CSRF protection, invite flow support, and user upsert
- **Audit log** — append-only `mgmt.audit_log` table with per-tenant/per-user filtering, pagination, and an `auditLog()` helper for handlers
- **Rate limiting** — in-memory token bucket rate limiter (per-user JWT or per-IP) with `X-RateLimit-*` response headers, ready for Redis backend later
- **Provider config test** — endpoint to validate LLM/STT/TTS provider API keys (OpenAI, Anthropic, Gemini, Deepgram, ElevenLabs) with latency measurement
- **Knowledge graph visualization** — new `/campaigns/{id}/knowledge/graph` endpoint returning full entity+relationship data for force-directed rendering
- **Super admin dashboard** — system-wide stats (tenants, users, campaigns, active sessions, session hours, audit count) and cross-tenant user listing
- **Auth providers discovery** — `/auth/providers` endpoint so the frontend knows which login buttons to show

### Frontend (Next.js/React)
- Login page dynamically shows Discord/Google/GitHub buttons based on configured providers
- Admin dashboard page (`/admin`) with stat cards and recent user table (super_admin only)
- Audit log viewer (`/admin/audit-log`) with resource type + action filtering and pagination
- Provider config UI (`/settings/providers`) with test buttons for LLM, STT, and TTS providers
- Knowledge graph browser (`/campaigns/[id]/knowledge`) with interactive SVG force-directed visualization
- Sidebar updated with Audit Log (tenant_admin+) and Admin (super_admin) nav items

### Database
- Migration 004: adds `google_id` and `github_id` columns to `mgmt.users`, creates `mgmt.audit_log` table with indexes

### Tests
- Rate limiter: allow/burst/keys/middleware/clientIP tests
- Audit log: list/filter/helper tests
- Admin dashboard: stats/users/auth-providers tests
- OAuth: login redirect, callback state validation, processInvite tests
- Knowledge graph: visualization endpoint tests

## Test plan
- [ ] `go test -race -count=1 ./internal/web/...` passes (verified locally)
- [ ] `go build ./cmd/glyphoxa-web/...` succeeds (verified locally)
- [ ] `npx next build` succeeds with all new routes (verified locally)
- [ ] Verify Google OAuth2 flow with real credentials
- [ ] Verify GitHub OAuth2 flow with real credentials
- [ ] Verify audit log entries are created on write operations
- [ ] Verify rate limiting returns 429 when exceeded
- [ ] Verify provider test buttons work with real API keys
- [ ] Verify knowledge graph renders entities with force layout
- [ ] Verify admin dashboard shows correct system-wide stats