### PR TITLE
fix(ci): fix Docker workflow build failure and cache race

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,8 +54,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=glyphoxa
+          cache-to: type=gha,mode=max,scope=glyphoxa
 
   # ---------------------------------------------------------------------------
   # Glyphoxa web management service (Next.js frontend + Go API backend)
@@ -102,5 +102,5 @@ jobs:
           push: true
           tags: ${{ steps.meta-web.outputs.tags }}
           labels: ${{ steps.meta-web.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=glyphoxa-web
+          cache-to: type=gha,mode=max,scope=glyphoxa-web

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -68,4 +68,4 @@ WORKDIR /app
 EXPOSE 3000 8090
 
 # Start Go API backend in background, Next.js frontend in foreground.
-CMD /usr/local/bin/glyphoxa-web & exec node server.js
+CMD ["/bin/sh", "-c", "/usr/local/bin/glyphoxa-web & exec node server.js"]

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -4,6 +4,7 @@ const apiBackendUrl =
   process.env.API_BACKEND_URL || "http://localhost:8090";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## Summary
- **Root cause**: `Dockerfile.web` copies `/app/.next/standalone` but `next.config.ts` was missing `output: "standalone"`, so Next.js never produced that directory → build failed with "not found"
- **Cache race**: Both `docker` and `docker-web` jobs ran in parallel using the same default GHA cache scope, causing "Unable to reserve cache" collisions. Added explicit `scope=glyphoxa` / `scope=glyphoxa-web` to isolate them
- **CMD format**: Switched Dockerfile.web CMD from shell form to JSON form to suppress the `JSONArgsRecommended` buildx warning about OS signal handling

## Test plan
- [ ] Docker workflow CI passes on this PR (both `glyphoxa` and `glyphoxa-web` jobs)
- [ ] No "Unable to reserve cache" warnings in post-job cleanup
- [ ] GHCR images are pushed successfully on merge to main