### PR TITLE
feat(web): wire Phase 3 pages into navigation

### DIFF
--- a/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, use } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Save, Trash2, Users, ScrollText } from "lucide-react";
+import { Save, Trash2, Users, ScrollText, Network } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -108,6 +108,10 @@ function CampaignForm({ campaign, campaignId }: { campaign: Campaign; campaignId
           <TabsTrigger value="sessions">
             <ScrollText className="mr-1 h-4 w-4" />
             Sessions
+          </TabsTrigger>
+          <TabsTrigger value="knowledge" render={<Link href={`/campaigns/${campaignId}/knowledge`} />}>
+            <Network className="mr-1 h-4 w-4" />
+            Knowledge Graph
           </TabsTrigger>
         </TabsList>
 

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,13 +13,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useUser, useUpdateMe, useUpdatePreferences } from "@/lib/hooks";
+import { useUser, useUpdateMe, useUpdatePreferences, useHasRole } from "@/lib/hooks";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { Cpu, ChevronRight } from "lucide-react";
 
 export default function SettingsPage() {
   const { data: user } = useUser();
+  const isAdmin = useHasRole("tenant_admin");
   const updateMe = useUpdateMe();
   const updatePreferences = useUpdatePreferences();
 
@@ -144,6 +147,25 @@ export default function SettingsPage() {
           </Button>
         </CardContent>
       </Card>
+
+      {isAdmin && (
+        <Link href="/settings/providers">
+          <Card className="group transition-all duration-200 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5">
+            <CardContent className="flex items-center gap-4 p-6">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 transition-colors group-hover:bg-primary/20">
+                <Cpu className="h-5 w-5 text-primary" />
+              </div>
+              <div className="flex-1">
+                <p className="font-medium">Provider Configuration</p>
+                <p className="text-sm text-muted-foreground">
+                  Test and configure LLM, STT, and TTS provider connections
+                </p>
+              </div>
+              <ChevronRight className="h-5 w-5 text-muted-foreground/50 transition-colors group-hover:text-primary" />
+            </CardContent>
+          </Card>
+        </Link>
+      )}
 
       <Card className="border-destructive/50">
         <CardHeader>

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Sparkles,
   Shield,
   FileText,
+  Cpu,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -33,6 +34,7 @@ const navItems: NavItem[] = [
   { href: "/users", label: "Users", icon: Users, minRole: "tenant_admin" },
   { href: "/admin/audit-log", label: "Audit Log", icon: FileText, minRole: "tenant_admin" },
   { href: "/settings", label: "Settings", icon: Settings },
+  { href: "/settings/providers", label: "Providers", icon: Cpu, minRole: "tenant_admin" },
   { href: "/admin", label: "Admin", icon: Shield, minRole: "super_admin" },
 ];
 


### PR DESCRIPTION
## Summary
- Add **Providers** link to sidebar navigation (visible to tenant_admin+)
- Add **Knowledge Graph** tab to campaign detail page, linking to the existing `/campaigns/[id]/knowledge` page
- Add **Provider Configuration** card to the Settings page with link to `/settings/providers`

The Phase 3 pages (audit log, provider config, knowledge graph browser, admin dashboard, OAuth login buttons) were all implemented in PR #121 but weren't wired into the navigation — users couldn't reach them without typing URLs directly. This PR connects them.

## Test plan
- [ ] Verify sidebar shows Providers link for tenant_admin+ users
- [ ] Verify campaign detail page has Knowledge Graph tab that navigates to the graph
- [ ] Verify Settings page shows Provider Configuration card for admin users
- [ ] Verify `npm run build` passes with no errors