### PR TITLE
fix(web): fix NPC editor crash and show OAuth login buttons

### DIFF
--- a/web/src/app/(app)/campaigns/[id]/npcs/[npcId]/page.tsx
+++ b/web/src/app/(app)/campaigns/[id]/npcs/[npcId]/page.tsx
@@ -56,8 +56,8 @@ function NPCForm({ npc, campaignId, campaignName }: NPCFormProps) {
 
   const [name, setName] = useState(npc.name);
   const [personality, setPersonality] = useState(npc.personality);
-  const [voiceProvider, setVoiceProvider] = useState(npc.voice_provider);
-  const [voiceId, setVoiceId] = useState(npc.voice_id);
+  const [voiceProvider, setVoiceProvider] = useState(npc.voice_provider ?? npc.voice?.provider ?? '');
+  const [voiceId, setVoiceId] = useState(npc.voice_id ?? npc.voice?.voice_id ?? '');
   const [engine, setEngine] = useState<"cascaded" | "s2s" | "sentence">(npc.engine);
   const [budgetTier, setBudgetTier] = useState<"fast" | "standard" | "deep">(npc.budget_tier);
   const [knowledgeScope, setKnowledgeScope] = useState<string[]>(npc.knowledge_scope ?? []);
@@ -83,14 +83,13 @@ function NPCForm({ npc, campaignId, campaignName }: NPCFormProps) {
     await updateNPC.mutateAsync({
       name: name.trim(),
       personality: personality.trim(),
-      voice_provider: voiceProvider,
-      voice_id: voiceId.trim(),
+      voice: { provider: voiceProvider, voice_id: voiceId.trim() },
       engine,
       budget_tier: budgetTier,
       knowledge_scope: knowledgeScope,
       behavior_rules: behaviorRules,
       address_only: addressOnly,
-    });
+    } as Partial<NPC>);
   }
 
   async function handleDelete() {

--- a/web/src/app/(app)/campaigns/[id]/npcs/new/page.tsx
+++ b/web/src/app/(app)/campaigns/[id]/npcs/new/page.tsx
@@ -20,6 +20,7 @@ import {
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { useCampaign, useCreateNPC } from "@/lib/hooks";
 import { toast } from "sonner";
+import type { NPC } from "@/lib/types";
 
 const personalityTemplates = [
   { label: "Gruff Guard", text: "A stern but fair guard who has watched over this area for decades. Suspicious of strangers, protective of the townsfolk, speaks in short, clipped sentences." },
@@ -67,14 +68,13 @@ export default function NewNPCPage({
     await createNPC.mutateAsync({
       name: name.trim(),
       personality: personality.trim(),
-      voice_provider: voiceProvider,
-      voice_id: voiceId.trim(),
+      voice: { provider: voiceProvider, voice_id: voiceId.trim() },
       engine,
       budget_tier: budgetTier,
       knowledge_scope: knowledgeScope,
       behavior_rules: behaviorRules,
       address_only: addressOnly,
-    });
+    } as Partial<NPC>);
     router.push(`/campaigns/${campaignId}`);
   }
 

--- a/web/src/app/(public)/login/page.tsx
+++ b/web/src/app/(public)/login/page.tsx
@@ -72,8 +72,8 @@ function LoginForm() {
   }
 
   const showDiscord = !authProviders || authProviders.discord;
-  const showGoogle = authProviders?.google ?? false;
-  const showGitHub = authProviders?.github ?? false;
+  const showGoogle = !authProviders || authProviders.google;
+  const showGitHub = !authProviders || authProviders.github;
   const showApiKey = !inviteToken && (!authProviders || authProviders.apikey);
 
   return (
@@ -118,7 +118,7 @@ function LoginForm() {
 
             {showGoogle && (
               <Button
-                className="w-full gap-2"
+                className="w-full gap-2 border-border/60 bg-white text-gray-700 hover:bg-gray-50"
                 size="lg"
                 variant="outline"
                 onClick={() => {
@@ -132,9 +132,8 @@ function LoginForm() {
 
             {showGitHub && (
               <Button
-                className="w-full gap-2"
+                className="w-full gap-2 bg-[#24292f] text-white hover:bg-[#32383f]"
                 size="lg"
-                variant="outline"
                 onClick={() => {
                   window.location.href = api.auth.githubUrl(inviteToken);
                 }}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -59,6 +59,12 @@ export interface NPC {
   personality: string;
   voice_provider: string;
   voice_id: string;
+  voice?: {
+    provider: string;
+    voice_id: string;
+    pitch_shift?: number;
+    speed?: number;
+  };
   voice_config: {
     pitch?: number;
     speed?: number;


### PR DESCRIPTION
## Summary
- **P0 fix**: NPC editor page crashed with `Cannot read properties of undefined (reading 'trim')` because the API returns voice config as nested `voice.provider`/`voice.voice_id` but the form read flat `voice_provider`/`voice_id` fields. Added `??` fallbacks and updated save payloads to use the nested format.
- **OAuth buttons**: Google and GitHub OAuth buttons were hidden by default (`?? false`). Changed to match Discord's default-visible pattern (`!authProviders || authProviders.X`). Added branded styling (white for Google, dark for GitHub).

## Test plan
- [x] `npm run build` passes with no errors
- [ ] NPC editor loads without crash
- [ ] Login page shows Discord, Google, and GitHub buttons