### PR TITLE
fix(web): always show Google/GitHub OAuth buttons on login

### DIFF
--- a/web/src/app/(public)/login/page.tsx
+++ b/web/src/app/(public)/login/page.tsx
@@ -72,8 +72,8 @@ function LoginForm() {
   }
 
   const showDiscord = !authProviders || authProviders.discord;
-  const showGoogle = !authProviders || authProviders.google;
-  const showGitHub = !authProviders || authProviders.github;
+  const showGoogle = true;
+  const showGitHub = true;
   const showApiKey = !inviteToken && (!authProviders || authProviders.apikey);
 
   return (


### PR DESCRIPTION
## Summary
- Force Google and GitHub OAuth buttons to always be visible on the login page, regardless of the `/auth/providers` response. The previous PR (#124) changed the default but the backend explicitly returns `false` for unconfigured providers, still hiding the buttons.

## Test plan
- [x] `npm run build` passes
- [ ] Login page shows all three OAuth buttons (Discord, Google, GitHub)