### PR TITLE
fix: harden error handling across gateway, discord, and provider packages

### DIFF
--- a/internal/discord/commands/campaign.go
+++ b/internal/discord/commands/campaign.go
@@ -258,7 +258,11 @@ func (cc *CampaignCommands) handleLoad(e *events.ApplicationCommandInteractionCr
 		return
 	}
 
-	data := e.Data.(discord.SlashCommandInteractionData)
+	data, ok := e.Data.(discord.SlashCommandInteractionData)
+	if !ok {
+		discordbot.RespondEphemeral(e, "Unexpected interaction data type.")
+		return
+	}
 	attachment, ok := FirstAttachment(data)
 	if !ok {
 		discordbot.RespondEphemeral(e, "Please attach a campaign YAML file.")
@@ -345,7 +349,11 @@ func (cc *CampaignCommands) handleSwitch(e *events.ApplicationCommandInteraction
 		return
 	}
 
-	data := e.Data.(discord.SlashCommandInteractionData)
+	data, ok := e.Data.(discord.SlashCommandInteractionData)
+	if !ok {
+		discordbot.RespondEphemeral(e, "Unexpected interaction data type.")
+		return
+	}
 	name := data.String("name")
 	if name == "" {
 		discordbot.RespondEphemeral(e, "Please provide a campaign name.")

--- a/internal/discord/commands/entity.go
+++ b/internal/discord/commands/entity.go
@@ -151,7 +151,11 @@ func (ec *EntityCommands) handleList(e *events.ApplicationCommandInteractionCrea
 	}
 
 	opts := entity.ListOptions{}
-	data := e.Data.(discord.SlashCommandInteractionData)
+	data, ok := e.Data.(discord.SlashCommandInteractionData)
+	if !ok {
+		discordbot.RespondEphemeral(e, "Unexpected interaction data type.")
+		return
+	}
 	if typeFilter, ok := data.OptString("type"); ok {
 		opts.Type = entity.EntityType(typeFilter)
 	}
@@ -218,7 +222,11 @@ func (ec *EntityCommands) handleRemove(e *events.ApplicationCommandInteractionCr
 		return
 	}
 
-	data := e.Data.(discord.SlashCommandInteractionData)
+	data, ok := e.Data.(discord.SlashCommandInteractionData)
+	if !ok {
+		discordbot.RespondEphemeral(e, "Unexpected interaction data type.")
+		return
+	}
 	name := data.String("name")
 	if name == "" {
 		discordbot.RespondEphemeral(e, "Please provide an entity name.")
@@ -344,7 +352,11 @@ func (ec *EntityCommands) handleImport(e *events.ApplicationCommandInteractionCr
 		return
 	}
 
-	data := e.Data.(discord.SlashCommandInteractionData)
+	data, ok := e.Data.(discord.SlashCommandInteractionData)
+	if !ok {
+		discordbot.RespondEphemeral(e, "Unexpected interaction data type.")
+		return
+	}
 	attachment, ok := FirstAttachment(data)
 	if !ok {
 		discordbot.RespondEphemeral(e, "Please attach a YAML or JSON file to import.")

--- a/internal/gateway/grpctransport/server.go
+++ b/internal/gateway/grpctransport/server.go
@@ -2,6 +2,7 @@ package grpctransport
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"google.golang.org/grpc"
@@ -232,7 +233,10 @@ func (c *GatewayClient) ReportState(ctx context.Context, sessionID string, state
 		State:     stringToPBState(state),
 		Error:     errMsg,
 	})
-	return err
+	if err != nil {
+		return fmt.Errorf("grpctransport: report state for session %s: %w", sessionID, err)
+	}
+	return nil
 }
 
 // Heartbeat sends a heartbeat to the gateway via gRPC.
@@ -240,7 +244,10 @@ func (c *GatewayClient) Heartbeat(ctx context.Context, sessionID string) error {
 	_, err := c.client.Heartbeat(ctx, &pb.HeartbeatRequest{
 		SessionId: sessionID,
 	})
-	return err
+	if err != nil {
+		return fmt.Errorf("grpctransport: heartbeat for session %s: %w", sessionID, err)
+	}
+	return nil
 }
 
 // TimestampPB converts a gateway.SessionStatus.StartedAt to a protobuf Timestamp.

--- a/internal/gateway/sessionctrl.go
+++ b/internal/gateway/sessionctrl.go
@@ -201,8 +201,18 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 		if gc.gwBot != nil && gc.bridgeSrv != nil {
 			bridge := gc.bridgeSrv.NewSessionBridge(sessionID)
 
-			gID, _ := snowflake.Parse(req.GuildID)
-			chID, _ := snowflake.Parse(req.ChannelID)
+			gID, parseErr := snowflake.Parse(req.GuildID)
+			if parseErr != nil {
+				gc.bridgeSrv.RemoveBridge(sessionID)
+				_ = gc.orch.Transition(ctx, sessionID, SessionEnded, parseErr.Error())
+				return fmt.Errorf("gateway: parse guild ID %q: %w", req.GuildID, parseErr)
+			}
+			chID, parseErr := snowflake.Parse(req.ChannelID)
+			if parseErr != nil {
+				gc.bridgeSrv.RemoveBridge(sessionID)
+				_ = gc.orch.Transition(ctx, sessionID, SessionEnded, parseErr.Error())
+				return fmt.Errorf("gateway: parse channel ID %q: %w", req.ChannelID, parseErr)
+			}
 
 			voiceMgr := gc.gwBot.Client().VoiceManager
 			if voiceMgr == nil {
@@ -311,7 +321,9 @@ func (gc *GatewaySessionController) Stop(ctx context.Context, sessionID string) 
 					"session_id", sessionID, "err", stopErr)
 			}
 			if c, ok := client.(interface{ Close() error }); ok {
-				c.Close()
+				if closeErr := c.Close(); closeErr != nil {
+					slog.Debug("gateway: close worker client error", "session_id", sessionID, "err", closeErr)
+				}
 			}
 		}
 		rpcCancel()
@@ -416,7 +428,11 @@ func (gc *GatewaySessionController) cleanupVoiceBridge(sessionID string) {
 // registerDisconnectListener watches for the bot being kicked from the voice
 // channel and stops the session if that happens.
 func (gc *GatewaySessionController) registerDisconnectListener(sessionID, guildID string) {
-	gID, _ := snowflake.Parse(guildID)
+	gID, err := snowflake.Parse(guildID)
+	if err != nil {
+		slog.Warn("gateway: invalid guild ID for disconnect listener", "guild_id", guildID, "err", err)
+		return
+	}
 
 	listener := bot.NewListenerFunc(func(e *events.GuildVoiceStateUpdate) {
 		if e.VoiceState.GuildID != gID || e.VoiceState.UserID != gc.gwBot.Client().ApplicationID {
@@ -473,13 +489,17 @@ func (gc *GatewaySessionController) dialNPCController(sessionID string) (NPCCont
 	npcCtrl, ok := client.(NPCController)
 	if !ok {
 		if c, ok := client.(interface{ Close() error }); ok {
-			c.Close()
+			if closeErr := c.Close(); closeErr != nil {
+				slog.Debug("gateway: close worker client error", "err", closeErr)
+			}
 		}
 		return nil, nil, fmt.Errorf("gateway: worker client does not implement NPCController")
 	}
 	cleanup := func() {
 		if c, ok := client.(interface{ Close() error }); ok {
-			c.Close()
+			if closeErr := c.Close(); closeErr != nil {
+				slog.Debug("gateway: close worker client error", "err", closeErr)
+			}
 		}
 	}
 	return npcCtrl, cleanup, nil
@@ -499,20 +519,26 @@ func (gc *GatewaySessionController) ListNPCs(ctx context.Context, sessionID stri
 func (gc *GatewaySessionController) MuteNPC(ctx context.Context, sessionID, npcName string) error {
 	ctrl, cleanup, err := gc.dialNPCController(sessionID)
 	if err != nil {
-		return err
+		return fmt.Errorf("gateway: mute NPC %q: %w", npcName, err)
 	}
 	defer cleanup()
-	return ctrl.MuteNPC(ctx, sessionID, npcName)
+	if err := ctrl.MuteNPC(ctx, sessionID, npcName); err != nil {
+		return fmt.Errorf("gateway: mute NPC %q: %w", npcName, err)
+	}
+	return nil
 }
 
 // UnmuteNPC implements [NPCController].
 func (gc *GatewaySessionController) UnmuteNPC(ctx context.Context, sessionID, npcName string) error {
 	ctrl, cleanup, err := gc.dialNPCController(sessionID)
 	if err != nil {
-		return err
+		return fmt.Errorf("gateway: unmute NPC %q: %w", npcName, err)
 	}
 	defer cleanup()
-	return ctrl.UnmuteNPC(ctx, sessionID, npcName)
+	if err := ctrl.UnmuteNPC(ctx, sessionID, npcName); err != nil {
+		return fmt.Errorf("gateway: unmute NPC %q: %w", npcName, err)
+	}
+	return nil
 }
 
 // MuteAllNPCs implements [NPCController].
@@ -539,10 +565,13 @@ func (gc *GatewaySessionController) UnmuteAllNPCs(ctx context.Context, sessionID
 func (gc *GatewaySessionController) SpeakNPC(ctx context.Context, sessionID, npcName, text string) error {
 	ctrl, cleanup, err := gc.dialNPCController(sessionID)
 	if err != nil {
-		return err
+		return fmt.Errorf("gateway: speak NPC %q: %w", npcName, err)
 	}
 	defer cleanup()
-	return ctrl.SpeakNPC(ctx, sessionID, npcName, text)
+	if err := ctrl.SpeakNPC(ctx, sessionID, npcName, text); err != nil {
+		return fmt.Errorf("gateway: speak NPC %q: %w", npcName, err)
+	}
+	return nil
 }
 
 // npcDefsToConfigs converts npcstore definitions to the gateway's NPCConfigMsg

--- a/internal/gateway/usage/memory.go
+++ b/internal/gateway/usage/memory.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -67,7 +68,7 @@ func (s *MemoryStore) CheckQuota(ctx context.Context, tenantID string, quota Quo
 	period := CurrentPeriod()
 	rec, err := s.GetUsage(ctx, tenantID, period)
 	if err != nil {
-		return err
+		return fmt.Errorf("usage: check quota for tenant %s: %w", tenantID, err)
 	}
 
 	if rec.SessionHours >= quota.MonthlySessionHours {

--- a/pkg/provider/s2s/openai/openai.go
+++ b/pkg/provider/s2s/openai/openai.go
@@ -377,15 +377,20 @@ func (s *session) handleFunctionCall(evt *serverEvent) {
 	}
 
 	// Return tool result and trigger the next model response.
-	_ = s.writeJSON(createConversationItemMessage{
+	if err := s.writeJSON(createConversationItemMessage{
 		Type: "conversation.item.create",
 		Item: conversationItem{
 			Type:   "function_call_output",
 			CallID: evt.CallID,
 			Output: result,
 		},
-	})
-	_ = s.writeJSON(map[string]string{"type": "response.create"})
+	}); err != nil {
+		s.setErr(fmt.Errorf("openai: send tool result: %w", err))
+		return
+	}
+	if err := s.writeJSON(map[string]string{"type": "response.create"}); err != nil {
+		s.setErr(fmt.Errorf("openai: trigger response after tool call: %w", err))
+	}
 }
 
 func (s *session) setErr(err error) {
@@ -534,7 +539,7 @@ func (s *session) InjectTextContext(items []s2s.ContextItem) error {
 			},
 		}
 		if err := s.writeJSON(msg); err != nil {
-			return err
+			return fmt.Errorf("openai: inject context item: %w", err)
 		}
 	}
 	return nil

--- a/pkg/provider/tts/elevenlabs/elevenlabs.go
+++ b/pkg/provider/tts/elevenlabs/elevenlabs.go
@@ -235,7 +235,11 @@ func (p *Provider) SynthesizeStream(ctx context.Context, text <-chan string, voi
 					slog.Debug("elevenlabs: text channel closed, sending flush")
 					// Text channel closed — send flush command.
 					flush := textMessage{Text: ""}
-					flushBytes, _ := json.Marshal(flush)
+					flushBytes, err := json.Marshal(flush)
+					if err != nil {
+						slog.Debug("elevenlabs: marshal flush error", "error", err)
+						return
+					}
 					_ = conn.Write(ctx, websocket.MessageText, flushBytes)
 					// Wait for the reader to finish draining audio.
 					<-readDone
@@ -249,7 +253,11 @@ func (p *Provider) SynthesizeStream(ctx context.Context, text <-chan string, voi
 				payload := textMessage{Text: sentence, VoiceSettings: vs}
 				// Only send voice settings on the first chunk; subsequent chunks can omit them.
 				vs = nil
-				msgBytes, _ := json.Marshal(payload)
+				msgBytes, err := json.Marshal(payload)
+				if err != nil {
+					slog.Debug("elevenlabs: marshal payload error", "error", err)
+					return
+				}
 				if err := conn.Write(ctx, websocket.MessageText, msgBytes); err != nil {
 					slog.Debug("elevenlabs: write error", "error", err)
 					return
@@ -290,7 +298,10 @@ func (p *Provider) acquireAndInit(ctx context.Context, voiceID string) (*websock
 		XiAPIKey:     p.apiKey,
 		OutputFormat: p.outputFormat,
 	}
-	boiBytes, _ := json.Marshal(boi)
+	boiBytes, err := json.Marshal(boi)
+	if err != nil {
+		return nil, fmt.Errorf("elevenlabs: marshal BOI: %w", err)
+	}
 
 	// Try a pre-warmed connection first.
 	if conn := p.takeWarm(voiceID); conn != nil {


### PR DESCRIPTION
## Summary
- Add comma-ok checks to 5 unchecked type assertions in Discord command handlers (`entity.go`, `campaign.go`) that could panic at runtime
- Check `snowflake.Parse` errors in `sessionctrl.go` instead of silently using zero-value IDs (would cause wrong Discord API calls)
- Wrap bare `return err` with context in gateway NPC controller proxy methods, gRPC client callbacks (`server.go`), and usage quota checks (`memory.go`)
- Check `json.Marshal` errors in ElevenLabs TTS WebSocket messages (`elevenlabs.go`) instead of silently sending nil data
- Log `Close()` errors on gRPC worker client connections in `sessionctrl.go`
- Check and propagate `writeJSON` errors in OpenAI Realtime tool call handler (`openai.go`) instead of silently discarding them
- Wrap bare error return in OpenAI s2s `InjectTextContext`

## Files changed (7)
- `internal/discord/commands/entity.go` — 3 unchecked type assertions → comma-ok
- `internal/discord/commands/campaign.go` — 2 unchecked type assertions → comma-ok
- `internal/gateway/sessionctrl.go` — snowflake.Parse checks, error wrapping, Close() logging
- `internal/gateway/grpctransport/server.go` — wrap bare error returns in GatewayClient
- `internal/gateway/usage/memory.go` — wrap bare error return in CheckQuota
- `pkg/provider/tts/elevenlabs/elevenlabs.go` — check json.Marshal errors
- `pkg/provider/s2s/openai/openai.go` — check writeJSON errors, wrap bare return

## Test plan
- [x] `go vet ./...` passes
- [x] `gofmt -l .` clean
- [x] `go test -race -count=1 ./...` — all modified packages pass (whisper/cmd failures are pre-existing missing C library issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)