### PR TITLE
fix: close 4 concurrency bugs in session, gateway, and audio

### DIFF
--- a/internal/gateway/sessionctrl.go
+++ b/internal/gateway/sessionctrl.go
@@ -155,7 +155,20 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 		gc.mu.Unlock()
 		return fmt.Errorf("gateway: session already active for guild %s", req.GuildID)
 	}
+	// Reserve the guild slot with an empty sentinel to prevent concurrent
+	// duplicate Start calls for the same guild from racing past the check.
+	gc.active[req.GuildID] = ""
 	gc.mu.Unlock()
+
+	// releaseGuild removes the reservation on failure.
+	releaseGuild := func() {
+		gc.mu.Lock()
+		// Only delete if still the sentinel (not overwritten by success path).
+		if gc.active[req.GuildID] == "" {
+			delete(gc.active, req.GuildID)
+		}
+		gc.mu.Unlock()
+	}
 
 	// Use the request's CampaignID (from web or Discord) with fallback to
 	// the tenant's default campaign.
@@ -166,6 +179,7 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 
 	sessionID, err := gc.orch.ValidateAndCreate(ctx, gc.tenantID, campaignID, req.GuildID, req.ChannelID, gc.tier)
 	if err != nil {
+		releaseGuild()
 		return fmt.Errorf("gateway: validate session: %w", err)
 	}
 
@@ -177,6 +191,7 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 		defs, listErr := gc.npcStore.List(ctx, campaignID)
 		if listErr != nil {
 			_ = gc.orch.Transition(ctx, sessionID, SessionEnded, listErr.Error())
+			releaseGuild()
 			return fmt.Errorf("gateway: load NPCs for campaign %q: %w", campaignID, listErr)
 		}
 		if len(defs) > 0 {
@@ -208,6 +223,7 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 			if voiceMgr == nil {
 				gc.bridgeSrv.RemoveBridge(sessionID)
 				_ = gc.orch.Transition(ctx, sessionID, SessionEnded, "VoiceManager not available")
+				releaseGuild()
 				return fmt.Errorf("gateway: VoiceManager not available on gateway bot")
 			}
 
@@ -216,6 +232,7 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 			if permErr := checkVoicePermissions(ctx, gc.gwBot.Client().Rest, gID, chID, gc.gwBot.Client().ApplicationID); permErr != nil {
 				gc.bridgeSrv.RemoveBridge(sessionID)
 				_ = gc.orch.Transition(ctx, sessionID, SessionEnded, permErr.Error())
+				releaseGuild()
 				return fmt.Errorf("gateway: voice permission check: %w", permErr)
 			}
 
@@ -227,6 +244,7 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 				voiceMgr.RemoveConn(gID)
 				gc.bridgeSrv.RemoveBridge(sessionID)
 				_ = gc.orch.Transition(ctx, sessionID, SessionEnded, joinErr.Error())
+				releaseGuild()
 				return fmt.Errorf("gateway: join voice channel: %w", joinErr)
 			}
 
@@ -274,6 +292,7 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 				slog.Error("gateway: failed to transition session after dispatch failure",
 					"session_id", sessionID, "err", transErr)
 			}
+			releaseGuild()
 			return fmt.Errorf("gateway: dispatch worker: %w", dispErr)
 		}
 
@@ -426,7 +445,9 @@ func (gc *GatewaySessionController) registerDisconnectListener(sessionID, guildI
 			slog.Info("gateway: bot disconnected from voice externally",
 				"session_id", sessionID, "guild_id", guildID)
 			go func() {
-				if err := gc.Stop(context.Background(), sessionID); err != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				if err := gc.Stop(ctx, sessionID); err != nil {
 					slog.Error("gateway: failed to stop session after voice disconnect",
 						"session_id", sessionID, "err", err)
 				}

--- a/internal/session/worker_handler.go
+++ b/internal/session/worker_handler.go
@@ -28,6 +28,7 @@ type RuntimeFactory func(ctx context.Context, req gateway.StartSessionRequest) (
 type WorkerHandler struct {
 	mu       sync.Mutex
 	sessions map[string]*managedSession
+	starting map[string]struct{} // session IDs currently being initialized
 	factory  RuntimeFactory
 	callback gateway.GatewayCallback
 }
@@ -47,6 +48,7 @@ type managedSession struct {
 func NewWorkerHandler(factory RuntimeFactory, callback gateway.GatewayCallback) *WorkerHandler {
 	return &WorkerHandler{
 		sessions: make(map[string]*managedSession),
+		starting: make(map[string]struct{}),
 		factory:  factory,
 		callback: callback,
 	}
@@ -59,6 +61,12 @@ func (h *WorkerHandler) StartSession(ctx context.Context, req gateway.StartSessi
 		h.mu.Unlock()
 		return fmt.Errorf("session: %q already running", req.SessionID)
 	}
+	if _, starting := h.starting[req.SessionID]; starting {
+		h.mu.Unlock()
+		return fmt.Errorf("session: %q is already starting", req.SessionID)
+	}
+	// Reserve the session ID to prevent concurrent duplicate starts.
+	h.starting[req.SessionID] = struct{}{}
 	h.mu.Unlock()
 
 	// Use a session-scoped context derived from context.Background() instead
@@ -67,18 +75,28 @@ func (h *WorkerHandler) StartSession(ctx context.Context, req gateway.StartSessi
 	// (audio pipeline, consolidator) created by the factory.
 	sessionCtx, cancel := context.WithCancel(context.Background())
 
+	// releaseStart removes the starting reservation on failure.
+	releaseStart := func() {
+		h.mu.Lock()
+		delete(h.starting, req.SessionID)
+		h.mu.Unlock()
+	}
+
 	rt, err := h.factory(sessionCtx, req)
 	if err != nil {
 		cancel()
+		releaseStart()
 		return fmt.Errorf("session: create runtime for %q: %w", req.SessionID, err)
 	}
 
 	if err := rt.Start(sessionCtx, nil); err != nil {
 		cancel()
+		releaseStart()
 		return fmt.Errorf("session: start runtime for %q: %w", req.SessionID, err)
 	}
 
 	h.mu.Lock()
+	delete(h.starting, req.SessionID)
 	h.sessions[req.SessionID] = &managedSession{
 		runtime:   rt,
 		state:     gateway.SessionActive,

--- a/pkg/audio/discord/connection.go
+++ b/pkg/audio/discord/connection.go
@@ -120,23 +120,6 @@ func (c *Connection) ReceiveOpusFrame(userID snowflake.ID, packet *voice.Packet)
 	}
 	c.decodersMu.Unlock()
 
-	// Ensure an input channel exists for this user.
-	c.inputsMu.Lock()
-	ch, chExists := c.inputs[userID]
-	if !chExists {
-		ch = make(chan audio.AudioFrame, inputChannelBuffer)
-		c.inputs[userID] = ch
-	}
-	c.inputsMu.Unlock()
-
-	if !chExists {
-		slog.Debug("discord: new participant", "userID", userID)
-		c.emitEvent(audio.Event{
-			Type:   audio.EventJoin,
-			UserID: userID.String(),
-		})
-	}
-
 	pcm, err := dec.decode(packet.Opus)
 	if err != nil {
 		slog.Warn("discord: opus decode error", "userID", userID, "error", err)
@@ -150,10 +133,43 @@ func (c *Connection) ReceiveOpusFrame(userID snowflake.ID, packet *voice.Packet)
 		Timestamp:  time.Duration(packet.Timestamp) * time.Second / time.Duration(opusSampleRate),
 	}
 
+	// Fast path: send to an existing channel while holding the read lock.
+	// The RLock prevents concurrent CleanupUser/Disconnect from closing the
+	// channel between our map lookup and the send, avoiding a panic on
+	// send-to-closed-channel.
+	c.inputsMu.RLock()
+	ch, chExists := c.inputs[userID]
+	if chExists {
+		select {
+		case ch <- frame:
+		default:
+			// Channel full — drop frame rather than block.
+		}
+		c.inputsMu.RUnlock()
+		return nil
+	}
+	c.inputsMu.RUnlock()
+
+	// Slow path: create channel under write lock. Double-check after
+	// acquiring the write lock in case another goroutine created it.
+	c.inputsMu.Lock()
+	ch, chExists = c.inputs[userID]
+	if !chExists {
+		ch = make(chan audio.AudioFrame, inputChannelBuffer)
+		c.inputs[userID] = ch
+	}
 	select {
 	case ch <- frame:
 	default:
-		// Channel full — drop frame rather than block.
+	}
+	c.inputsMu.Unlock()
+
+	if !chExists {
+		slog.Debug("discord: new participant", "userID", userID)
+		c.emitEvent(audio.Event{
+			Type:   audio.EventJoin,
+			UserID: userID.String(),
+		})
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- **WorkerHandler.StartSession TOCTOU race** — Two concurrent `StartSession` calls for the same session ID could both pass the existence check (lock released between check and insert), creating duplicate sessions and leaking the first runtime. Added a `starting` set to atomically reserve session IDs during initialization.
- **Discord Connection send-on-closed-channel** — `ReceiveOpusFrame` grabbed a channel reference under the lock, released it, then sent to it. `CleanupUser`/`Disconnect` could close the channel in the gap, causing a **panic**. Restructured to hold `RLock` through the non-blocking send (fast path) with a write-lock slow path for channel creation.
- **GatewaySessionController.Start TOCTOU race** — Same check-then-act pattern for the guild→session active map. Two concurrent `Start` calls for the same guild could race past the check. Added sentinel reservation with cleanup on all 6 failure paths.
- **Disconnect listener goroutine without timeout** — Voice disconnect handler called `gc.Stop(context.Background())` which could block indefinitely if the worker is unreachable. Added 30-second timeout context.

### Not bugs (triaged out)
- Double `cancel()` in Dispatcher — `context.CancelFunc` is idempotent in Go
- Recap generator goroutine "leak" — buffered channel (size 1) completes immediately
- PipelineStats `percentiles()` — called under parent mutex, safe
- Mixer barge-in handlers — fire-and-forget event callbacks that complete naturally

## Test plan
- [x] `go test -race -count=1` passes on all affected packages (`internal/session`, `internal/gateway/...`, `pkg/audio/discord`)
- [x] `go vet` clean
- [x] `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)