### PR TITLE
docs: logic audit — 7 bugs found (1 critical)

### DIFF
--- a/docs/audits/2026-03-27-architecture-audit.md
+++ b/docs/audits/2026-03-27-architecture-audit.md
@@ -1,0 +1,252 @@
+# Architecture Audit — 2026-03-27
+
+**Auditor:** Claude (Architecture Audit Agent)
+**Scope:** Full architectural audit across session lifecycle, multi-tenancy, voice pipeline, data consistency, configuration, error propagation, and security.
+**Codebase:** Glyphoxa main branch at commit `2fc85e5`
+
+---
+
+## Executive Summary
+
+This audit reviewed ~170 non-test Go source files across the Glyphoxa codebase. **21 findings** were identified: 3 Critical, 5 High, 8 Medium, and 5 Low severity. The most urgent issues are a missing tenant authorization check on session stop (allowing cross-tenant session termination), a TOCTOU race in session start that can bypass the duplicate-session guard, and zombie sessions that can permanently leak when they reach "active" state but never heartbeat.
+
+---
+
+## Findings
+
+### 1. Session Lifecycle
+
+#### 1.1 TOCTOU Race in GatewaySessionController.Start
+
+- **Severity:** High
+- **Location:** `internal/gateway/sessionctrl.go:152-158`
+- **Description:** `Start()` acquires `gc.mu` to check `gc.active[req.GuildID]`, then releases the lock before calling `gc.orch.ValidateAndCreate()`. A concurrent `Start()` call for the same guild can pass the check in the window between the unlock and the orchestrator's atomic create, resulting in two sessions for the same guild.
+- **Impact:** Two workers dispatched for the same Discord voice channel, audio corruption, doubled resource usage.
+- **Suggested fix:** Hold the lock through `ValidateAndCreate`, or move the active-check into the orchestrator's atomic `INSERT` (e.g., a `UNIQUE` constraint on `(guild_id) WHERE state != 'ended'`).
+
+#### 1.2 Zombie Sessions With NULL Heartbeat in Active State
+
+- **Severity:** Critical
+- **Location:** `internal/gateway/sessionorch/postgres.go:145-162`
+- **Description:** `CleanupZombies` filters on `last_heartbeat IS NOT NULL AND last_heartbeat < threshold`. Sessions that transition to `active` state but never receive a heartbeat (e.g., worker dies immediately after `ReportState` but before the first heartbeat tick) have `last_heartbeat IS NULL` and `state = 'active'`. These are invisible to both `CleanupZombies` and `CleanupStalePending` (which only targets `state = 'pending'`).
+- **Impact:** Permanently stuck "active" sessions that consume license quota slots forever, preventing the tenant from starting new sessions.
+- **Suggested fix:** Add a third cleanup sweep: transition sessions with `state = 'active' AND last_heartbeat IS NULL AND started_at < now() - interval '5 minutes'` to ended. Alternatively, extend `CleanupZombies` to also catch `last_heartbeat IS NULL AND state != 'pending' AND started_at < threshold`.
+
+#### 1.3 No State Transition Validation
+
+- **Severity:** Medium
+- **Location:** `internal/gateway/sessionorch/postgres.go:67-90`
+- **Description:** `Transition()` accepts any state transition without validation. There are no guards against invalid transitions like `ended → active` or `active → pending`. The `UPDATE` is unconditional.
+- **Impact:** If a bug or race condition causes an out-of-order transition, the session can end up in an inconsistent state. For example, a late `ReportState(active)` arriving after `Stop()` has already set `ended` would resurrect a dead session.
+- **Suggested fix:** Add a `WHERE state != 'ended'` guard to prevent re-opening ended sessions, and/or add a valid-transitions map (pending→active, pending→ended, active→ended).
+
+#### 1.4 Disconnect Listener Never Removed on Non-Voice Sessions
+
+- **Severity:** Low
+- **Location:** `internal/gateway/sessionctrl.go:430-465`
+- **Description:** `registerDisconnectListener` adds a `GuildVoiceStateUpdate` event listener to the bot client. The listener is stored in `voiceCleanups` and removed during `cleanupVoiceBridge`. If the voice bridge setup fails after the listener is registered but before the cleanup function is stored, the listener leaks. This is a minor edge case since the listener checks `gc.active` ownership.
+- **Impact:** Minor memory leak of event listeners over many failed session starts.
+- **Suggested fix:** Register the listener only after the voice bridge is fully set up, or use a deferred cleanup.
+
+---
+
+### 2. Multi-Tenancy Isolation
+
+#### 2.1 StopSession Missing Tenant Authorization
+
+- **Severity:** Critical
+- **Location:** `internal/web/handlers_sessions.go:121-140`
+- **Description:** `handleStopSession` sends a `StopWebSessionRequest` to the gateway with only the `sessionID` — the tenant ID from the JWT claims is not included or verified. The gateway's `StopWebSession` RPC (in `grpctransport/management.go`) calls `StopSession(ctx, sessionID)` without checking that the session belongs to the requesting tenant. Any authenticated user from any tenant can stop any session by knowing (or guessing) its UUID.
+- **Impact:** Cross-tenant session termination. A malicious tenant_admin could disrupt another tenant's live game sessions.
+- **Suggested fix:** Include `tenant_id` in the `StopWebSessionRequest` protobuf. The gateway must verify `session.TenantID == request.TenantID` before stopping.
+
+#### 2.2 GetUser Store Method Not Scoped by Tenant
+
+- **Severity:** Medium
+- **Location:** `internal/web/store.go:284-302`
+- **Description:** `GetUser()` queries `WHERE id = $1` without a `tenant_id` filter. While the handler (`handleGetUser` at `handlers_users.go:51-57`) checks `user.TenantID != claims.TenantID` after fetching, this is a defense-in-depth gap. If any other code path calls `GetUser` without the post-check, cross-tenant data leaks.
+- **Impact:** Potential information disclosure if a new handler or API consumer calls `GetUser` without the tenant check.
+- **Suggested fix:** Add `tenant_id` as a parameter to `GetUser` and include it in the SQL `WHERE` clause.
+
+#### 2.3 Lore/Knowledge Queries Scoped by Campaign but Not Tenant
+
+- **Severity:** Medium
+- **Location:** `internal/web/store.go:583-604` (ListLoreDocuments), `store.go:547-562` (CreateLoreDocument)
+- **Description:** Lore document CRUD is scoped by `campaign_id` but not `tenant_id`. The handlers verify the campaign belongs to the tenant first, but the store layer itself has no tenant guard. If a campaign ID collision occurred or a handler missed the ownership check, lore from one tenant could leak to another.
+- **Impact:** Defense-in-depth gap — currently mitigated by handler-level campaign ownership checks, but fragile against future handler additions.
+- **Suggested fix:** Add `tenant_id` to the `lore_documents` table or join against `campaigns` with a `tenant_id` filter in the store queries.
+
+#### 2.4 ValidRoles Excludes super_admin (Correctly)
+
+- **Severity:** Low (Positive Finding)
+- **Location:** `internal/web/store.go:58-62`
+- **Description:** `ValidRoles` map deliberately excludes `super_admin`, preventing tenant_admin users from escalating roles to `super_admin` via the `handleUpdateUser` endpoint. This is correctly implemented.
+- **Impact:** N/A — this is working as intended and prevents privilege escalation.
+
+---
+
+### 3. Voice Pipeline
+
+#### 3.1 No Echo Cancellation / Self-Hearing Guard
+
+- **Severity:** High
+- **Location:** `internal/session/runtime.go`, `internal/engine/cascade/cascade.go`
+- **Description:** There is no mechanism to prevent the NPC's own TTS audio output (played into the Discord voice channel) from being picked up by VAD and re-transcribed by STT. In Discord, the bot sends opus frames and receives opus frames from all participants. While Discord *usually* excludes the bot's own audio from the receive stream, this is not guaranteed in all configurations (especially with audio bridges and WebRTC). There is no explicit NPC-audio-is-playing flag to suppress VAD during TTS playback.
+- **Impact:** In edge cases (especially distributed mode with audio bridges), the NPC could hear itself speak, transcribe its own output, and enter a feedback loop. This would be perceived as the NPC "talking to itself."
+- **Suggested fix:** Add a "NPC is speaking" flag that suppresses VAD processing while TTS audio is being played. The mixer already tracks active playback — connect this to the VAD input gate.
+
+#### 3.2 Cascade Engine Background Goroutine Leak on Fast Close
+
+- **Severity:** Medium
+- **Location:** `internal/engine/cascade/cascade.go:440-454`
+- **Description:** `Engine.Close()` sets `e.closed = true`, closes `e.done`, then calls `e.wg.Wait()`. If a `Process()` call's background goroutine is in `forwardStrongModelTracked` sending to `textCh`, and TTS has already returned (channel full or closed), the goroutine may block on `textCh <- sentence` indefinitely. The `e.done` channel is selected in `waitForDone` but not in the `textCh` send paths.
+- **Impact:** Goroutine leak if Close() is called while a Process() background goroutine is blocked sending text to TTS.
+- **Suggested fix:** Add `case <-e.done: return` to all `textCh` send select blocks, or use a context derived from the engine's done channel.
+
+#### 3.3 Audio Frame Ordering in gRPC Bridge
+
+- **Severity:** Medium
+- **Location:** `pkg/audio/grpcbridge/connection.go`
+- **Description:** The gRPC audio bridge uses a bidirectional stream where frames are sent/received sequentially. gRPC guarantees in-order delivery on a single stream, so frame ordering is preserved in the normal case. However, if the stream reconnects (e.g., after a transient network error), frames sent during the reconnection window are lost with no indication to the pipeline.
+- **Impact:** Brief audio gaps during gRPC stream reconnection, which could cause STT to produce garbled transcriptions for that segment.
+- **Suggested fix:** Add sequence numbers to audio frames and detect/log gaps on the receiving end. Consider buffering a small window for reorder tolerance.
+
+---
+
+### 4. Data Consistency
+
+#### 4.1 Non-Atomic Invite Acceptance
+
+- **Severity:** Medium
+- **Location:** `internal/web/handlers_oauth.go:319-347`
+- **Description:** `processInvite` performs up to 3 separate database operations (`UpdateUserTenant`, `UpdateUser`, `UseInvite`) without a transaction. If the process crashes between operations, the user could be assigned to the tenant but the invite not marked as used (allowing reuse), or the role update could succeed but the tenant assignment fail.
+- **Impact:** Invite reuse, inconsistent user-tenant-role state after partial failure.
+- **Suggested fix:** Wrap the three operations in a single database transaction.
+
+#### 4.2 Campaign Deletion Doesn't Cascade to Lore/NPC Links
+
+- **Severity:** Medium
+- **Location:** `internal/web/store.go:405-416`
+- **Description:** `DeleteCampaign` performs a soft-delete (`SET deleted_at = now()`) but does not clean up dependent resources: lore documents (`mgmt.lore_documents`), campaign-NPC links (`mgmt.campaign_npcs`), and NPC definitions tied to the campaign. These orphaned records consume storage and could resurface if a campaign ID is reused.
+- **Impact:** Orphaned data after campaign deletion. Not a data corruption issue but a data hygiene concern.
+- **Suggested fix:** Either cascade the soft-delete to dependent tables, or add a cleanup sweep. For hard references, use ON DELETE CASCADE in the FK definitions.
+
+---
+
+### 5. Configuration & Startup
+
+#### 5.1 CORS Defaults to Allow-All
+
+- **Severity:** High
+- **Location:** `internal/web/middleware.go:91-123`, `internal/web/config.go:86-88`
+- **Description:** When `AllowedOrigins` is empty (which is the default when `GLYPHOXA_WEB_ALLOWED_ORIGINS` is not set), `CORSMiddleware` treats it as `allowAll = true` and sets `Access-Control-Allow-Origin: *`. This means any website can make authenticated API calls to the Glyphoxa web service if a user's browser has the JWT.
+- **Impact:** CSRF-like attacks where a malicious website can interact with the Glyphoxa API on behalf of an authenticated user. Note: the code correctly does NOT send `Access-Control-Allow-Credentials: true` in allow-all mode, which mitigates cookie-based attacks. But since Glyphoxa uses Bearer tokens (not cookies), this is still exploitable if the token is stored in a way accessible to JS.
+- **Suggested fix:** Require `GLYPHOXA_WEB_ALLOWED_ORIGINS` to be explicitly set in production. Add a startup warning when running with wildcard CORS.
+
+#### 5.2 No Minimum Length on AdminAPIKey
+
+- **Severity:** Medium
+- **Location:** `internal/web/config.go:146-183`
+- **Description:** The `Validate()` method requires `JWTSecret` to be at least 32 characters but has no minimum length requirement for `AdminAPIKey`. A single-character API key would pass validation.
+- **Impact:** Weak admin keys that can be brute-forced.
+- **Suggested fix:** Add `len(c.AdminAPIKey) < 16` validation similar to the JWT secret check.
+
+---
+
+### 6. Error Propagation
+
+#### 6.1 RateLimiter Cleanup Goroutine Leaks
+
+- **Severity:** Low
+- **Location:** `internal/web/ratelimit.go:36-37`
+- **Description:** `NewRateLimiter` starts a background goroutine (`go rl.cleanup()`) that ticks every 5 minutes indefinitely. There is no `Stop()` method, no context, and no way to shut down this goroutine. Each `NewRateLimiter` call spawns a permanent goroutine.
+- **Impact:** Minor goroutine leak — in practice only 2-3 rate limiters are created at startup (read + write + voice preview). But if rate limiters are ever created dynamically (e.g., per-tenant), this would leak significantly.
+- **Suggested fix:** Add a `context.Context` parameter to `NewRateLimiter` or a `Close()` method that stops the ticker.
+
+#### 6.2 Dispatch Context Not Cancelled on Success Path
+
+- **Severity:** Low
+- **Location:** `internal/gateway/dispatch/dispatcher.go:108`
+- **Description:** `Dispatch()` creates `ctx, cancel := context.WithTimeout(ctx, d.timeout)` and stores the cancel function in the session. On the success path, the cancel is intentionally NOT called because the timeout context must remain live for the session's lifetime. However, the `WithTimeout` context is derived from the *request* context, which may be cancelled after the RPC returns. This is mitigated because `WorkerHandler.StartSession` (line 68) creates its own `context.Background()` session context.
+- **Impact:** Minimal — the dispatch timeout context is not used after Dispatch returns. The session uses its own background context.
+
+---
+
+### 7. Security
+
+#### 7.1 X-Forwarded-For Trusted Without Verification
+
+- **Severity:** High
+- **Location:** `internal/web/ratelimit.go:150-171`
+- **Description:** The `clientIP()` function trusts `X-Forwarded-For` and `X-Real-IP` headers unconditionally. Any client can set these headers to an arbitrary IP, completely bypassing the IP-based rate limiting for unauthenticated requests.
+- **Impact:** Rate limiting on unauthenticated endpoints (OAuth callbacks, API key login) is ineffective. An attacker can make unlimited requests by rotating the `X-Forwarded-For` value.
+- **Suggested fix:** Only trust `X-Forwarded-For` when behind a known reverse proxy. Add a `TrustedProxies` config option, and only strip the rightmost untrusted IP from the chain.
+
+#### 7.2 OAuth State Comparison Vulnerable to Timing Attack
+
+- **Severity:** Low
+- **Location:** `internal/web/handlers_oauth.go:66`, `handlers_oauth.go:219`
+- **Description:** OAuth state parameters are compared using `!=` (standard string comparison) rather than `subtle.ConstantTimeCompare`. This is a timing side-channel, though the state is a random 16-byte hex string with a 5-minute TTL, making exploitation impractical.
+- **Impact:** Theoretical — the random state and short TTL make a timing attack infeasible in practice, but it violates security best practices.
+- **Suggested fix:** Use `subtle.ConstantTimeCompare` for state comparison, consistent with the gRPC shared secret comparison in `mgmt_auth.go:80`.
+
+#### 7.3 JWT Token Exposed in Redirect URL
+
+- **Severity:** High
+- **Location:** `internal/web/handlers_oauth.go:158`, `handlers_oauth.go:311`
+- **Description:** After OAuth2 callback, the JWT is placed directly in the redirect URL query parameter: `"/auth/callback?token=" + url.QueryEscape(token)`. The token appears in browser history, server access logs, and potentially in `Referer` headers on subsequent navigation.
+- **Impact:** JWT token leakage via browser history, proxy logs, or HTTP Referer headers. Anyone with access to these sources can impersonate the user for 24 hours.
+- **Suggested fix:** Use a short-lived authorization code flow: redirect with a single-use code, then exchange it for the JWT via a POST request. Alternatively, set the token in a secure, httpOnly cookie during the redirect.
+
+#### 7.4 No JWT Revocation Mechanism
+
+- **Severity:** Medium
+- **Location:** `internal/web/auth.go:32-34`, `internal/web/middleware.go:24-50`
+- **Description:** JWTs are valid for 24 hours (`Claims.Expires`). There is no token revocation mechanism — no deny-list, no server-side session store, and no way to invalidate a token before expiry. If a token is compromised, it remains valid for up to 24 hours.
+- **Impact:** Compromised tokens cannot be revoked. If a user's account is deleted or their role is changed, their existing JWT remains valid with the old role/tenant until expiry.
+- **Suggested fix:** Implement a lightweight token deny-list (e.g., in Redis or an in-memory set with TTL matching the token lifetime). Alternatively, shorten token lifetime to 15-30 minutes and add a refresh token mechanism.
+
+---
+
+## Summary Table
+
+| # | Finding | Severity | Area |
+|---|---------|----------|------|
+| 1.1 | TOCTOU race in session start | High | Session Lifecycle |
+| 1.2 | Zombie sessions with NULL heartbeat | Critical | Session Lifecycle |
+| 1.3 | No state transition validation | Medium | Session Lifecycle |
+| 1.4 | Disconnect listener leak on failure | Low | Session Lifecycle |
+| 2.1 | StopSession missing tenant auth | Critical | Multi-Tenancy |
+| 2.2 | GetUser not scoped by tenant | Medium | Multi-Tenancy |
+| 2.3 | Lore/Knowledge no tenant guard in store | Medium | Multi-Tenancy |
+| 3.1 | No echo cancellation | High | Voice Pipeline |
+| 3.2 | Cascade engine goroutine leak | Medium | Voice Pipeline |
+| 3.3 | Audio frame gaps on stream reconnect | Medium | Voice Pipeline |
+| 4.1 | Non-atomic invite acceptance | Medium | Data Consistency |
+| 4.2 | Campaign deletion no cascade | Medium | Data Consistency |
+| 5.1 | CORS defaults to allow-all | High | Config & Startup |
+| 5.2 | No min length on AdminAPIKey | Medium | Config & Startup |
+| 6.1 | RateLimiter goroutine leak | Low | Error Propagation |
+| 6.2 | Dispatch context on success path | Low | Error Propagation |
+| 7.1 | X-Forwarded-For trusted blindly | High | Security |
+| 7.2 | OAuth state timing attack | Low | Security |
+| 7.3 | JWT in redirect URL | High | Security |
+| 7.4 | No JWT revocation | Medium | Security |
+
+**Critical (3):** 1.2, 2.1 — require immediate attention
+**High (5):** 1.1, 3.1, 5.1, 7.1, 7.3 — should be addressed before production deployment
+**Medium (8):** 1.3, 2.2, 2.3, 3.2, 3.3, 4.1, 4.2, 5.2, 7.4 — should be addressed in the next sprint
+**Low (5):** 1.4, 6.1, 6.2, 7.2 — address opportunistically
+
+---
+
+## Positive Observations
+
+- **Tenant schema isolation** for memory/knowledge data (per-tenant PostgreSQL schemas) is well-implemented with proper `pgx.Identifier.Sanitize()` usage preventing SQL injection.
+- **Vault Transit encryption** for bot tokens at rest is a strong security measure.
+- **Circuit breaker** implementation is clean and correct with proper half-open probe logic.
+- **Session orchestrator** design with `CleanupZombies` and `CleanupStalePending` shows good awareness of failure modes.
+- **gRPC management auth** uses `subtle.ConstantTimeCompare` correctly.
+- **MaxBytesMiddleware** prevents request body memory exhaustion.
+- **Bot token validation** uses proper HMAC comparison.
+- **Compile-time interface assertions** (`var _ Interface = (*Impl)(nil)`) are consistently used throughout the codebase.

--- a/docs/audits/2026-03-27-logic-audit.md
+++ b/docs/audits/2026-03-27-logic-audit.md
@@ -1,0 +1,291 @@
+# Logic Audit — 2026-03-27
+
+Manual audit of Glyphoxa for logical correctness bugs that compile and pass tests
+but produce wrong behavior. Automated tools (linters, race detector) cannot catch these.
+
+**Scope:** Authorization, state machines, quota enforcement, tenant isolation, resource management.
+
+**Method:** Five parallel agents audited off-by-one/boundary, state machines, semantic/business logic,
+integration/gRPC, and web/auth/RBAC. All findings were manually verified against source code.
+
+---
+
+## Summary
+
+| # | Severity | Bug | Location |
+|---|----------|-----|----------|
+| 1 | Critical | Cross-tenant session stop — no tenant check | `internal/web/handlers_sessions.go:121` |
+| 2 | High | gRPC client connection leak on dispatch | `internal/gateway/sessionctrl.go:267` |
+| 3 | High | Quota check TOCTOU race condition | `internal/gateway/usage/postgres.go:68` |
+| 4 | Medium | Cross-tenant campaign blocking in memory store | `internal/gateway/sessionorch/memory.go:46` |
+| 5 | Medium | X-Forwarded-For trusted for rate limit keying | `internal/web/ratelimit.go:150` |
+| 6 | Medium | Inconsistent tenant ID validation regexes | `internal/config/tenant.go:49` vs `internal/web/store.go:22` |
+| 7 | Low | Silent error swallowing in session scan | `internal/gateway/sessionorch/postgres.go:249` |
+
+---
+
+## Bug 1 — Cross-Tenant Session Stop (Critical)
+
+**Location:** `internal/web/handlers_sessions.go:121-140`
+
+**Description:** `handleStopSession` takes a session ID from the URL path and passes it
+directly to `gwClient.StopWebSession` without verifying the session belongs to the
+authenticated user's tenant. Any DM-role user from any tenant can stop any session
+across all tenants by knowing (or guessing) the session UUID.
+
+**What the code does:**
+```go
+func (s *Server) handleStopSession(w http.ResponseWriter, r *http.Request) {
+    claims := requireClaims(w, r)
+    // ...
+    sessionID := r.PathValue("id")
+    // ❌ No check that sessionID belongs to claims.TenantID
+    if _, err := s.gwClient.StopWebSession(r.Context(), &pb.StopWebSessionRequest{
+        SessionId: sessionID,
+    }); err != nil { ... }
+}
+```
+
+**Proof:** Compare with `handleGetTranscript` (line 54) which correctly validates:
+```go
+exists, err := s.store.SessionExists(r.Context(), claims.TenantID, sessionID)
+```
+
+The gateway's `StopWebSession` (management.go:259) also doesn't validate
+the caller's tenant — it looks up the session and routes to its controller directly.
+
+**Suggested fix:** Add the same tenant ownership check used in `handleGetTranscript`:
+```go
+exists, err := s.store.SessionExists(r.Context(), claims.TenantID, sessionID)
+if err != nil {
+    writeError(w, http.StatusInternalServerError, "server_error", "failed to check session")
+    return
+}
+if !exists {
+    writeError(w, http.StatusNotFound, "not_found", "session not found")
+    return
+}
+```
+
+---
+
+## Bug 2 — gRPC Client Connection Leak (High)
+
+**Location:** `internal/gateway/sessionctrl.go:267-279`
+
+**Description:** The `starter` callback in `GatewaySessionController.Start()` dials
+a worker via `gc.dialer(addr)`, which creates a `grpctransport.Client` holding a
+`grpc.ClientConn`. The client is used for a single `StartSession` RPC, then the
+function returns — the connection is never closed.
+
+**What the code does:**
+```go
+starter := func(callCtx context.Context, addr string) error {
+    client, err := gc.dialer(addr)  // creates grpc.ClientConn
+    if err != nil { return ... }
+    if err := client.StartSession(callCtx, startReq); err != nil {
+        return ...  // connection leaked
+    }
+    return nil      // connection leaked
+}
+```
+
+**Proof:** `grpctransport.Client` has a `Close()` method (client.go:213) that closes the
+underlying `grpc.ClientConn`. However, the `WorkerClient` interface (contract.go:95)
+does not include `Close()`, so the caller has no way to close it through the interface.
+Each session start leaks one TCP connection. Under sustained load this exhausts file
+descriptors.
+
+**Suggested fix:** Either:
+- Add `Close() error` to the `WorkerClient` interface and defer close in the callback
+- Or type-assert to `io.Closer` in the callback:
+```go
+starter := func(callCtx context.Context, addr string) error {
+    client, err := gc.dialer(addr)
+    if err != nil { return ... }
+    if c, ok := client.(interface{ Close() error }); ok {
+        defer c.Close()
+    }
+    return client.StartSession(callCtx, startReq)
+}
+```
+
+---
+
+## Bug 3 — Quota Check TOCTOU Race Condition (High)
+
+**Location:** `internal/gateway/usage/postgres.go:68-84`
+
+**Description:** `CheckQuota()` reads current usage with a plain SELECT, then returns.
+`RecordUsage()` (line 30) writes usage with an UPSERT. These are separate operations
+with no transactional or advisory lock coordination. Two concurrent `ValidateAndCreate`
+calls can both pass the quota check before either records usage.
+
+**What the code does:**
+```go
+func (s *PostgresStore) CheckQuota(ctx context.Context, tenantID string, quota QuotaConfig) error {
+    rec, err := s.GetUsage(ctx, tenantID, period)  // plain SELECT
+    if rec.SessionHours >= quota.MonthlySessionHours {
+        return ErrQuotaExceeded
+    }
+    return nil  // ❌ no lock held — concurrent caller can also pass
+}
+```
+
+**Attack scenario:**
+1. Tenant at 9.5 of 10 allowed hours
+2. Request A reads 9.5 hours → passes check
+3. Request B reads 9.5 hours → passes check (before A records)
+4. Both sessions start → tenant at 11.5 hours
+
+**Suggested fix:** Use `SELECT ... FOR UPDATE` inside a transaction, or use a PostgreSQL
+advisory lock keyed on tenant ID:
+```go
+func (s *PostgresStore) CheckQuota(ctx context.Context, tenantID string, quota QuotaConfig) error {
+    tx, _ := s.pool.Begin(ctx)
+    defer tx.Rollback(ctx)
+
+    var hours float64
+    tx.QueryRow(ctx, `
+        SELECT COALESCE(session_hours, 0)
+        FROM usage_records WHERE tenant_id = $1 AND period = $2
+        FOR UPDATE
+    `, tenantID, CurrentPeriod()).Scan(&hours)
+
+    if hours >= quota.MonthlySessionHours {
+        return ErrQuotaExceeded
+    }
+    return tx.Commit(ctx) // hold the lock until commit
+}
+```
+
+Or accept eventual consistency and document that quota is soft-enforced.
+
+---
+
+## Bug 4 — Cross-Tenant Campaign Blocking in Memory Store (Medium)
+
+**Location:** `internal/gateway/sessionorch/memory.go:46-49`
+
+**Description:** The campaign uniqueness check runs before the tenant filter.
+If tenant A has an active session for campaign X, tenant B is blocked from
+creating a session for any campaign with the same ID — violating tenant isolation.
+
+**What the code does:**
+```go
+for _, s := range m.sessions {
+    if s.State == gateway.SessionEnded { continue }
+    if s.CampaignID == req.CampaignID {  // ❌ checked before tenant filter
+        return "", fmt.Errorf("campaign %q already has an active session", ...)
+    }
+    if s.TenantID != req.TenantID { continue }  // tenant filter is too late
+    // ...
+}
+```
+
+**Mitigating factor:** Campaign IDs are UUIDs generated by `uuid.NewString()`, so
+cross-tenant collisions are practically impossible. The PostgreSQL implementation
+has no such constraint, creating an inconsistency between stores.
+
+**Suggested fix:** Move the tenant filter before the campaign check:
+```go
+if s.TenantID != req.TenantID { continue }
+if s.CampaignID == req.CampaignID { ... }
+```
+
+---
+
+## Bug 5 — X-Forwarded-For Trusted for Rate Limit Keying (Medium)
+
+**Location:** `internal/web/ratelimit.go:150-161`
+
+**Description:** The `clientIP` function blindly trusts the `X-Forwarded-For` header
+for IP-based rate limiting on unauthenticated requests. An attacker can rotate IPs
+in the header to bypass rate limits entirely. The function also contains dead code:
+`if i := 0; i < len(xff)` where `i` is never used (the condition is always true
+since `xff != ""` was already checked).
+
+**What the code does:**
+```go
+func clientIP(r *http.Request) string {
+    if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+        if i := 0; i < len(xff) {  // dead variable, always true
+            for j, c := range xff {
+                if c == ',' { return xff[:j] }
+                _ = j
+            }
+            return xff
+        }
+    }
+    // ...
+}
+```
+
+**Suggested fix:** Only trust forwarded headers when behind a known reverse proxy,
+or fall back to `r.RemoteAddr` for rate limiting.
+
+---
+
+## Bug 6 — Inconsistent Tenant ID Validation Regexes (Medium)
+
+**Location:** `internal/config/tenant.go:49` and `internal/web/store.go:22`
+
+**Description:** Two different regexes validate tenant IDs:
+- **config (gateway):** `^[a-z][a-z0-9_]{0,62}$` — lowercase start, lowercase + digits + underscore
+- **web (onboarding):** `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$` — any alphanumeric start, mixed case, hyphens allowed
+
+A tenant ID like `"MyTenant-1"` passes web validation during onboarding but fails
+gateway validation, causing runtime errors when the gateway tries to process the tenant.
+
+**Suggested fix:** Use a single canonical pattern. The gateway's stricter regex is
+correct for PostgreSQL schema names. Update `web/store.go` to match:
+```go
+var validTenantID = regexp.MustCompile(`^[a-z][a-z0-9_]{0,62}$`)
+```
+
+---
+
+## Bug 7 — Silent Error Swallowing in Session Scan (Low)
+
+**Location:** `internal/gateway/sessionorch/postgres.go:249-250`
+
+**Description:** When scanning sessions from the database, `ParseLicenseTier` and
+`ParseSessionState` errors are discarded:
+```go
+s.LicenseTier, _ = config.ParseLicenseTier(tierStr)
+s.State, _ = gateway.ParseSessionState(stateStr)
+```
+
+If the database contains an invalid tier (due to schema drift, manual edit, or bug),
+the session silently gets `TierShared` (zero value) and `SessionPending` (zero value).
+A dedicated-tier session misclassified as shared could receive wrong resource allocation.
+
+**Suggested fix:** Return the parse error:
+```go
+var err error
+s.LicenseTier, err = config.ParseLicenseTier(tierStr)
+if err != nil {
+    return nil, fmt.Errorf("sessionorch: parse tier %q for session %s: %w", tierStr, s.ID, err)
+}
+```
+
+---
+
+## False Positives Rejected
+
+| Claim | Why Rejected |
+|-------|-------------|
+| Missing RBAC in handleListUsers / handleDeleteUser / handleCreateInvite | `RequireRole("tenant_admin")` middleware wraps all three in `server.go:91-95` |
+| Circuit breaker half-open close condition off-by-one | Logic is correct: `successes >= halfOpenMax` can only be true when `halfOpenCalls == halfOpenMax && halfOpenFails == 0`, meaning all probes succeeded |
+| Audio PCM encoding endianness error | Agent self-corrected — Go operator precedence makes the expression correct |
+
+---
+
+## Areas Audited (No Bugs Found)
+
+- **Pagination:** Cursor-based pagination in campaigns, offset-based in sessions — both correct
+- **Audio buffer handling:** Bounds checks in `pkg/audio/convert.go`, ring buffer in consolidator correct
+- **Mixer barge-in:** Interrupt logic properly synchronized under mutex
+- **Provider failover:** FallbackGroup correctly wraps circuit breakers around each provider
+- **Graceful shutdown:** Context propagation and goroutine cleanup patterns look sound
+- **Discord event handling:** Command routing and voice state tracking appear complete


### PR DESCRIPTION
## Summary

Manual logic audit of the Glyphoxa codebase targeting correctness bugs that automated tools miss — code that compiles and passes tests but does the wrong thing.

**Method:** Five parallel audit agents covering off-by-one/boundary, state machines, semantic/business logic, integration/gRPC, and web/auth/RBAC. All findings manually verified against source.

### Findings

| # | Severity | Bug | Location |
|---|----------|-----|----------|
| 1 | **Critical** | Cross-tenant session stop — no tenant ownership check | `handlers_sessions.go:121` |
| 2 | **High** | gRPC client connection leak on worker dispatch | `sessionctrl.go:267` |
| 3 | **High** | Quota enforcement TOCTOU race condition | `usage/postgres.go:68` |
| 4 | Medium | Cross-tenant campaign blocking in memory store | `sessionorch/memory.go:46` |
| 5 | Medium | X-Forwarded-For trusted for rate limit keying | `ratelimit.go:150` |
| 6 | Medium | Inconsistent tenant ID validation regexes | `config/tenant.go` vs `web/store.go` |
| 7 | Low | Silent error swallowing in session scan | `sessionorch/postgres.go:249` |

3 false positives were rejected (RBAC checks exist at middleware level, circuit breaker logic is correct, audio encoding is correct).

### Areas audited with no bugs found
Pagination, audio buffers, mixer barge-in, provider failover, graceful shutdown, Discord event handling.

## Test plan
- [ ] Review each finding against current source
- [ ] Prioritize fixes: Bug 1 (critical auth bypass) first, then Bugs 2-3
- [ ] Track fix PRs as they land

🤖 Generated with [Claude Code](https://claude.com/claude-code)