### PR TITLE
ci: add web-ui frontend Docker image to CI pipeline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -104,3 +104,51 @@ jobs:
           labels: ${{ steps.meta-web.outputs.labels }}
           cache-from: type=gha,scope=glyphoxa-web
           cache-to: type=gha,mode=max,scope=glyphoxa-web
+
+  # ---------------------------------------------------------------------------
+  # Glyphoxa web UI (Next.js frontend only)
+  # ---------------------------------------------------------------------------
+  docker-web-ui:
+    name: Build and push (glyphoxa-web-ui)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta-web-ui
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/mrwong99/glyphoxa-web-ui
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.web-ui
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-web-ui.outputs.tags }}
+          labels: ${{ steps.meta-web-ui.outputs.labels }}
+          cache-from: type=gha,scope=glyphoxa-web-ui
+          cache-to: type=gha,mode=max,scope=glyphoxa-web-ui

--- a/Dockerfile.web-ui
+++ b/Dockerfile.web-ui
@@ -1,0 +1,49 @@
+# =============================================================================
+# Multi-stage build for Glyphoxa Web UI (Next.js frontend only)
+# =============================================================================
+#
+# Builds the Next.js frontend in standalone mode. The Go API backend is
+# deployed separately via Dockerfile.web or as its own service.
+#
+# The API_BACKEND_URL build arg controls where Next.js rewrites /api/*
+# requests (resolved at build time via next.config.ts).
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage 1: Build Next.js frontend (standalone output)
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS build
+
+WORKDIR /app
+
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+
+COPY web/ ./
+
+# Set backend URL for Next.js rewrites (resolved at build time).
+ARG API_BACKEND_URL=http://glyphoxa-web-api:8090
+ENV API_BACKEND_URL=${API_BACKEND_URL}
+
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage 2: Runtime
+# ---------------------------------------------------------------------------
+FROM node:22-slim
+
+RUN groupadd -r glyphoxa && useradd -r -g glyphoxa -m glyphoxa
+
+# Copy Next.js standalone server and static assets.
+COPY --from=build /app/.next/standalone /app
+COPY --from=build /app/.next/static /app/.next/static
+
+ENV HOSTNAME="0.0.0.0"
+ENV PORT=3000
+
+USER glyphoxa
+WORKDIR /app
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary
- Add `Dockerfile.web-ui` — standalone Next.js frontend image (node:22-slim, standalone output)
- Add `docker-web-ui` job to `.github/workflows/docker.yml` to build and push `ghcr.io/mrwong99/glyphoxa-web-ui` with the same cache/platform/tag strategy as the other two images

## Notes
- No K3s manifest update needed — there's no existing web-ui deployment reference to change
- The existing `Dockerfile.web` (combined frontend+backend) is unchanged

## Test plan
- [ ] CI `docker-web-ui` job passes on this branch
- [ ] Image appears at `ghcr.io/mrwong99/glyphoxa-web-ui:feat-docker-webui-ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)