### PR TITLE
fix: enforce gRPC mgmt secret and constant-time API key comparison

### DIFF
--- a/internal/gateway/admin.go
+++ b/internal/gateway/admin.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -166,7 +167,7 @@ func (a *AdminAPI) authMiddleware(next http.Handler) http.Handler {
 		if len(key) > len(bearerPrefix) && key[:len(bearerPrefix)] == bearerPrefix {
 			key = key[len(bearerPrefix):]
 		}
-		if key != a.apiKey {
+		if subtle.ConstantTimeCompare([]byte(key), []byte(a.apiKey)) != 1 {
 			writeAdminError(w, http.StatusForbidden, "invalid API key")
 			return
 		}

--- a/internal/gateway/grpctransport/mgmt_auth.go
+++ b/internal/gateway/grpctransport/mgmt_auth.go
@@ -25,7 +25,8 @@ const (
 // validates a shared secret in gRPC metadata for ManagementService RPCs.
 // Other services (GatewayService, AudioBridgeService) pass through unchecked.
 //
-// If secret is empty the interceptor is a no-op (backward compatible for dev).
+// If secret is empty, all ManagementService RPCs are rejected (fail-closed).
+// Set GLYPHOXA_GRPC_MGMT_SECRET in production.
 func ManagementAuthUnaryInterceptor(secret string) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
@@ -33,8 +34,12 @@ func ManagementAuthUnaryInterceptor(secret string) grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (any, error) {
-		if secret == "" || !strings.HasPrefix(info.FullMethod, managementServicePrefix) {
+		if !strings.HasPrefix(info.FullMethod, managementServicePrefix) {
 			return handler(ctx, req)
+		}
+		if secret == "" {
+			slog.Error("mgmt-auth: GLYPHOXA_GRPC_MGMT_SECRET not configured — rejecting management RPC", "method", info.FullMethod)
+			return nil, status.Error(codes.Unavailable, "management secret not configured — set GLYPHOXA_GRPC_MGMT_SECRET")
 		}
 		if err := verifyMgmtSecret(ctx, secret); err != nil {
 			return nil, err
@@ -45,6 +50,8 @@ func ManagementAuthUnaryInterceptor(secret string) grpc.UnaryServerInterceptor {
 
 // ManagementAuthStreamInterceptor returns a [grpc.StreamServerInterceptor]
 // that validates a shared secret for ManagementService streaming RPCs.
+//
+// If secret is empty, all ManagementService streaming RPCs are rejected (fail-closed).
 func ManagementAuthStreamInterceptor(secret string) grpc.StreamServerInterceptor {
 	return func(
 		srv any,
@@ -52,8 +59,12 @@ func ManagementAuthStreamInterceptor(secret string) grpc.StreamServerInterceptor
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
 	) error {
-		if secret == "" || !strings.HasPrefix(info.FullMethod, managementServicePrefix) {
+		if !strings.HasPrefix(info.FullMethod, managementServicePrefix) {
 			return handler(srv, ss)
+		}
+		if secret == "" {
+			slog.Error("mgmt-auth: GLYPHOXA_GRPC_MGMT_SECRET not configured — rejecting management RPC", "method", info.FullMethod)
+			return status.Error(codes.Unavailable, "management secret not configured — set GLYPHOXA_GRPC_MGMT_SECRET")
 		}
 		if err := verifyMgmtSecret(ss.Context(), secret); err != nil {
 			return err

--- a/internal/gateway/grpctransport/mgmt_auth_test.go
+++ b/internal/gateway/grpctransport/mgmt_auth_test.go
@@ -26,9 +26,16 @@ func TestManagementAuthUnaryInterceptor(t *testing.T) {
 		wantPass bool
 	}{
 		{
-			name:     "no secret configured — passthrough",
+			name:     "no secret configured — fail-closed",
 			secret:   "",
 			method:   "/glyphoxa.v1.ManagementService/CreateTenant",
+			mdSecret: "",
+			wantCode: codes.Unavailable,
+		},
+		{
+			name:     "non-management RPC — passthrough even without secret",
+			secret:   "",
+			method:   "/glyphoxa.v1.GatewayService/SessionReady",
 			mdSecret: "",
 			wantPass: true,
 		},
@@ -116,9 +123,16 @@ func TestManagementAuthStreamInterceptor(t *testing.T) {
 		wantPass bool
 	}{
 		{
-			name:     "no secret configured - passthrough",
+			name:     "no secret configured - fail-closed",
 			secret:   "",
 			method:   "/glyphoxa.v1.ManagementService/CreateTenant",
+			mdSecret: "",
+			wantCode: codes.Unavailable,
+		},
+		{
+			name:     "non-management RPC - passthrough even without secret",
+			secret:   "",
+			method:   "/glyphoxa.v1.GatewayService/SessionReady",
 			mdSecret: "",
 			wantPass: true,
 		},


### PR DESCRIPTION
## Summary

- **gRPC management secret fail-closed (Critical -- audit 5.2):** `ManagementAuthUnaryInterceptor` and `ManagementAuthStreamInterceptor` now reject all ManagementService RPCs with `codes.Unavailable` when `GLYPHOXA_GRPC_MGMT_SECRET` is empty, instead of silently passing them through. Non-management RPCs (GatewayService, AudioBridgeService) are unaffected.
- **Admin API constant-time key comparison (High -- audit 7.5):** `authMiddleware` in `admin.go` now uses `crypto/subtle.ConstantTimeCompare` instead of `!=` for API key validation, eliminating timing side-channel attacks.
- Updated tests to cover fail-closed behavior and added test case for non-management RPCs passthrough when no secret is configured.

## Test plan

- [x] `go test -race -count=1 ./internal/gateway/grpctransport/...` -- all pass
- [x] `go test -race -count=1 ./internal/gateway/...` -- all pass
- [x] `gofmt -w .` -- clean
- [ ] Verify in staging that management RPCs fail when `GLYPHOXA_GRPC_MGMT_SECRET` is unset
- [ ] Verify gateway/worker RPCs still work without a management secret

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)