### PR TITLE
fix: block SSRF via provider test endpoint (audit 7.4)

### DIFF
--- a/internal/web/handlers_providers.go
+++ b/internal/web/handlers_providers.go
@@ -38,6 +38,13 @@ func (s *Server) handleTestProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate base URL to prevent SSRF attacks — block private IPs,
+	// internal DNS, cloud metadata endpoints, and K8s service addresses.
+	if err := validateBaseURL(body.BaseURL, nil); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_base_url", err.Error())
+		return
+	}
+
 	start := time.Now()
 	testErr := testProviderConnection(r, body.Type, body.Provider, body.APIKey, body.BaseURL)
 	latency := time.Since(start).Milliseconds()

--- a/internal/web/handlers_providers_test.go
+++ b/internal/web/handlers_providers_test.go
@@ -1,0 +1,153 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleTestProvider_SSRFBlocked(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	srv.mux.Handle("POST /api/v1/providers/test", AuthMiddleware(secret)(http.HandlerFunc(srv.handleTestProvider)))
+
+	tests := []struct {
+		name    string
+		baseURL string
+		wantOK  bool
+	}{
+		{
+			name:    "private 10.x blocked",
+			baseURL: "http://10.0.0.1",
+			wantOK:  false,
+		},
+		{
+			name:    "private 192.168.x blocked",
+			baseURL: "http://192.168.1.1",
+			wantOK:  false,
+		},
+		{
+			name:    "loopback blocked",
+			baseURL: "http://127.0.0.1",
+			wantOK:  false,
+		},
+		{
+			name:    "metadata endpoint blocked",
+			baseURL: "http://169.254.169.254",
+			wantOK:  false,
+		},
+		{
+			name:    "localhost hostname blocked",
+			baseURL: "http://localhost",
+			wantOK:  false,
+		},
+		{
+			name:    "kubernetes service DNS blocked",
+			baseURL: "https://vault.default.svc.cluster.local",
+			wantOK:  false,
+		},
+		{
+			name:    "file scheme blocked",
+			baseURL: "file:///etc/passwd",
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body, _ := json.Marshal(map[string]string{
+				"type":     "llm",
+				"provider": "openai",
+				"api_key":  "sk-test",
+				"base_url": tt.baseURL,
+			})
+			req := authReq(t, http.MethodPost, "/api/v1/providers/test",
+				bytes.NewBuffer(body), secret, "user-1", "tenant-1", "tenant_admin")
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rr, req)
+
+			if tt.wantOK {
+				if rr.Code == http.StatusBadRequest {
+					t.Errorf("expected request to be allowed, got 400: %s", rr.Body.String())
+				}
+			} else {
+				if rr.Code != http.StatusBadRequest {
+					t.Errorf("expected 400 for SSRF attempt, got %d: %s", rr.Code, rr.Body.String())
+				}
+				// Verify error response structure.
+				var resp struct {
+					Error struct {
+						Code    string `json:"code"`
+						Message string `json:"message"`
+					} `json:"error"`
+				}
+				if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+					t.Fatalf("decode response: %v", err)
+				}
+				if resp.Error.Code != "invalid_base_url" {
+					t.Errorf("error code = %q, want %q", resp.Error.Code, "invalid_base_url")
+				}
+			}
+		})
+	}
+}
+
+func TestHandleTestProvider_EmptyBaseURLAllowed(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	srv.mux.Handle("POST /api/v1/providers/test", AuthMiddleware(secret)(http.HandlerFunc(srv.handleTestProvider)))
+
+	// An empty base_url should pass validation (uses provider defaults).
+	// The request will fail at the provider connection stage since we have
+	// no real API key, but it should NOT fail with "invalid_base_url".
+	body, _ := json.Marshal(map[string]string{
+		"type":     "llm",
+		"provider": "openai",
+		"api_key":  "sk-test",
+	})
+	req := authReq(t, http.MethodPost, "/api/v1/providers/test",
+		bytes.NewBuffer(body), secret, "user-1", "tenant-1", "tenant_admin")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	// Should not be a 400 with "invalid_base_url".
+	if rr.Code == http.StatusBadRequest {
+		var resp struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		_ = json.NewDecoder(rr.Body).Decode(&resp)
+		if resp.Error.Code == "invalid_base_url" {
+			t.Error("empty base_url should not trigger SSRF validation")
+		}
+	}
+}
+
+func TestHandleTestProvider_MissingFields(t *testing.T) {
+	t.Parallel()
+
+	srv, _, _, secret := testServerWithStores(t)
+	srv.mux.Handle("POST /api/v1/providers/test", AuthMiddleware(secret)(http.HandlerFunc(srv.handleTestProvider)))
+
+	body, _ := json.Marshal(map[string]string{
+		"api_key": "sk-test",
+	})
+	req := authReq(t, http.MethodPost, "/api/v1/providers/test",
+		bytes.NewBuffer(body), secret, "user-1", "tenant-1", "tenant_admin")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+}

--- a/internal/web/urlvalidation.go
+++ b/internal/web/urlvalidation.go
@@ -1,0 +1,161 @@
+package web
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// isPrivateIP reports whether ip is a private, loopback, link-local,
+// or otherwise non-routable address that should be blocked to prevent
+// SSRF attacks.
+func isPrivateIP(ip net.IP) bool {
+	// Loopback (127.0.0.0/8, ::1).
+	if ip.IsLoopback() {
+		return true
+	}
+	// Link-local unicast (169.254.0.0/16, fe80::/10).
+	if ip.IsLinkLocalUnicast() {
+		return true
+	}
+	// Link-local multicast.
+	if ip.IsLinkLocalMulticast() {
+		return true
+	}
+	// RFC 1918 private ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+	// and RFC 4193 unique-local (fc00::/7).
+	if ip.IsPrivate() {
+		return true
+	}
+	// Unspecified (0.0.0.0, ::).
+	if ip.IsUnspecified() {
+		return true
+	}
+	return false
+}
+
+// blockedHostSuffixes contains DNS suffixes that resolve to internal
+// infrastructure and must be rejected to prevent SSRF.
+var blockedHostSuffixes = []string{
+	".internal",
+	".local",
+	".localhost",
+	".svc.cluster.local", // Kubernetes service DNS
+	".pod.cluster.local", // Kubernetes pod DNS
+	".svc",               // short Kubernetes DNS
+}
+
+// blockedHostExact contains exact hostnames that must be rejected.
+var blockedHostExact = map[string]bool{
+	"localhost":                true,
+	"metadata.google.internal": true, // GCE metadata
+	"169.254.169.254":          true, // AWS/GCP/Azure metadata endpoint
+	"metadata":                 true, // GKE metadata shortname
+}
+
+// blockedCIDRs are additional CIDR ranges to reject beyond the standard
+// private/loopback/link-local checks. This catches edge cases like the
+// cloud metadata IP and carrier-grade NAT range.
+var blockedCIDRs []*net.IPNet
+
+func init() {
+	cidrs := []string{
+		"169.254.169.254/32", // Cloud metadata endpoint
+		"100.64.0.0/10",      // Carrier-grade NAT (RFC 6598)
+		"0.0.0.0/8",          // "This" network
+		"fd00::/8",           // Unique-local (commonly used internally)
+	}
+	for _, cidr := range cidrs {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic("web: invalid blocked CIDR: " + cidr)
+		}
+		blockedCIDRs = append(blockedCIDRs, ipNet)
+	}
+}
+
+// isBlockedCIDR reports whether ip falls within any of the additional
+// blocked CIDR ranges.
+func isBlockedCIDR(ip net.IP) bool {
+	for _, cidr := range blockedCIDRs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateBaseURL checks that a user-supplied base URL is safe to use
+// for outbound HTTP requests. It rejects private IPs, internal DNS
+// names, cloud metadata endpoints, and Kubernetes service addresses
+// to prevent SSRF attacks.
+//
+// The resolver parameter allows injecting a custom DNS lookup function
+// for testing. Pass nil to use net.DefaultResolver.
+func validateBaseURL(rawURL string, resolver func(string) ([]net.IP, error)) error {
+	if rawURL == "" {
+		return nil // No custom base URL — will use provider defaults.
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("web: invalid base URL: %w", err)
+	}
+
+	// Only allow HTTPS (and HTTP for localhost in dev, but we block
+	// localhost anyway, so effectively HTTPS-only).
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return fmt.Errorf("web: base URL must use https scheme, got %q", parsed.Scheme)
+	}
+
+	hostname := parsed.Hostname()
+	if hostname == "" {
+		return fmt.Errorf("web: base URL has no hostname")
+	}
+
+	// Check exact blocked hostnames.
+	lower := strings.ToLower(hostname)
+	if blockedHostExact[lower] {
+		return fmt.Errorf("web: base URL hostname %q is not allowed", hostname)
+	}
+
+	// Check blocked DNS suffixes.
+	for _, suffix := range blockedHostSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return fmt.Errorf("web: base URL hostname %q is not allowed", hostname)
+		}
+	}
+
+	// If the hostname is already an IP literal, validate it directly.
+	if ip := net.ParseIP(hostname); ip != nil {
+		if isPrivateIP(ip) || isBlockedCIDR(ip) {
+			return fmt.Errorf("web: base URL resolves to blocked address %s", ip)
+		}
+		return nil
+	}
+
+	// Resolve the hostname and check every returned address.
+	resolve := resolver
+	if resolve == nil {
+		resolve = func(host string) ([]net.IP, error) {
+			return net.LookupIP(host)
+		}
+	}
+
+	ips, err := resolve(hostname)
+	if err != nil {
+		return fmt.Errorf("web: cannot resolve base URL host %q: %w", hostname, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("web: base URL host %q has no DNS records", hostname)
+	}
+
+	for _, ip := range ips {
+		if isPrivateIP(ip) || isBlockedCIDR(ip) {
+			return fmt.Errorf("web: base URL resolves to blocked address %s", ip)
+		}
+	}
+
+	return nil
+}

--- a/internal/web/urlvalidation_test.go
+++ b/internal/web/urlvalidation_test.go
@@ -1,0 +1,395 @@
+package web
+
+import (
+	"net"
+	"testing"
+)
+
+func TestValidateBaseURL(t *testing.T) {
+	t.Parallel()
+
+	// mockResolver returns a resolver function that maps hostnames to IPs.
+	mockResolver := func(mapping map[string][]net.IP) func(string) ([]net.IP, error) {
+		return func(host string) ([]net.IP, error) {
+			ips, ok := mapping[host]
+			if !ok {
+				return nil, &net.DNSError{Err: "no such host", Name: host}
+			}
+			return ips, nil
+		}
+	}
+
+	tests := []struct {
+		name     string
+		url      string
+		resolver func(string) ([]net.IP, error)
+		wantErr  bool
+	}{
+		// -- Allowed cases --
+		{
+			name:     "empty URL is allowed",
+			url:      "",
+			resolver: nil,
+			wantErr:  false,
+		},
+		{
+			name: "public HTTPS URL",
+			url:  "https://api.openai.com",
+			resolver: mockResolver(map[string][]net.IP{
+				"api.openai.com": {net.ParseIP("104.18.7.192")},
+			}),
+			wantErr: false,
+		},
+		{
+			name: "public HTTP URL",
+			url:  "http://api.example.com",
+			resolver: mockResolver(map[string][]net.IP{
+				"api.example.com": {net.ParseIP("93.184.216.34")},
+			}),
+			wantErr: false,
+		},
+		{
+			name:     "public IP literal",
+			url:      "https://93.184.216.34",
+			resolver: nil,
+			wantErr:  false,
+		},
+		{
+			name: "URL with port",
+			url:  "https://api.example.com:8443",
+			resolver: mockResolver(map[string][]net.IP{
+				"api.example.com": {net.ParseIP("93.184.216.34")},
+			}),
+			wantErr: false,
+		},
+		{
+			name: "URL with path",
+			url:  "https://api.example.com/v1",
+			resolver: mockResolver(map[string][]net.IP{
+				"api.example.com": {net.ParseIP("93.184.216.34")},
+			}),
+			wantErr: false,
+		},
+
+		// -- Blocked: Private IPv4 ranges (RFC 1918) --
+		{
+			name:     "10.0.0.0/8 IP literal",
+			url:      "https://10.0.0.1",
+			resolver: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "172.16.0.0/12 IP literal",
+			url:      "https://172.16.0.1",
+			resolver: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "172.31.x.x IP literal",
+			url:      "https://172.31.255.255",
+			resolver: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "192.168.0.0/16 IP literal",
+			url:      "https://192.168.1.1",
+			resolver: nil,
+			wantErr:  true,
+		},
+
+		// -- Blocked: Loopback --
+		{
+			name:     "127.0.0.1 IP literal",
+			url:      "https://127.0.0.1",
+			resolver: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "127.0.0.2 IP literal",
+			url:      "https://127.0.0.2",
+			resolver: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "IPv6 loopback",
+			url:      "https://[::1]",
+			resolver: nil,
+			wantErr:  true,
+		},
+
+		// -- Blocked: Link-local --
+		{
+			name:     "link-local 169.254.x.x",
+			url:      "https://169.254.1.1",
+			resolver: nil,
+			wantErr:  true,
+		},
+
+		// -- Blocked: Cloud metadata --
+		{
+			name:     "AWS/GCP metadata IP",
+			url:      "http://169.254.169.254",
+			resolver: nil,
+			wantErr:  true,
+		},
+		{
+			name: "metadata.google.internal hostname",
+			url:  "http://metadata.google.internal",
+			resolver: mockResolver(map[string][]net.IP{
+				"metadata.google.internal": {net.ParseIP("169.254.169.254")},
+			}),
+			wantErr: true,
+		},
+
+		// -- Blocked: Unspecified --
+		{
+			name:     "0.0.0.0",
+			url:      "https://0.0.0.0",
+			resolver: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "IPv6 unspecified",
+			url:      "https://[::]",
+			resolver: nil,
+			wantErr:  true,
+		},
+
+		// -- Blocked: Carrier-grade NAT (RFC 6598) --
+		{
+			name:     "100.64.0.0/10",
+			url:      "https://100.64.0.1",
+			resolver: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "100.127.255.255",
+			url:      "https://100.127.255.255",
+			resolver: nil,
+			wantErr:  true,
+		},
+
+		// -- Blocked: Exact hostnames --
+		{
+			name: "localhost",
+			url:  "https://localhost",
+			resolver: mockResolver(map[string][]net.IP{
+				"localhost": {net.ParseIP("127.0.0.1")},
+			}),
+			wantErr: true,
+		},
+		{
+			name: "LOCALHOST (case insensitive)",
+			url:  "https://LOCALHOST",
+			resolver: mockResolver(map[string][]net.IP{
+				"localhost": {net.ParseIP("127.0.0.1")},
+			}),
+			wantErr: true,
+		},
+
+		// -- Blocked: DNS suffixes --
+		{
+			name: ".internal suffix",
+			url:  "https://service.internal",
+			resolver: mockResolver(map[string][]net.IP{
+				"service.internal": {net.ParseIP("10.0.0.5")},
+			}),
+			wantErr: true,
+		},
+		{
+			name: ".local suffix",
+			url:  "https://myservice.local",
+			resolver: mockResolver(map[string][]net.IP{
+				"myservice.local": {net.ParseIP("192.168.1.100")},
+			}),
+			wantErr: true,
+		},
+		{
+			name: ".localhost suffix",
+			url:  "https://evil.localhost",
+			resolver: mockResolver(map[string][]net.IP{
+				"evil.localhost": {net.ParseIP("127.0.0.1")},
+			}),
+			wantErr: true,
+		},
+		{
+			name: "Kubernetes service DNS",
+			url:  "https://my-svc.default.svc.cluster.local",
+			resolver: mockResolver(map[string][]net.IP{
+				"my-svc.default.svc.cluster.local": {net.ParseIP("10.96.0.1")},
+			}),
+			wantErr: true,
+		},
+		{
+			name: "Kubernetes pod DNS",
+			url:  "https://10-244-0-5.default.pod.cluster.local",
+			resolver: mockResolver(map[string][]net.IP{
+				"10-244-0-5.default.pod.cluster.local": {net.ParseIP("10.244.0.5")},
+			}),
+			wantErr: true,
+		},
+		{
+			name: "short Kubernetes .svc suffix",
+			url:  "https://my-service.default.svc",
+			resolver: mockResolver(map[string][]net.IP{
+				"my-service.default.svc": {net.ParseIP("10.96.0.2")},
+			}),
+			wantErr: true,
+		},
+
+		// -- Blocked: DNS resolves to private IP (TOCTOU-aware) --
+		{
+			name: "public hostname resolving to private IP",
+			url:  "https://evil.example.com",
+			resolver: mockResolver(map[string][]net.IP{
+				"evil.example.com": {net.ParseIP("10.0.0.1")},
+			}),
+			wantErr: true,
+		},
+		{
+			name: "hostname resolving to loopback",
+			url:  "https://sneaky.example.com",
+			resolver: mockResolver(map[string][]net.IP{
+				"sneaky.example.com": {net.ParseIP("127.0.0.1")},
+			}),
+			wantErr: true,
+		},
+		{
+			name: "hostname resolving to metadata IP",
+			url:  "https://metadata-proxy.example.com",
+			resolver: mockResolver(map[string][]net.IP{
+				"metadata-proxy.example.com": {net.ParseIP("169.254.169.254")},
+			}),
+			wantErr: true,
+		},
+		{
+			name: "one of multiple IPs is private",
+			url:  "https://dual.example.com",
+			resolver: mockResolver(map[string][]net.IP{
+				"dual.example.com": {
+					net.ParseIP("93.184.216.34"),
+					net.ParseIP("10.0.0.5"),
+				},
+			}),
+			wantErr: true,
+		},
+
+		// -- Blocked: Invalid URLs --
+		{
+			name:     "non-http scheme (ftp)",
+			url:      "ftp://files.example.com",
+			resolver: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "non-http scheme (file)",
+			url:      "file:///etc/passwd",
+			resolver: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "no hostname",
+			url:      "https://",
+			resolver: nil,
+			wantErr:  true,
+		},
+
+		// -- Blocked: DNS resolution fails --
+		{
+			name:     "unresolvable hostname",
+			url:      "https://nonexistent.example.invalid",
+			resolver: mockResolver(map[string][]net.IP{
+				// not in mapping
+			}),
+			wantErr: true,
+		},
+
+		// -- Blocked: metadata exact hostname --
+		{
+			name: "metadata shortname",
+			url:  "http://metadata",
+			resolver: mockResolver(map[string][]net.IP{
+				"metadata": {net.ParseIP("169.254.169.254")},
+			}),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateBaseURL(tt.url, tt.resolver)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateBaseURL(%q) error = %v, wantErr = %v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsPrivateIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{"loopback v4", "127.0.0.1", true},
+		{"loopback v6", "::1", true},
+		{"private 10.x", "10.0.0.1", true},
+		{"private 172.16.x", "172.16.0.1", true},
+		{"private 192.168.x", "192.168.0.1", true},
+		{"link-local v4", "169.254.1.1", true},
+		{"link-local v6", "fe80::1", true},
+		{"unspecified v4", "0.0.0.0", true},
+		{"unspecified v6", "::", true},
+		{"public v4", "8.8.8.8", false},
+		{"public v6", "2001:4860:4860::8888", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse IP %q", tt.ip)
+			}
+			got := isPrivateIP(ip)
+			if got != tt.want {
+				t.Errorf("isPrivateIP(%s) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBlockedCIDR(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{"metadata IP", "169.254.169.254", true},
+		{"CGNAT start", "100.64.0.1", true},
+		{"CGNAT end", "100.127.255.255", true},
+		{"this network 0.x", "0.0.0.1", true},
+		{"just above CGNAT", "100.128.0.0", false},
+		{"public", "8.8.8.8", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse IP %q", tt.ip)
+			}
+			got := isBlockedCIDR(ip)
+			if got != tt.want {
+				t.Errorf("isBlockedCIDR(%s) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `validateBaseURL()` to block SSRF attacks through the `POST /api/v1/providers/test` endpoint
- Reject private IPs (10.x, 172.16-31.x, 192.168.x, 127.x), link-local, cloud metadata endpoints (169.254.169.254), carrier-grade NAT (RFC 6598), Kubernetes service DNS (`.svc.cluster.local`, `.pod.cluster.local`), and other internal hostnames
- Resolve DNS hostnames with `net.LookupIP` before connecting to catch DNS rebinding attacks where a public hostname resolves to a private IP

## Files changed

- `internal/web/urlvalidation.go` — new SSRF validation logic (`validateBaseURL`, `isPrivateIP`, `isBlockedCIDR`)
- `internal/web/handlers_providers.go` — call `validateBaseURL` before provider test request
- `internal/web/urlvalidation_test.go` — 40+ test cases covering all blocked ranges and edge cases
- `internal/web/handlers_providers_test.go` — integration tests for the handler endpoint

## Test plan

- [x] `TestValidateBaseURL` — table-driven tests for all private IP ranges, loopback, link-local, metadata endpoints, K8s DNS, DNS rebinding, invalid schemes, and allowed public URLs
- [x] `TestIsPrivateIP` — unit tests for the IP classification helper
- [x] `TestIsBlockedCIDR` — unit tests for additional CIDR range blocking
- [x] `TestHandleTestProvider_SSRFBlocked` — handler integration tests confirming 400 responses with correct error codes
- [x] `TestHandleTestProvider_EmptyBaseURLAllowed` — verifies empty base_url still works (provider defaults)
- [x] `TestHandleTestProvider_MissingFields` — verifies existing validation still works
- [x] All existing tests pass (`go test -race -count=1 ./internal/web/...`)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)