### PR TITLE
fix: add tenant_id to npc_definitions for multi-tenant isolation

### DIFF
--- a/internal/agent/npcstore/definition.go
+++ b/internal/agent/npcstore/definition.go
@@ -28,6 +28,10 @@ type NPCDefinition struct {
 	// ID is the unique identifier for this NPC definition.
 	ID string `yaml:"id" json:"id"`
 
+	// TenantID identifies the tenant that owns this NPC definition. All
+	// queries are scoped by tenant to enforce multi-tenant isolation.
+	TenantID string `yaml:"tenant_id" json:"tenant_id"`
+
 	// CampaignID groups NPCs that belong to the same campaign.
 	CampaignID string `yaml:"campaign_id" json:"campaign_id"`
 

--- a/internal/agent/npcstore/postgres.go
+++ b/internal/agent/npcstore/postgres.go
@@ -15,6 +15,7 @@ import (
 const Schema = `
 CREATE TABLE IF NOT EXISTS npc_definitions (
     id               TEXT PRIMARY KEY,
+    tenant_id        TEXT NOT NULL DEFAULT '',
     campaign_id      TEXT NOT NULL DEFAULT '',
     name             TEXT NOT NULL,
     personality      TEXT NOT NULL DEFAULT '',
@@ -33,10 +34,15 @@ CREATE TABLE IF NOT EXISTS npc_definitions (
 );
 CREATE INDEX IF NOT EXISTS idx_npc_definitions_campaign ON npc_definitions(campaign_id);
 CREATE INDEX IF NOT EXISTS idx_npc_definitions_name ON npc_definitions(name);
+CREATE INDEX IF NOT EXISTS idx_npc_definitions_tenant ON npc_definitions(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_npc_definitions_tenant_campaign ON npc_definitions(tenant_id, campaign_id);
 
 -- Migration: add columns for existing tables that predate the GM helper feature.
 ALTER TABLE npc_definitions ADD COLUMN IF NOT EXISTS gm_helper BOOLEAN NOT NULL DEFAULT false;
 ALTER TABLE npc_definitions ADD COLUMN IF NOT EXISTS address_only BOOLEAN NOT NULL DEFAULT false;
+
+-- Migration: add tenant_id column for existing tables that predate tenant isolation.
+ALTER TABLE npc_definitions ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT '';
 `
 
 // DB is the database interface used by [PostgresStore]. Both *pgxpool.Pool
@@ -74,7 +80,8 @@ func (s *PostgresStore) Migrate(ctx context.Context) error {
 }
 
 // Create inserts a new NPC definition. It validates the definition and returns
-// an error if an NPC with the same ID already exists.
+// an error if an NPC with the same ID already exists. The definition's TenantID
+// field must be set.
 func (s *PostgresStore) Create(ctx context.Context, def *NPCDefinition) error {
 	if err := def.Validate(); err != nil {
 		return err
@@ -107,14 +114,14 @@ func (s *PostgresStore) Create(ctx context.Context, def *NPCDefinition) error {
 
 	const query = `
 		INSERT INTO npc_definitions (
-			id, campaign_id, name, personality, engine,
+			id, tenant_id, campaign_id, name, personality, engine,
 			voice, knowledge_scope, secret_knowledge, behavior_rules, tools,
 			budget_tier, gm_helper, address_only, attributes
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
 		RETURNING created_at, updated_at`
 
 	err = s.db.QueryRow(ctx, query,
-		def.ID, def.CampaignID, def.Name, def.Personality, defaultEngine(def.Engine),
+		def.ID, def.TenantID, def.CampaignID, def.Name, def.Personality, defaultEngine(def.Engine),
 		voiceJSON, ksJSON, skJSON, brJSON, toolsJSON,
 		defaultBudgetTier(def.BudgetTier), def.GMHelper, def.AddressOnly, attrJSON,
 	).Scan(&def.CreatedAt, &def.UpdatedAt)
@@ -127,22 +134,23 @@ func (s *PostgresStore) Create(ctx context.Context, def *NPCDefinition) error {
 	return nil
 }
 
-// Get retrieves an NPC definition by ID. When campaignID is non-empty, it is
-// included as a filter (defense-in-depth against cross-campaign access).
-// Returns (nil, nil) if no NPC with the given ID exists.
-func (s *PostgresStore) Get(ctx context.Context, id, campaignID string) (*NPCDefinition, error) {
+// Get retrieves an NPC definition by ID, scoped to the given tenant. When
+// campaignID is non-empty, it is included as an additional filter
+// (defense-in-depth against cross-campaign access).
+// Returns (nil, nil) if no NPC with the given ID exists for the tenant.
+func (s *PostgresStore) Get(ctx context.Context, tenantID, id, campaignID string) (*NPCDefinition, error) {
 	const query = `
-		SELECT id, campaign_id, name, personality, engine,
+		SELECT id, tenant_id, campaign_id, name, personality, engine,
 		       voice, knowledge_scope, secret_knowledge, behavior_rules, tools,
 		       budget_tier, gm_helper, address_only, attributes, created_at, updated_at
 		FROM npc_definitions
-		WHERE id = $1 AND ($2 = '' OR campaign_id = $2)`
+		WHERE id = $1 AND tenant_id = $2 AND ($3 = '' OR campaign_id = $3)`
 
 	var def NPCDefinition
 	var voiceJSON, ksJSON, skJSON, brJSON, toolsJSON, attrJSON []byte
 
-	err := s.db.QueryRow(ctx, query, id, campaignID).Scan(
-		&def.ID, &def.CampaignID, &def.Name, &def.Personality, &def.Engine,
+	err := s.db.QueryRow(ctx, query, id, tenantID, campaignID).Scan(
+		&def.ID, &def.TenantID, &def.CampaignID, &def.Name, &def.Personality, &def.Engine,
 		&voiceJSON, &ksJSON, &skJSON, &brJSON, &toolsJSON,
 		&def.BudgetTier, &def.GMHelper, &def.AddressOnly, &attrJSON, &def.CreatedAt, &def.UpdatedAt,
 	)
@@ -160,7 +168,8 @@ func (s *PostgresStore) Get(ctx context.Context, id, campaignID string) (*NPCDef
 }
 
 // Update replaces an existing NPC definition. It validates the new definition
-// and returns an error if the NPC is not found.
+// and returns an error if the NPC is not found. The WHERE clause includes
+// tenant_id to prevent cross-tenant updates.
 func (s *PostgresStore) Update(ctx context.Context, def *NPCDefinition) error {
 	if err := def.Validate(); err != nil {
 		return err
@@ -193,16 +202,16 @@ func (s *PostgresStore) Update(ctx context.Context, def *NPCDefinition) error {
 
 	const query = `
 		UPDATE npc_definitions SET
-			campaign_id = $2, name = $3, personality = $4, engine = $5,
-			voice = $6, knowledge_scope = $7, secret_knowledge = $8,
-			behavior_rules = $9, tools = $10, budget_tier = $11,
-			gm_helper = $12, address_only = $13,
-			attributes = $14, updated_at = now()
-		WHERE id = $1
+			campaign_id = $3, name = $4, personality = $5, engine = $6,
+			voice = $7, knowledge_scope = $8, secret_knowledge = $9,
+			behavior_rules = $10, tools = $11, budget_tier = $12,
+			gm_helper = $13, address_only = $14,
+			attributes = $15, updated_at = now()
+		WHERE id = $1 AND tenant_id = $2
 		RETURNING updated_at`
 
 	err = s.db.QueryRow(ctx, query,
-		def.ID, def.CampaignID, def.Name, def.Personality, defaultEngine(def.Engine),
+		def.ID, def.TenantID, def.CampaignID, def.Name, def.Personality, defaultEngine(def.Engine),
 		voiceJSON, ksJSON, skJSON, brJSON, toolsJSON,
 		defaultBudgetTier(def.BudgetTier), def.GMHelper, def.AddressOnly, attrJSON,
 	).Scan(&def.UpdatedAt)
@@ -215,41 +224,42 @@ func (s *PostgresStore) Update(ctx context.Context, def *NPCDefinition) error {
 	return nil
 }
 
-// Delete removes an NPC definition by ID and campaign ID (defense-in-depth).
-// Deleting a non-existent NPC is not an error.
-func (s *PostgresStore) Delete(ctx context.Context, id, campaignID string) error {
-	const query = `DELETE FROM npc_definitions WHERE id = $1 AND campaign_id = $2`
-	_, err := s.db.Exec(ctx, query, id, campaignID)
+// Delete removes an NPC definition by ID, scoped to the given tenant and
+// campaign (defense-in-depth). Deleting a non-existent NPC is not an error.
+func (s *PostgresStore) Delete(ctx context.Context, tenantID, id, campaignID string) error {
+	const query = `DELETE FROM npc_definitions WHERE id = $1 AND tenant_id = $2 AND campaign_id = $3`
+	_, err := s.db.Exec(ctx, query, id, tenantID, campaignID)
 	if err != nil {
 		return fmt.Errorf("npcstore: delete %q: %w", id, err)
 	}
 	return nil
 }
 
-// List returns all NPC definitions, optionally filtered by campaign ID. An
-// empty campaignID returns all definitions.
-func (s *PostgresStore) List(ctx context.Context, campaignID string) ([]NPCDefinition, error) {
+// List returns NPC definitions for the given tenant, optionally filtered by
+// campaign ID. An empty campaignID returns all definitions for the tenant.
+func (s *PostgresStore) List(ctx context.Context, tenantID, campaignID string) ([]NPCDefinition, error) {
 	var (
 		rows pgx.Rows
 		err  error
 	)
 	if campaignID == "" {
 		const query = `
-			SELECT id, campaign_id, name, personality, engine,
+			SELECT id, tenant_id, campaign_id, name, personality, engine,
 			       voice, knowledge_scope, secret_knowledge, behavior_rules, tools,
 			       budget_tier, gm_helper, address_only, attributes, created_at, updated_at
 			FROM npc_definitions
+			WHERE tenant_id = $1
 			ORDER BY name`
-		rows, err = s.db.Query(ctx, query)
+		rows, err = s.db.Query(ctx, query, tenantID)
 	} else {
 		const query = `
-			SELECT id, campaign_id, name, personality, engine,
+			SELECT id, tenant_id, campaign_id, name, personality, engine,
 			       voice, knowledge_scope, secret_knowledge, behavior_rules, tools,
 			       budget_tier, gm_helper, address_only, attributes, created_at, updated_at
 			FROM npc_definitions
-			WHERE campaign_id = $1
+			WHERE tenant_id = $1 AND campaign_id = $2
 			ORDER BY name`
-		rows, err = s.db.Query(ctx, query, campaignID)
+		rows, err = s.db.Query(ctx, query, tenantID, campaignID)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("npcstore: list: %w", err)
@@ -262,7 +272,7 @@ func (s *PostgresStore) List(ctx context.Context, campaignID string) ([]NPCDefin
 		var voiceJSON, ksJSON, skJSON, brJSON, toolsJSON, attrJSON []byte
 
 		if err := rows.Scan(
-			&def.ID, &def.CampaignID, &def.Name, &def.Personality, &def.Engine,
+			&def.ID, &def.TenantID, &def.CampaignID, &def.Name, &def.Personality, &def.Engine,
 			&voiceJSON, &ksJSON, &skJSON, &brJSON, &toolsJSON,
 			&def.BudgetTier, &def.GMHelper, &def.AddressOnly, &attrJSON, &def.CreatedAt, &def.UpdatedAt,
 		); err != nil {
@@ -282,7 +292,7 @@ func (s *PostgresStore) List(ctx context.Context, campaignID string) ([]NPCDefin
 
 // Upsert creates or replaces an NPC definition. This is useful for importing
 // definitions from YAML config files. The definition is validated before
-// persistence.
+// persistence. The definition's TenantID field must be set.
 func (s *PostgresStore) Upsert(ctx context.Context, def *NPCDefinition) error {
 	if err := def.Validate(); err != nil {
 		return err
@@ -315,11 +325,12 @@ func (s *PostgresStore) Upsert(ctx context.Context, def *NPCDefinition) error {
 
 	const query = `
 		INSERT INTO npc_definitions (
-			id, campaign_id, name, personality, engine,
+			id, tenant_id, campaign_id, name, personality, engine,
 			voice, knowledge_scope, secret_knowledge, behavior_rules, tools,
 			budget_tier, gm_helper, address_only, attributes
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
 		ON CONFLICT (id) DO UPDATE SET
+			tenant_id = EXCLUDED.tenant_id,
 			campaign_id = EXCLUDED.campaign_id,
 			name = EXCLUDED.name,
 			personality = EXCLUDED.personality,
@@ -337,7 +348,7 @@ func (s *PostgresStore) Upsert(ctx context.Context, def *NPCDefinition) error {
 		RETURNING created_at, updated_at`
 
 	err = s.db.QueryRow(ctx, query,
-		def.ID, def.CampaignID, def.Name, def.Personality, defaultEngine(def.Engine),
+		def.ID, def.TenantID, def.CampaignID, def.Name, def.Personality, defaultEngine(def.Engine),
 		voiceJSON, ksJSON, skJSON, brJSON, toolsJSON,
 		defaultBudgetTier(def.BudgetTier), def.GMHelper, def.AddressOnly, attrJSON,
 	).Scan(&def.CreatedAt, &def.UpdatedAt)

--- a/internal/agent/npcstore/postgres_test.go
+++ b/internal/agent/npcstore/postgres_test.go
@@ -356,6 +356,9 @@ func TestPostgresStore_Migrate(t *testing.T) {
 				if !strings.Contains(sql, "CREATE TABLE") {
 					t.Errorf("Migrate SQL should contain CREATE TABLE, got: %s", sql)
 				}
+				if !strings.Contains(sql, "tenant_id") {
+					t.Errorf("Migrate SQL should contain tenant_id column, got: %s", sql)
+				}
 				return pgconn.CommandTag{}, nil
 			},
 		}
@@ -411,6 +414,7 @@ func TestPostgresStore_Create(t *testing.T) {
 		store := NewPostgresStore(db)
 		def := &NPCDefinition{
 			ID:         "npc-1",
+			TenantID:   "tenant-1",
 			CampaignID: "camp-1",
 			Name:       "Greymantle",
 		}
@@ -423,11 +427,14 @@ func TestPostgresStore_Create(t *testing.T) {
 		if !strings.Contains(capturedSQL, "INSERT INTO npc_definitions") {
 			t.Errorf("SQL should contain INSERT, got: %s", capturedSQL)
 		}
-		if len(capturedArgs) != 14 {
-			t.Errorf("expected 14 args, got %d", len(capturedArgs))
+		if len(capturedArgs) != 15 {
+			t.Errorf("expected 15 args, got %d", len(capturedArgs))
 		}
 		if capturedArgs[0] != "npc-1" {
-			t.Errorf("first arg = %v, want 'npc-1'", capturedArgs[0])
+			t.Errorf("first arg (id) = %v, want 'npc-1'", capturedArgs[0])
+		}
+		if capturedArgs[1] != "tenant-1" {
+			t.Errorf("second arg (tenant_id) = %v, want 'tenant-1'", capturedArgs[1])
 		}
 		if def.CreatedAt != fixedTime {
 			t.Errorf("CreatedAt = %v, want %v", def.CreatedAt, fixedTime)
@@ -509,17 +516,18 @@ func TestPostgresStore_Create(t *testing.T) {
 		}
 
 		store := NewPostgresStore(db)
-		def := &NPCDefinition{ID: "npc-2", Name: "NPC"}
+		def := &NPCDefinition{ID: "npc-2", TenantID: "t1", Name: "NPC"}
 		if err := store.Create(context.Background(), def); err != nil {
 			t.Fatalf("Create() unexpected error: %v", err)
 		}
 
-		// engine is arg index 4 (0-based), budget_tier is arg index 10
-		if capturedArgs[4] != "cascaded" {
-			t.Errorf("engine = %v, want 'cascaded'", capturedArgs[4])
+		// engine is arg index 5 (0-based: id, tenant_id, campaign_id, name, personality, engine)
+		// budget_tier is arg index 11
+		if capturedArgs[5] != "cascaded" {
+			t.Errorf("engine = %v, want 'cascaded'", capturedArgs[5])
 		}
-		if capturedArgs[10] != "fast" {
-			t.Errorf("budget_tier = %v, want 'fast'", capturedArgs[10])
+		if capturedArgs[11] != "fast" {
+			t.Errorf("budget_tier = %v, want 'fast'", capturedArgs[11])
 		}
 	})
 }
@@ -537,24 +545,31 @@ func TestPostgresStore_Get(t *testing.T) {
 				if args[0] != "npc-1" {
 					t.Errorf("Get() id = %v, want 'npc-1'", args[0])
 				}
+				if args[1] != "tenant-1" {
+					t.Errorf("Get() tenant_id = %v, want 'tenant-1'", args[1])
+				}
+				if !strings.Contains(sql, "tenant_id = $2") {
+					t.Errorf("Get() SQL should contain tenant_id filter, got: %s", sql)
+				}
 				return &mockRow{
 					scanFunc: func(dest ...any) error {
 						*(dest[0].(*string)) = "npc-1"
-						*(dest[1].(*string)) = "camp-1"
-						*(dest[2].(*string)) = "Greymantle"
-						*(dest[3].(*string)) = "Wise"
-						*(dest[4].(*string)) = "cascaded"
-						*(dest[5].(*[]byte)) = []byte(`{"provider":"elevenlabs","voice_id":"v1","pitch_shift":0,"speed_factor":1.0}`)
-						*(dest[6].(*[]byte)) = []byte(`["history"]`)
-						*(dest[7].(*[]byte)) = []byte(`["secret"]`)
-						*(dest[8].(*[]byte)) = []byte(`["rule1"]`)
-						*(dest[9].(*[]byte)) = []byte(`["tool1"]`)
-						*(dest[10].(*string)) = "fast"
-						*(dest[11].(*bool)) = false
+						*(dest[1].(*string)) = "tenant-1"
+						*(dest[2].(*string)) = "camp-1"
+						*(dest[3].(*string)) = "Greymantle"
+						*(dest[4].(*string)) = "Wise"
+						*(dest[5].(*string)) = "cascaded"
+						*(dest[6].(*[]byte)) = []byte(`{"provider":"elevenlabs","voice_id":"v1","pitch_shift":0,"speed_factor":1.0}`)
+						*(dest[7].(*[]byte)) = []byte(`["history"]`)
+						*(dest[8].(*[]byte)) = []byte(`["secret"]`)
+						*(dest[9].(*[]byte)) = []byte(`["rule1"]`)
+						*(dest[10].(*[]byte)) = []byte(`["tool1"]`)
+						*(dest[11].(*string)) = "fast"
 						*(dest[12].(*bool)) = false
-						*(dest[13].(*[]byte)) = []byte(`{"race":"elf"}`)
-						*(dest[14].(*time.Time)) = fixedTime
+						*(dest[13].(*bool)) = false
+						*(dest[14].(*[]byte)) = []byte(`{"race":"elf"}`)
 						*(dest[15].(*time.Time)) = fixedTime
+						*(dest[16].(*time.Time)) = fixedTime
 						return nil
 					},
 				}
@@ -562,7 +577,7 @@ func TestPostgresStore_Get(t *testing.T) {
 		}
 
 		store := NewPostgresStore(db)
-		def, err := store.Get(context.Background(), "npc-1", "camp-1")
+		def, err := store.Get(context.Background(), "tenant-1", "npc-1", "camp-1")
 		if err != nil {
 			t.Fatalf("Get() unexpected error: %v", err)
 		}
@@ -572,6 +587,9 @@ func TestPostgresStore_Get(t *testing.T) {
 		}
 		if def.ID != "npc-1" {
 			t.Errorf("ID = %q, want 'npc-1'", def.ID)
+		}
+		if def.TenantID != "tenant-1" {
+			t.Errorf("TenantID = %q, want 'tenant-1'", def.TenantID)
 		}
 		if def.Name != "Greymantle" {
 			t.Errorf("Name = %q, want 'Greymantle'", def.Name)
@@ -597,12 +615,32 @@ func TestPostgresStore_Get(t *testing.T) {
 			},
 		}
 		store := NewPostgresStore(db)
-		def, err := store.Get(context.Background(), "missing", "camp-1")
+		def, err := store.Get(context.Background(), "tenant-1", "missing", "camp-1")
 		if err != nil {
 			t.Fatalf("Get() unexpected error: %v", err)
 		}
 		if def != nil {
 			t.Errorf("Get() = %v, want nil for missing NPC", def)
+		}
+	})
+
+	t.Run("wrong tenant returns nil", func(t *testing.T) {
+		t.Parallel()
+		db := &mockDB{
+			queryRowFunc: func(_ context.Context, _ string, _ ...any) pgx.Row {
+				// Simulates PostgreSQL returning no rows because tenant_id doesn't match.
+				return &mockRow{
+					scanFunc: func(_ ...any) error { return pgx.ErrNoRows },
+				}
+			},
+		}
+		store := NewPostgresStore(db)
+		def, err := store.Get(context.Background(), "wrong-tenant", "npc-1", "camp-1")
+		if err != nil {
+			t.Fatalf("Get() unexpected error: %v", err)
+		}
+		if def != nil {
+			t.Errorf("Get() = %v, want nil for wrong tenant", def)
 		}
 	})
 
@@ -616,7 +654,7 @@ func TestPostgresStore_Get(t *testing.T) {
 			},
 		}
 		store := NewPostgresStore(db)
-		_, err := store.Get(context.Background(), "npc-1", "camp-1")
+		_, err := store.Get(context.Background(), "tenant-1", "npc-1", "camp-1")
 		if err == nil {
 			t.Fatal("Get() expected error, got nil")
 		}
@@ -638,6 +676,9 @@ func TestPostgresStore_Update(t *testing.T) {
 				if !strings.Contains(sql, "UPDATE npc_definitions") {
 					t.Errorf("Update SQL should contain UPDATE, got: %s", sql)
 				}
+				if !strings.Contains(sql, "tenant_id = $2") {
+					t.Errorf("Update SQL should contain tenant_id in WHERE, got: %s", sql)
+				}
 				return &mockRow{
 					scanFunc: func(dest ...any) error {
 						*(dest[0].(*time.Time)) = fixedTime
@@ -648,7 +689,7 @@ func TestPostgresStore_Update(t *testing.T) {
 		}
 
 		store := NewPostgresStore(db)
-		def := &NPCDefinition{ID: "npc-1", Name: "Updated"}
+		def := &NPCDefinition{ID: "npc-1", TenantID: "tenant-1", Name: "Updated"}
 		err := store.Update(context.Background(), def)
 		if err != nil {
 			t.Fatalf("Update() unexpected error: %v", err)
@@ -668,7 +709,7 @@ func TestPostgresStore_Update(t *testing.T) {
 			},
 		}
 		store := NewPostgresStore(db)
-		err := store.Update(context.Background(), &NPCDefinition{ID: "missing", Name: "X"})
+		err := store.Update(context.Background(), &NPCDefinition{ID: "missing", TenantID: "t1", Name: "X"})
 		if err == nil {
 			t.Fatal("Update() expected error for missing NPC")
 		}
@@ -707,15 +748,18 @@ func TestPostgresStore_Delete(t *testing.T) {
 		}
 
 		store := NewPostgresStore(db)
-		err := store.Delete(context.Background(), "npc-1", "camp-1")
+		err := store.Delete(context.Background(), "tenant-1", "npc-1", "camp-1")
 		if err != nil {
 			t.Fatalf("Delete() unexpected error: %v", err)
 		}
 		if !strings.Contains(capturedSQL, "DELETE FROM npc_definitions") {
 			t.Errorf("SQL = %q, want DELETE statement", capturedSQL)
 		}
-		if len(capturedArgs) != 2 || capturedArgs[0] != "npc-1" || capturedArgs[1] != "camp-1" {
-			t.Errorf("args = %v, want [npc-1 camp-1]", capturedArgs)
+		if !strings.Contains(capturedSQL, "tenant_id = $2") {
+			t.Errorf("SQL = %q, want tenant_id in WHERE clause", capturedSQL)
+		}
+		if len(capturedArgs) != 3 || capturedArgs[0] != "npc-1" || capturedArgs[1] != "tenant-1" || capturedArgs[2] != "camp-1" {
+			t.Errorf("args = %v, want [npc-1 tenant-1 camp-1]", capturedArgs)
 		}
 	})
 
@@ -727,7 +771,7 @@ func TestPostgresStore_Delete(t *testing.T) {
 			},
 		}
 		store := NewPostgresStore(db)
-		err := store.Delete(context.Background(), "npc-1", "camp-1")
+		err := store.Delete(context.Background(), "tenant-1", "npc-1", "camp-1")
 		if err == nil {
 			t.Fatal("Delete() expected error, got nil")
 		}
@@ -742,9 +786,10 @@ func TestPostgresStore_List(t *testing.T) {
 
 	fixedTime := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
 
-	makeRow := func(id, campaignID, name string) []any {
+	makeRow := func(id, tenantID, campaignID, name string) []any {
 		return []any{
 			id,           // id
+			tenantID,     // tenant_id
 			campaignID,   // campaign_id
 			name,         // name
 			"",           // personality
@@ -763,27 +808,30 @@ func TestPostgresStore_List(t *testing.T) {
 		}
 	}
 
-	t.Run("all", func(t *testing.T) {
+	t.Run("all for tenant", func(t *testing.T) {
 		t.Parallel()
 		db := &mockDB{
 			queryFunc: func(_ context.Context, sql string, args ...any) (pgx.Rows, error) {
-				if strings.Contains(sql, "WHERE campaign_id") {
+				if !strings.Contains(sql, "WHERE tenant_id = $1") {
+					t.Error("List should filter by tenant_id")
+				}
+				if strings.Contains(sql, "campaign_id = $2") {
 					t.Error("List all should not filter by campaign_id")
 				}
-				if len(args) != 0 {
-					t.Errorf("List all should have 0 args, got %d", len(args))
+				if len(args) != 1 || args[0] != "tenant-1" {
+					t.Errorf("List all args = %v, want [tenant-1]", args)
 				}
 				return &mockRows{
 					data: [][]any{
-						makeRow("npc-1", "camp-1", "Alpha"),
-						makeRow("npc-2", "camp-2", "Beta"),
+						makeRow("npc-1", "tenant-1", "camp-1", "Alpha"),
+						makeRow("npc-2", "tenant-1", "camp-2", "Beta"),
 					},
 				}, nil
 			},
 		}
 
 		store := NewPostgresStore(db)
-		defs, err := store.List(context.Background(), "")
+		defs, err := store.List(context.Background(), "tenant-1", "")
 		if err != nil {
 			t.Fatalf("List() unexpected error: %v", err)
 		}
@@ -792,6 +840,9 @@ func TestPostgresStore_List(t *testing.T) {
 		}
 		if defs[0].ID != "npc-1" {
 			t.Errorf("defs[0].ID = %q, want 'npc-1'", defs[0].ID)
+		}
+		if defs[0].TenantID != "tenant-1" {
+			t.Errorf("defs[0].TenantID = %q, want 'tenant-1'", defs[0].TenantID)
 		}
 		if defs[1].ID != "npc-2" {
 			t.Errorf("defs[1].ID = %q, want 'npc-2'", defs[1].ID)
@@ -802,22 +853,22 @@ func TestPostgresStore_List(t *testing.T) {
 		t.Parallel()
 		db := &mockDB{
 			queryFunc: func(_ context.Context, sql string, args ...any) (pgx.Rows, error) {
-				if !strings.Contains(sql, "WHERE campaign_id") {
-					t.Error("List filtered should contain WHERE campaign_id")
+				if !strings.Contains(sql, "WHERE tenant_id = $1 AND campaign_id = $2") {
+					t.Error("List filtered should contain WHERE tenant_id AND campaign_id")
 				}
-				if len(args) != 1 || args[0] != "camp-1" {
-					t.Errorf("args = %v, want [camp-1]", args)
+				if len(args) != 2 || args[0] != "tenant-1" || args[1] != "camp-1" {
+					t.Errorf("args = %v, want [tenant-1 camp-1]", args)
 				}
 				return &mockRows{
 					data: [][]any{
-						makeRow("npc-1", "camp-1", "Alpha"),
+						makeRow("npc-1", "tenant-1", "camp-1", "Alpha"),
 					},
 				}, nil
 			},
 		}
 
 		store := NewPostgresStore(db)
-		defs, err := store.List(context.Background(), "camp-1")
+		defs, err := store.List(context.Background(), "tenant-1", "camp-1")
 		if err != nil {
 			t.Fatalf("List() unexpected error: %v", err)
 		}
@@ -835,7 +886,7 @@ func TestPostgresStore_List(t *testing.T) {
 		}
 
 		store := NewPostgresStore(db)
-		defs, err := store.List(context.Background(), "")
+		defs, err := store.List(context.Background(), "tenant-1", "")
 		if err != nil {
 			t.Fatalf("List() unexpected error: %v", err)
 		}
@@ -853,7 +904,7 @@ func TestPostgresStore_List(t *testing.T) {
 		}
 
 		store := NewPostgresStore(db)
-		_, err := store.List(context.Background(), "")
+		_, err := store.List(context.Background(), "tenant-1", "")
 		if err == nil {
 			t.Fatal("List() expected error, got nil")
 		}
@@ -871,7 +922,7 @@ func TestPostgresStore_List(t *testing.T) {
 		}
 
 		store := NewPostgresStore(db)
-		_, err := store.List(context.Background(), "")
+		_, err := store.List(context.Background(), "tenant-1", "")
 		if err == nil {
 			t.Fatal("List() expected error from rows.Err()")
 		}
@@ -904,13 +955,16 @@ func TestPostgresStore_Upsert(t *testing.T) {
 		}
 
 		store := NewPostgresStore(db)
-		def := &NPCDefinition{ID: "npc-1", Name: "Upserted"}
+		def := &NPCDefinition{ID: "npc-1", TenantID: "tenant-1", Name: "Upserted"}
 		err := store.Upsert(context.Background(), def)
 		if err != nil {
 			t.Fatalf("Upsert() unexpected error: %v", err)
 		}
 		if !strings.Contains(capturedSQL, "ON CONFLICT") {
 			t.Errorf("SQL should contain ON CONFLICT, got: %s", capturedSQL)
+		}
+		if !strings.Contains(capturedSQL, "tenant_id") {
+			t.Errorf("SQL should reference tenant_id, got: %s", capturedSQL)
 		}
 		if def.CreatedAt != fixedTime {
 			t.Errorf("CreatedAt = %v, want %v", def.CreatedAt, fixedTime)
@@ -936,12 +990,166 @@ func TestPostgresStore_Upsert(t *testing.T) {
 			},
 		}
 		store := NewPostgresStore(db)
-		err := store.Upsert(context.Background(), &NPCDefinition{ID: "x", Name: "X"})
+		err := store.Upsert(context.Background(), &NPCDefinition{ID: "x", TenantID: "t1", Name: "X"})
 		if err == nil {
 			t.Fatal("Upsert() expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), "npcstore: upsert:") {
 			t.Errorf("error = %q, want prefix 'npcstore: upsert:'", err.Error())
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Cross-tenant isolation tests
+// ---------------------------------------------------------------------------
+
+func TestPostgresStore_CrossTenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Get scopes query by tenant_id", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedArgs []any
+		db := &mockDB{
+			queryRowFunc: func(_ context.Context, sql string, args ...any) pgx.Row {
+				capturedArgs = args
+				if !strings.Contains(sql, "tenant_id = $2") {
+					t.Error("Get SQL must include tenant_id in WHERE clause")
+				}
+				return &mockRow{
+					scanFunc: func(_ ...any) error { return pgx.ErrNoRows },
+				}
+			},
+		}
+
+		store := NewPostgresStore(db)
+		def, err := store.Get(context.Background(), "tenant-A", "npc-1", "")
+		if err != nil {
+			t.Fatalf("Get() unexpected error: %v", err)
+		}
+		if def != nil {
+			t.Error("Get() should return nil for non-matching tenant")
+		}
+		if len(capturedArgs) < 2 || capturedArgs[1] != "tenant-A" {
+			t.Errorf("tenant_id arg = %v, want 'tenant-A'", capturedArgs)
+		}
+	})
+
+	t.Run("List scopes query by tenant_id", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedArgs []any
+		db := &mockDB{
+			queryFunc: func(_ context.Context, sql string, args ...any) (pgx.Rows, error) {
+				capturedArgs = args
+				if !strings.Contains(sql, "tenant_id = $1") {
+					t.Error("List SQL must include tenant_id in WHERE clause")
+				}
+				return &mockRows{}, nil
+			},
+		}
+
+		store := NewPostgresStore(db)
+		_, err := store.List(context.Background(), "tenant-B", "")
+		if err != nil {
+			t.Fatalf("List() unexpected error: %v", err)
+		}
+		if len(capturedArgs) < 1 || capturedArgs[0] != "tenant-B" {
+			t.Errorf("tenant_id arg = %v, want 'tenant-B'", capturedArgs)
+		}
+	})
+
+	t.Run("Delete scopes query by tenant_id", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedArgs []any
+		db := &mockDB{
+			execFunc: func(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+				capturedArgs = args
+				if !strings.Contains(sql, "tenant_id = $2") {
+					t.Error("Delete SQL must include tenant_id in WHERE clause")
+				}
+				return pgconn.CommandTag{}, nil
+			},
+		}
+
+		store := NewPostgresStore(db)
+		err := store.Delete(context.Background(), "tenant-C", "npc-1", "camp-1")
+		if err != nil {
+			t.Fatalf("Delete() unexpected error: %v", err)
+		}
+		if len(capturedArgs) < 2 || capturedArgs[1] != "tenant-C" {
+			t.Errorf("tenant_id arg = %v, want 'tenant-C'", capturedArgs)
+		}
+	})
+
+	t.Run("Update scopes query by tenant_id", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedSQL string
+		db := &mockDB{
+			queryRowFunc: func(_ context.Context, sql string, args ...any) pgx.Row {
+				capturedSQL = sql
+				// Simulate not found because the tenant doesn't match.
+				return &mockRow{
+					scanFunc: func(_ ...any) error { return pgx.ErrNoRows },
+				}
+			},
+		}
+
+		store := NewPostgresStore(db)
+		err := store.Update(context.Background(), &NPCDefinition{
+			ID:       "npc-1",
+			TenantID: "wrong-tenant",
+			Name:     "Hack",
+		})
+		if err == nil {
+			t.Fatal("Update() should fail when tenant doesn't match")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("error = %q, want 'not found'", err.Error())
+		}
+		if !strings.Contains(capturedSQL, "tenant_id = $2") {
+			t.Errorf("Update SQL should contain tenant_id in WHERE, got: %s", capturedSQL)
+		}
+	})
+
+	t.Run("Create includes tenant_id in INSERT", func(t *testing.T) {
+		t.Parallel()
+
+		fixedTime := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+		var capturedSQL string
+		var capturedArgs []any
+		db := &mockDB{
+			queryRowFunc: func(_ context.Context, sql string, args ...any) pgx.Row {
+				capturedSQL = sql
+				capturedArgs = args
+				return &mockRow{
+					scanFunc: func(dest ...any) error {
+						*(dest[0].(*time.Time)) = fixedTime
+						*(dest[1].(*time.Time)) = fixedTime
+						return nil
+					},
+				}
+			},
+		}
+
+		store := NewPostgresStore(db)
+		def := &NPCDefinition{
+			ID:       "npc-new",
+			TenantID: "tenant-X",
+			Name:     "NewNPC",
+		}
+		err := store.Create(context.Background(), def)
+		if err != nil {
+			t.Fatalf("Create() unexpected error: %v", err)
+		}
+		if !strings.Contains(capturedSQL, "tenant_id") {
+			t.Errorf("Create SQL should reference tenant_id, got: %s", capturedSQL)
+		}
+		if capturedArgs[1] != "tenant-X" {
+			t.Errorf("tenant_id arg = %v, want 'tenant-X'", capturedArgs[1])
 		}
 	})
 }

--- a/internal/agent/npcstore/store.go
+++ b/internal/agent/npcstore/store.go
@@ -3,29 +3,34 @@ package npcstore
 import "context"
 
 // Store provides CRUD operations for NPC definitions.
+// All methods require a tenantID to enforce multi-tenant isolation.
 // Implementations must be safe for concurrent use.
 type Store interface {
 	// Create inserts a new NPC definition. The definition is validated before
-	// insertion. Returns an error if an NPC with the same ID already exists.
+	// insertion. The definition's TenantID field must be set. Returns an error
+	// if an NPC with the same ID already exists.
 	Create(ctx context.Context, def *NPCDefinition) error
 
-	// Get retrieves an NPC definition by ID and campaign ID (defense-in-depth).
-	// Returns (nil, nil) if not found.
-	Get(ctx context.Context, id, campaignID string) (*NPCDefinition, error)
+	// Get retrieves an NPC definition by ID, scoped to the given tenant and
+	// (optionally) campaign. Returns (nil, nil) if not found.
+	Get(ctx context.Context, tenantID, id, campaignID string) (*NPCDefinition, error)
 
 	// Update replaces an existing NPC definition. The definition is validated
-	// before the update. Returns an error if the NPC is not found.
+	// before the update. The definition's TenantID field must be set and is
+	// included in the WHERE clause. Returns an error if the NPC is not found.
 	Update(ctx context.Context, def *NPCDefinition) error
 
-	// Delete removes an NPC definition by ID and campaign ID (defense-in-depth).
-	// Deleting a non-existent NPC is not an error.
-	Delete(ctx context.Context, id, campaignID string) error
+	// Delete removes an NPC definition by ID, scoped to the given tenant and
+	// campaign (defense-in-depth). Deleting a non-existent NPC is not an error.
+	Delete(ctx context.Context, tenantID, id, campaignID string) error
 
-	// List returns all NPC definitions, optionally filtered by campaign ID.
-	// An empty campaignID returns all definitions.
-	List(ctx context.Context, campaignID string) ([]NPCDefinition, error)
+	// List returns NPC definitions for the given tenant, optionally filtered
+	// by campaign ID. An empty campaignID returns all definitions for the
+	// tenant.
+	List(ctx context.Context, tenantID, campaignID string) ([]NPCDefinition, error)
 
 	// Upsert creates or replaces an NPC definition (useful for YAML import).
-	// The definition is validated before persistence.
+	// The definition's TenantID field must be set. The definition is validated
+	// before persistence.
 	Upsert(ctx context.Context, def *NPCDefinition) error
 }

--- a/internal/gateway/sessionctrl.go
+++ b/internal/gateway/sessionctrl.go
@@ -190,7 +190,7 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 	// campaign, not a stale startup snapshot.
 	npcConfigs := gc.npcConfigs
 	if gc.npcStore != nil && campaignID != "" {
-		defs, listErr := gc.npcStore.List(ctx, campaignID)
+		defs, listErr := gc.npcStore.List(ctx, gc.tenantID, campaignID)
 		if listErr != nil {
 			_ = gc.orch.Transition(ctx, sessionID, SessionEnded, listErr.Error())
 			releaseGuild()

--- a/internal/gateway/sessionctrl_campaign_test.go
+++ b/internal/gateway/sessionctrl_campaign_test.go
@@ -78,14 +78,14 @@ type mockNPCStore struct {
 }
 
 func (m *mockNPCStore) Create(_ context.Context, _ *npcstore.NPCDefinition) error { return nil }
-func (m *mockNPCStore) Get(_ context.Context, _, _ string) (*npcstore.NPCDefinition, error) {
+func (m *mockNPCStore) Get(_ context.Context, _, _, _ string) (*npcstore.NPCDefinition, error) {
 	return nil, nil
 }
 func (m *mockNPCStore) Update(_ context.Context, _ *npcstore.NPCDefinition) error { return nil }
-func (m *mockNPCStore) Delete(_ context.Context, _, _ string) error               { return nil }
+func (m *mockNPCStore) Delete(_ context.Context, _, _, _ string) error            { return nil }
 func (m *mockNPCStore) Upsert(_ context.Context, _ *npcstore.NPCDefinition) error { return nil }
 
-func (m *mockNPCStore) List(_ context.Context, _ string) ([]npcstore.NPCDefinition, error) {
+func (m *mockNPCStore) List(_ context.Context, _, _ string) ([]npcstore.NPCDefinition, error) {
 	return m.defs, m.listErr
 }
 

--- a/internal/web/handlers_campaign_npcs.go
+++ b/internal/web/handlers_campaign_npcs.go
@@ -20,9 +20,9 @@ func (s *Server) handleLinkNPCToCampaign(w http.ResponseWriter, r *http.Request)
 
 	npcID := r.PathValue("npc_id")
 
-	// Verify NPC exists — pass the NPC's own campaign for lookup, then verify
-	// tenant ownership via the campaign check below.
-	npc, err := s.npcs.Get(r.Context(), npcID, "")
+	// Verify NPC exists — scoped to the calling tenant, pass empty campaign
+	// to look up across campaigns within the tenant.
+	npc, err := s.npcs.Get(r.Context(), claims.TenantID, npcID, "")
 	if err != nil || npc == nil {
 		writeError(w, http.StatusNotFound, "not_found", "NPC not found")
 		return
@@ -105,7 +105,7 @@ func (s *Server) handleListLinkedNPCs(w http.ResponseWriter, r *http.Request) {
 	result := make([]linkedNPC, 0, len(links))
 	for _, link := range links {
 		ln := linkedNPC{CampaignNPCLink: link}
-		npc, err := s.npcs.Get(r.Context(), link.NPCID, "")
+		npc, err := s.npcs.Get(r.Context(), claims.TenantID, link.NPCID, "")
 		if err == nil && npc != nil {
 			ln.NPC = npc
 		}

--- a/internal/web/handlers_campaign_npcs_test.go
+++ b/internal/web/handlers_campaign_npcs_test.go
@@ -17,7 +17,7 @@ func TestHandleLinkNPCToCampaign(t *testing.T) {
 
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Campaign A"}
 	ws.campaigns["c2"] = &Campaign{ID: "c2", TenantID: "tenant-1", Name: "Campaign B"}
-	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c1", Name: "Traveler"}
+	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", TenantID: "tenant-1", CampaignID: "c1", Name: "Traveler"}
 
 	// Link npc-1 (home: c1) to c2.
 	req := authReq(t, http.MethodPost, "/api/v1/campaigns/c2/npcs/npc-1/link",
@@ -42,7 +42,7 @@ func TestHandleLinkNPCToCampaign_HomeFails(t *testing.T) {
 	srv.registerRoutes()
 
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Campaign A"}
-	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c1", Name: "HomeNPC"}
+	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", TenantID: "tenant-1", CampaignID: "c1", Name: "HomeNPC"}
 
 	// Linking to home campaign should fail.
 	req := authReq(t, http.MethodPost, "/api/v1/campaigns/c1/npcs/npc-1/link",
@@ -80,7 +80,7 @@ func TestHandleListLinkedNPCs(t *testing.T) {
 	srv.registerRoutes()
 
 	ws.campaigns["c2"] = &Campaign{ID: "c2", TenantID: "tenant-1", Name: "Campaign B"}
-	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c1", Name: "Traveler"}
+	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", TenantID: "tenant-1", CampaignID: "c1", Name: "Traveler"}
 
 	// Seed a link.
 	ws.campaignNPCLinks["c2"] = []CampaignNPCLink{
@@ -148,7 +148,7 @@ func TestHandleLinkNPCToCampaign_CampaignNotFound(t *testing.T) {
 	srv, _, ns, secret := testServerWithStores(t)
 	srv.registerRoutes()
 
-	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c1", Name: "Traveler"}
+	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", TenantID: "tenant-1", CampaignID: "c1", Name: "Traveler"}
 
 	// Campaign does not exist.
 	req := authReq(t, http.MethodPost, "/api/v1/campaigns/nonexistent/npcs/npc-1/link",
@@ -171,7 +171,7 @@ func TestHandleLinkNPCToCampaign_CrossTenantBlocked(t *testing.T) {
 	ws.campaigns["c2"] = &Campaign{ID: "c2", TenantID: "tenant-1", Name: "Campaign B"}
 	// NPC belongs to campaign owned by a different tenant.
 	ws.campaigns["c-other"] = &Campaign{ID: "c-other", TenantID: "tenant-2", Name: "Other"}
-	ns.npcs["npc-other"] = &npcstore.NPCDefinition{ID: "npc-other", CampaignID: "c-other", Name: "Cross-Tenant"}
+	ns.npcs["npc-other"] = &npcstore.NPCDefinition{ID: "npc-other", TenantID: "tenant-2", CampaignID: "c-other", Name: "Cross-Tenant"}
 
 	req := authReq(t, http.MethodPost, "/api/v1/campaigns/c1/npcs/npc-other/link",
 		nil, secret, "user-1", "tenant-1", "dm")

--- a/internal/web/handlers_npcs.go
+++ b/internal/web/handlers_npcs.go
@@ -55,6 +55,7 @@ func (s *Server) handleCreateNPC(w http.ResponseWriter, r *http.Request) {
 
 	def := &npcstore.NPCDefinition{
 		ID:              req.ID,
+		TenantID:        claims.TenantID,
 		CampaignID:      campaignID,
 		Name:            req.Name,
 		Personality:     req.Personality,
@@ -95,7 +96,7 @@ func (s *Server) handleListNPCs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	npcs, err := s.npcs.List(r.Context(), campaignID)
+	npcs, err := s.npcs.List(r.Context(), claims.TenantID, campaignID)
 	if err != nil {
 		slog.Error("web: list npcs", "campaign_id", campaignID, "err", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to list NPCs")
@@ -120,7 +121,7 @@ func (s *Server) handleGetNPC(w http.ResponseWriter, r *http.Request) {
 	}
 
 	npcID := r.PathValue("npc_id")
-	npc, err := s.npcs.Get(r.Context(), npcID, campaignID)
+	npc, err := s.npcs.Get(r.Context(), claims.TenantID, npcID, campaignID)
 	if err != nil {
 		slog.Error("web: get npc", "npc_id", npcID, "err", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to get NPC")
@@ -146,7 +147,7 @@ func (s *Server) handleUpdateNPC(w http.ResponseWriter, r *http.Request) {
 	}
 
 	npcID := r.PathValue("npc_id")
-	existing, err := s.npcs.Get(r.Context(), npcID, campaignID)
+	existing, err := s.npcs.Get(r.Context(), claims.TenantID, npcID, campaignID)
 	if err != nil || existing == nil {
 		writeError(w, http.StatusNotFound, "not_found", "NPC not found")
 		return
@@ -194,14 +195,14 @@ func (s *Server) handleDeleteNPC(w http.ResponseWriter, r *http.Request) {
 
 	npcID := r.PathValue("npc_id")
 
-	// Verify the NPC belongs to this campaign before deleting.
-	existing, err := s.npcs.Get(r.Context(), npcID, campaignID)
+	// Verify the NPC belongs to this tenant and campaign before deleting.
+	existing, err := s.npcs.Get(r.Context(), claims.TenantID, npcID, campaignID)
 	if err != nil || existing == nil {
 		writeError(w, http.StatusNotFound, "not_found", "NPC not found")
 		return
 	}
 
-	if err := s.npcs.Delete(r.Context(), npcID, campaignID); err != nil {
+	if err := s.npcs.Delete(r.Context(), claims.TenantID, npcID, campaignID); err != nil {
 		slog.Error("web: delete npc", "npc_id", npcID, "err", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to delete NPC")
 		return

--- a/internal/web/handlers_npcs_test.go
+++ b/internal/web/handlers_npcs_test.go
@@ -132,9 +132,9 @@ func TestHandleListNPCs(t *testing.T) {
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
 
 	// Seed NPCs.
-	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c1", Name: "Heinrich"}
-	ns.npcs["npc-2"] = &npcstore.NPCDefinition{ID: "npc-2", CampaignID: "c1", Name: "Mathilde"}
-	ns.npcs["npc-3"] = &npcstore.NPCDefinition{ID: "npc-3", CampaignID: "c2", Name: "OtherCampaign"}
+	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", TenantID: "tenant-1", CampaignID: "c1", Name: "Heinrich"}
+	ns.npcs["npc-2"] = &npcstore.NPCDefinition{ID: "npc-2", TenantID: "tenant-1", CampaignID: "c1", Name: "Mathilde"}
+	ns.npcs["npc-3"] = &npcstore.NPCDefinition{ID: "npc-3", TenantID: "tenant-1", CampaignID: "c2", Name: "OtherCampaign"}
 
 	req := authReq(t, http.MethodGet, "/api/v1/campaigns/c1/npcs", nil, secret, "user-1", "tenant-1", "dm")
 	rr := httptest.NewRecorder()
@@ -205,8 +205,8 @@ func TestHandleGetNPC(t *testing.T) {
 			srv.mux.Handle("GET /api/v1/campaigns/{id}/npcs/{npc_id}", auth(http.HandlerFunc(srv.handleGetNPC)))
 
 			ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
-			ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c1", Name: "Heinrich"}
-			ns.npcs["npc-other"] = &npcstore.NPCDefinition{ID: "npc-other", CampaignID: "c2", Name: "WrongCampaign"}
+			ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", TenantID: "tenant-1", CampaignID: "c1", Name: "Heinrich"}
+			ns.npcs["npc-other"] = &npcstore.NPCDefinition{ID: "npc-other", TenantID: "tenant-1", CampaignID: "c2", Name: "WrongCampaign"}
 
 			req := authReq(t, http.MethodGet, "/api/v1/campaigns/c1/npcs/"+tt.npcID, nil, secret, "user-1", "tenant-1", "dm")
 			rr := httptest.NewRecorder()
@@ -262,7 +262,7 @@ func TestHandleUpdateNPC(t *testing.T) {
 
 			ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
 			if tt.seedNPC {
-				ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c1", Name: "OldName", Personality: "Wise"}
+				ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", TenantID: "tenant-1", CampaignID: "c1", Name: "OldName", Personality: "Wise"}
 			}
 
 			req := authReq(t, http.MethodPut, "/api/v1/campaigns/c1/npcs/"+tt.npcID,
@@ -297,7 +297,7 @@ func TestHandleUpdateNPC_WrongCampaign(t *testing.T) {
 	srv.mux.Handle("PUT /api/v1/campaigns/{id}/npcs/{npc_id}", auth(RequireRole("dm")(http.HandlerFunc(srv.handleUpdateNPC))))
 
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Campaign1"}
-	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c2", Name: "WrongCampaign"}
+	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", TenantID: "tenant-1", CampaignID: "c2", Name: "WrongCampaign"}
 
 	req := authReq(t, http.MethodPut, "/api/v1/campaigns/c1/npcs/npc-1",
 		bytes.NewBufferString(`{"name":"Hack"}`), secret, "user-1", "tenant-1", "dm")
@@ -317,7 +317,7 @@ func TestHandleDeleteNPC(t *testing.T) {
 	srv.mux.Handle("DELETE /api/v1/campaigns/{id}/npcs/{npc_id}", auth(RequireRole("dm")(http.HandlerFunc(srv.handleDeleteNPC))))
 
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Campaign"}
-	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c1", Name: "ToDelete"}
+	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", TenantID: "tenant-1", CampaignID: "c1", Name: "ToDelete"}
 
 	req := authReq(t, http.MethodDelete, "/api/v1/campaigns/c1/npcs/npc-1", nil, secret, "user-1", "tenant-1", "dm")
 	rr := httptest.NewRecorder()
@@ -358,7 +358,7 @@ func TestHandleDeleteNPC_WrongCampaign(t *testing.T) {
 	srv.mux.Handle("DELETE /api/v1/campaigns/{id}/npcs/{npc_id}", auth(RequireRole("dm")(http.HandlerFunc(srv.handleDeleteNPC))))
 
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "Campaign"}
-	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", CampaignID: "c-other", Name: "WrongCampaign"}
+	ns.npcs["npc-1"] = &npcstore.NPCDefinition{ID: "npc-1", TenantID: "tenant-1", CampaignID: "c-other", Name: "WrongCampaign"}
 
 	req := authReq(t, http.MethodDelete, "/api/v1/campaigns/c1/npcs/npc-1", nil, secret, "user-1", "tenant-1", "dm")
 	rr := httptest.NewRecorder()

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -40,9 +40,12 @@ func (m *mockNPCStore) Create(_ context.Context, def *npcstore.NPCDefinition) er
 	return nil
 }
 
-func (m *mockNPCStore) Get(_ context.Context, id, campaignID string) (*npcstore.NPCDefinition, error) {
+func (m *mockNPCStore) Get(_ context.Context, tenantID, id, campaignID string) (*npcstore.NPCDefinition, error) {
 	def, ok := m.npcs[id]
 	if !ok {
+		return nil, nil
+	}
+	if tenantID != "" && def.TenantID != tenantID {
 		return nil, nil
 	}
 	if campaignID != "" && def.CampaignID != campaignID {
@@ -52,7 +55,11 @@ func (m *mockNPCStore) Get(_ context.Context, id, campaignID string) (*npcstore.
 }
 
 func (m *mockNPCStore) Update(_ context.Context, def *npcstore.NPCDefinition) error {
-	if _, ok := m.npcs[def.ID]; !ok {
+	existing, ok := m.npcs[def.ID]
+	if !ok {
+		return nil
+	}
+	if def.TenantID != "" && existing.TenantID != def.TenantID {
 		return nil
 	}
 	def.UpdatedAt = time.Now().UTC()
@@ -60,9 +67,12 @@ func (m *mockNPCStore) Update(_ context.Context, def *npcstore.NPCDefinition) er
 	return nil
 }
 
-func (m *mockNPCStore) Delete(_ context.Context, id, campaignID string) error {
-	if campaignID != "" {
-		if def, ok := m.npcs[id]; ok && def.CampaignID != campaignID {
+func (m *mockNPCStore) Delete(_ context.Context, tenantID, id, campaignID string) error {
+	if def, ok := m.npcs[id]; ok {
+		if tenantID != "" && def.TenantID != tenantID {
+			return nil
+		}
+		if campaignID != "" && def.CampaignID != campaignID {
 			return nil
 		}
 	}
@@ -70,9 +80,12 @@ func (m *mockNPCStore) Delete(_ context.Context, id, campaignID string) error {
 	return nil
 }
 
-func (m *mockNPCStore) List(_ context.Context, campaignID string) ([]npcstore.NPCDefinition, error) {
+func (m *mockNPCStore) List(_ context.Context, tenantID, campaignID string) ([]npcstore.NPCDefinition, error) {
 	var result []npcstore.NPCDefinition
 	for _, def := range m.npcs {
+		if tenantID != "" && def.TenantID != tenantID {
+			continue
+		}
 		if campaignID == "" || def.CampaignID == campaignID {
 			result = append(result, *def)
 		}

--- a/internal/web/handlers_voice_preview.go
+++ b/internal/web/handlers_voice_preview.go
@@ -28,7 +28,7 @@ func (s *Server) handleVoicePreview(w http.ResponseWriter, r *http.Request) {
 	}
 
 	npcID := r.PathValue("npc_id")
-	npc, err := s.npcs.Get(r.Context(), npcID, "")
+	npc, err := s.npcs.Get(r.Context(), claims.TenantID, npcID, "")
 	if err != nil {
 		slog.Error("web: get npc for voice preview", "npc_id", npcID, "err", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to get NPC")

--- a/internal/web/handlers_voice_preview_test.go
+++ b/internal/web/handlers_voice_preview_test.go
@@ -19,6 +19,7 @@ func TestHandleVoicePreview_ReturnsAudio(t *testing.T) {
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
 	ns.npcs["npc-1"] = &npcstore.NPCDefinition{
 		ID:         "npc-1",
+		TenantID:   "tenant-1",
 		CampaignID: "c1",
 		Name:       "TestNPC",
 		Voice:      npcstore.VoiceConfig{Provider: "elevenlabs", VoiceID: "v1"},
@@ -53,6 +54,7 @@ func TestHandleVoicePreview_DefaultText(t *testing.T) {
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
 	ns.npcs["npc-1"] = &npcstore.NPCDefinition{
 		ID:         "npc-1",
+		TenantID:   "tenant-1",
 		CampaignID: "c1",
 		Name:       "TestNPC",
 		Voice:      npcstore.VoiceConfig{Provider: "elevenlabs", VoiceID: "v1"},
@@ -78,6 +80,7 @@ func TestHandleVoicePreview_TextTooLong(t *testing.T) {
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
 	ns.npcs["npc-1"] = &npcstore.NPCDefinition{
 		ID:         "npc-1",
+		TenantID:   "tenant-1",
 		CampaignID: "c1",
 		Name:       "TestNPC",
 		Voice:      npcstore.VoiceConfig{Provider: "elevenlabs", VoiceID: "v1"},
@@ -119,6 +122,7 @@ func TestHandleVoicePreview_RateLimiting(t *testing.T) {
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
 	ns.npcs["npc-1"] = &npcstore.NPCDefinition{
 		ID:         "npc-1",
+		TenantID:   "tenant-1",
 		CampaignID: "c1",
 		Name:       "TestNPC",
 		Voice:      npcstore.VoiceConfig{Provider: "elevenlabs", VoiceID: "v1"},
@@ -158,6 +162,7 @@ func TestHandleVoicePreview_NoProvider(t *testing.T) {
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
 	ns.npcs["npc-1"] = &npcstore.NPCDefinition{
 		ID:         "npc-1",
+		TenantID:   "tenant-1",
 		CampaignID: "c1",
 		Name:       "TestNPC",
 		Voice:      npcstore.VoiceConfig{Provider: "elevenlabs", VoiceID: "v1"},
@@ -183,6 +188,7 @@ func TestHandleVoicePreview_WrongTenant(t *testing.T) {
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
 	ns.npcs["npc-1"] = &npcstore.NPCDefinition{
 		ID:         "npc-1",
+		TenantID:   "tenant-1",
 		CampaignID: "c1",
 		Name:       "TestNPC",
 		Voice:      npcstore.VoiceConfig{Provider: "elevenlabs", VoiceID: "v1"},
@@ -224,6 +230,7 @@ func TestHandleVoicePreview_ExactMaxLength(t *testing.T) {
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "tenant-1", Name: "TestCampaign"}
 	ns.npcs["npc-1"] = &npcstore.NPCDefinition{
 		ID:         "npc-1",
+		TenantID:   "tenant-1",
 		CampaignID: "c1",
 		Name:       "TestNPC",
 		Voice:      npcstore.VoiceConfig{Provider: "elevenlabs", VoiceID: "v1"},

--- a/internal/web/integration_test.go
+++ b/internal/web/integration_test.go
@@ -88,9 +88,12 @@ func (m *mockNPCStore) Create(_ context.Context, def *npcstore.NPCDefinition) er
 	return nil
 }
 
-func (m *mockNPCStore) Get(_ context.Context, id, campaignID string) (*npcstore.NPCDefinition, error) {
+func (m *mockNPCStore) Get(_ context.Context, tenantID, id, campaignID string) (*npcstore.NPCDefinition, error) {
 	def, ok := m.npcs[id]
 	if !ok {
+		return nil, nil
+	}
+	if tenantID != "" && def.TenantID != tenantID {
 		return nil, nil
 	}
 	if campaignID != "" && def.CampaignID != campaignID {
@@ -100,7 +103,11 @@ func (m *mockNPCStore) Get(_ context.Context, id, campaignID string) (*npcstore.
 }
 
 func (m *mockNPCStore) Update(_ context.Context, def *npcstore.NPCDefinition) error {
-	if _, ok := m.npcs[def.ID]; !ok {
+	existing, ok := m.npcs[def.ID]
+	if !ok {
+		return nil
+	}
+	if def.TenantID != "" && existing.TenantID != def.TenantID {
 		return nil
 	}
 	def.UpdatedAt = time.Now().UTC()
@@ -108,14 +115,22 @@ func (m *mockNPCStore) Update(_ context.Context, def *npcstore.NPCDefinition) er
 	return nil
 }
 
-func (m *mockNPCStore) Delete(_ context.Context, id, _ string) error {
+func (m *mockNPCStore) Delete(_ context.Context, tenantID, id, _ string) error {
+	if def, ok := m.npcs[id]; ok {
+		if tenantID != "" && def.TenantID != tenantID {
+			return nil
+		}
+	}
 	delete(m.npcs, id)
 	return nil
 }
 
-func (m *mockNPCStore) List(_ context.Context, campaignID string) ([]npcstore.NPCDefinition, error) {
+func (m *mockNPCStore) List(_ context.Context, tenantID, campaignID string) ([]npcstore.NPCDefinition, error) {
 	var result []npcstore.NPCDefinition
 	for _, def := range m.npcs {
+		if tenantID != "" && def.TenantID != tenantID {
+			continue
+		}
 		if campaignID == "" || def.CampaignID == campaignID {
 			result = append(result, *def)
 		}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -130,7 +130,7 @@ func TestServer_RegistrationIntegration(t *testing.T) {
 
 	// Seed data.
 	ws.campaigns["c1"] = &Campaign{ID: "c1", TenantID: "t1", Name: "Camp"}
-	ns.npcs["n1"] = &npcstore.NPCDefinition{ID: "n1", CampaignID: "c1", Name: "NPC"}
+	ns.npcs["n1"] = &npcstore.NPCDefinition{ID: "n1", TenantID: "t1", CampaignID: "c1", Name: "NPC"}
 
 	token := signTestToken(t, cfg.JWTSecret, "u1", "t1", "dm")
 


### PR DESCRIPTION
## Summary

- Adds `tenant_id` column to `npc_definitions` table with migration for existing tables
- Updates `Store` interface: `Get`, `Delete`, and `List` now require `tenantID` parameter; `Create`, `Update`, and `Upsert` use `def.TenantID`
- All PostgresStore SQL queries include `tenant_id` in WHERE clauses, preventing cross-tenant NPC access
- Propagates tenant_id through web handlers (`handlers_npcs.go`, `handlers_campaign_npcs.go`, `handlers_voice_preview.go`), gateway session controller, and all mock implementations
- Adds dedicated cross-tenant isolation tests verifying every query path (Get, List, Delete, Update, Create)

## Context

Architecture audit item 2.5 (High severity). The `npc_definitions` table had no `tenant_id` column, and NPC queries were scoped only by `campaign_id`. Since NPC IDs are UUIDs, the practical risk was low, but defense-in-depth requires every data-access path to enforce tenant boundaries at the SQL level.

## Test plan

- [x] `go test -race -count=1 ./internal/agent/npcstore/...` -- all pass
- [x] `go test -race -count=1 ./internal/web/...` -- all pass
- [x] `go test -race -count=1 ./internal/gateway/...` -- all pass
- [x] `gofmt -w .` -- clean
- [ ] Verify migration applies cleanly on a database with existing `npc_definitions` rows (the `ALTER TABLE ADD COLUMN IF NOT EXISTS` should backfill with empty string default)