### PR TITLE
fix: wire self-hearing guard to prevent NPC echo/feedback loops

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -198,6 +198,7 @@ func runFull(cfg *config.Config) int {
 			MCPHost:      application.MCPHost(),
 			Entities:     application.EntityStore(),
 			Tenant:       application.Tenant(),
+			BotUserID:    bot.Client().ApplicationID.String(),
 		})
 
 		// Session and recap register themselves in the constructor.

--- a/cmd/glyphoxa/worker_factory.go
+++ b/cmd/glyphoxa/worker_factory.go
@@ -140,6 +140,11 @@ func (wf *workerFactory) CreateRuntime(ctx context.Context, req gw.StartSessionR
 			}
 			return nil, fmt.Errorf("worker: connect audio bridge: %w", err)
 		}
+		// Activate self-hearing guard so the worker drops frames from the
+		// bot's own user ID (prevents NPC echo/feedback loops).
+		if req.BotUserID != "" {
+			bridgeConn.SetBotUserID(req.BotUserID)
+		}
 		conn = bridgeConn
 		voicePlatformCloser = bridgeConnCloser
 	} else {
@@ -161,6 +166,12 @@ func (wf *workerFactory) CreateRuntime(ctx context.Context, req gw.StartSessionR
 				_ = storeCloser()
 			}
 			return nil, fmt.Errorf("worker: connect to voice channel %s: %w", req.ChannelID, err)
+		}
+		// Activate self-hearing guard on the voice connection.
+		if req.BotUserID != "" {
+			if guard, ok := conn.(audio.SelfHearingGuard); ok {
+				guard.SetBotUserID(req.BotUserID)
+			}
 		}
 		voicePlatformCloser = platform.Close
 	}
@@ -341,6 +352,7 @@ func (wf *workerFactory) CreateRuntime(ctx context.Context, req gw.StartSessionR
 			Ctx:         sessionCtx,
 			Pipeline:    correctionPipeline,
 			Entities:    entityNamesFn,
+			BotUserID:   req.BotUserID,
 		})
 		pipeline.Start()
 		pipelineCloser = pipeline.Stop

--- a/gen/glyphoxa/v1/session.pb.go
+++ b/gen/glyphoxa/v1/session.pb.go
@@ -178,15 +178,19 @@ func (x *NPCConfig) GetAddressOnly() bool {
 
 // StartSessionRequest is sent by the gateway to a worker to start a new voice session.
 type StartSessionRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	TenantId      string                 `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
-	CampaignId    string                 `protobuf:"bytes,2,opt,name=campaign_id,json=campaignId,proto3" json:"campaign_id,omitempty"`
-	GuildId       string                 `protobuf:"bytes,3,opt,name=guild_id,json=guildId,proto3" json:"guild_id,omitempty"`
-	ChannelId     string                 `protobuf:"bytes,4,opt,name=channel_id,json=channelId,proto3" json:"channel_id,omitempty"`
-	LicenseTier   string                 `protobuf:"bytes,5,opt,name=license_tier,json=licenseTier,proto3" json:"license_tier,omitempty"`
-	SessionId     string                 `protobuf:"bytes,6,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	NpcConfigs    []*NPCConfig           `protobuf:"bytes,7,rep,name=npc_configs,json=npcConfigs,proto3" json:"npc_configs,omitempty"`
-	BotToken      string                 `protobuf:"bytes,8,opt,name=bot_token,json=botToken,proto3" json:"bot_token,omitempty"`
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	TenantId    string                 `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	CampaignId  string                 `protobuf:"bytes,2,opt,name=campaign_id,json=campaignId,proto3" json:"campaign_id,omitempty"`
+	GuildId     string                 `protobuf:"bytes,3,opt,name=guild_id,json=guildId,proto3" json:"guild_id,omitempty"`
+	ChannelId   string                 `protobuf:"bytes,4,opt,name=channel_id,json=channelId,proto3" json:"channel_id,omitempty"`
+	LicenseTier string                 `protobuf:"bytes,5,opt,name=license_tier,json=licenseTier,proto3" json:"license_tier,omitempty"`
+	SessionId   string                 `protobuf:"bytes,6,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	NpcConfigs  []*NPCConfig           `protobuf:"bytes,7,rep,name=npc_configs,json=npcConfigs,proto3" json:"npc_configs,omitempty"`
+	BotToken    string                 `protobuf:"bytes,8,opt,name=bot_token,json=botToken,proto3" json:"bot_token,omitempty"`
+	// bot_user_id is the bot's Discord user ID (snowflake). Workers use it to
+	// activate the self-hearing guard — filtering out the bot's own audio frames
+	// so NPCs don't hear their own TTS output (echo/feedback loop prevention).
+	BotUserId     string `protobuf:"bytes,13,opt,name=bot_user_id,json=botUserId,proto3" json:"bot_user_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -273,6 +277,13 @@ func (x *StartSessionRequest) GetNpcConfigs() []*NPCConfig {
 func (x *StartSessionRequest) GetBotToken() string {
 	if x != nil {
 		return x.BotToken
+	}
+	return ""
+}
+
+func (x *StartSessionRequest) GetBotUserId() string {
+	if x != nil {
+		return x.BotUserId
 	}
 	return ""
 }
@@ -1486,7 +1497,7 @@ const file_glyphoxa_v1_session_proto_rawDesc = "" +
 	"\vbudget_tier\x18\x06 \x01(\tR\n" +
 	"budgetTier\x12\x1b\n" +
 	"\tgm_helper\x18\a \x01(\bR\bgmHelper\x12!\n" +
-	"\faddress_only\x18\b \x01(\bR\vaddressOnly\"\xf9\x02\n" +
+	"\faddress_only\x18\b \x01(\bR\vaddressOnly\"\x8c\x03\n" +
 	"\x13StartSessionRequest\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x1f\n" +
 	"\vcampaign_id\x18\x02 \x01(\tR\n" +
@@ -1499,9 +1510,10 @@ const file_glyphoxa_v1_session_proto_rawDesc = "" +
 	"session_id\x18\x06 \x01(\tR\tsessionId\x127\n" +
 	"\vnpc_configs\x18\a \x03(\v2\x16.glyphoxa.v1.NPCConfigR\n" +
 	"npcConfigs\x12\x1b\n" +
-	"\tbot_token\x18\b \x01(\tR\bbotTokenJ\x04\b\t\x10\n" +
+	"\tbot_token\x18\b \x01(\tR\bbotToken\x12\x1e\n" +
+	"\vbot_user_id\x18\r \x01(\tR\tbotUserIdJ\x04\b\t\x10\n" +
 	"J\x04\b\n" +
-	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rR\x10voice_session_idR\vvoice_tokenR\x0evoice_endpointR\vbot_user_id\"K\n" +
+	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rR\x10voice_session_idR\vvoice_tokenR\x0evoice_endpoint\"K\n" +
 	"\x14StartSessionResponse\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x14\n" +

--- a/internal/app/exports.go
+++ b/internal/app/exports.go
@@ -75,6 +75,7 @@ type AudioPipelineConfig struct {
 	Ctx         context.Context
 	Pipeline    transcript.Pipeline // may be nil — correction is skipped when nil
 	Entities    func() []string     // returns current entity names; may be nil
+	BotUserID   string              // bot's own user ID — workers for this ID are skipped
 }
 
 // AudioPipeline is the exported type alias for the audio pipeline.
@@ -95,5 +96,6 @@ func NewAudioPipeline(cfg AudioPipelineConfig) *AudioPipeline {
 		ctx:         cfg.Ctx,
 		pipeline:    cfg.Pipeline,
 		entities:    cfg.Entities,
+		botUserID:   cfg.BotUserID,
 	})
 }

--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -80,6 +80,7 @@ type SessionManager struct {
 	mcpHost      mcp.Host
 	entities     entity.Store
 	tenant       config.TenantContext
+	botUserID    string // bot's own user ID — for self-hearing guard
 }
 
 // SessionManagerConfig holds all dependencies for a [SessionManager].
@@ -93,6 +94,11 @@ type SessionManagerConfig struct {
 	MCPHost      mcp.Host
 	Entities     entity.Store
 	Tenant       config.TenantContext
+
+	// BotUserID is the bot's own user ID (e.g., Discord application ID as a
+	// string). Used by the self-hearing guard to filter out the bot's own
+	// audio frames and prevent echo/feedback loops.
+	BotUserID string
 }
 
 // NewSessionManager creates a SessionManager with the given dependencies.
@@ -107,6 +113,7 @@ func NewSessionManager(cfg SessionManagerConfig) *SessionManager {
 		mcpHost:      cfg.MCPHost,
 		entities:     cfg.Entities,
 		tenant:       cfg.Tenant,
+		botUserID:    cfg.BotUserID,
 	}
 }
 
@@ -145,6 +152,15 @@ func (sm *SessionManager) Start(ctx context.Context, channelID string, dmUserID 
 	conn, err := sm.platform.Connect(ctx, channelID)
 	if err != nil {
 		return fmt.Errorf("session: connect to voice channel: %w", err)
+	}
+
+	// Activate self-hearing guard on the connection so the bot's own audio
+	// frames are dropped before reaching the pipeline. This prevents NPC
+	// echo/feedback loops where the bot hears its own TTS output.
+	if sm.botUserID != "" {
+		if guard, ok := conn.(audio.SelfHearingGuard); ok {
+			guard.SetBotUserID(sm.botUserID)
+		}
 	}
 
 	// Create mixer for this session, wired to the voice connection output.
@@ -272,6 +288,7 @@ func (sm *SessionManager) Start(ctx context.Context, channelID string, dmUserID 
 			ctx:         sessionCtx,
 			pipeline:    correctionPipeline,
 			entities:    entityNamesFn,
+			botUserID:   sm.botUserID,
 		})
 		activePipeline.Start()
 		closers = append(closers, activePipeline.Stop)

--- a/internal/app/session_manager_test.go
+++ b/internal/app/session_manager_test.go
@@ -466,6 +466,94 @@ func TestSessionManager_UsesLLMSummariser(t *testing.T) {
 	}
 }
 
+// ─── Self-hearing guard wiring ──────────────────────────────────────────────
+
+// guardConnection is a mock that implements both audio.Connection and
+// audio.SelfHearingGuard, so we can verify that SessionManager calls
+// SetBotUserID on the connection when BotUserID is configured.
+type guardConnection struct {
+	audiomock.Connection
+	mu          sync.Mutex
+	botUserIDCh chan string
+}
+
+func (g *guardConnection) SetBotUserID(id string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.botUserIDCh <- id
+}
+
+// TestSessionManager_SelfHearingGuardWired verifies that when BotUserID is
+// configured and the connection implements audio.SelfHearingGuard,
+// SetBotUserID is called during session Start.
+func TestSessionManager_SelfHearingGuardWired(t *testing.T) {
+	t.Parallel()
+
+	conn := &guardConnection{botUserIDCh: make(chan string, 1)}
+	platform := &audiomock.Platform{ConnectResult: conn}
+	store := &memorymock.SessionStore{}
+	cfg := &config.Config{
+		Campaign: config.CampaignConfig{Name: "GuardTest"},
+	}
+
+	sm := app.NewSessionManager(app.SessionManagerConfig{
+		Platform:     platform,
+		Config:       cfg,
+		Providers:    &app.Providers{},
+		SessionStore: store,
+		BotUserID:    "123456789",
+	})
+
+	ctx := context.Background()
+	if err := sm.Start(ctx, "ch-guard", "dm-1"); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer func() { _ = sm.Stop(ctx) }()
+
+	select {
+	case id := <-conn.botUserIDCh:
+		if id != "123456789" {
+			t.Errorf("SetBotUserID called with %q, want %q", id, "123456789")
+		}
+	case <-time.After(time.Second):
+		t.Error("SetBotUserID was not called on the connection")
+	}
+}
+
+// TestSessionManager_SelfHearingGuardSkippedWhenEmpty verifies that when
+// BotUserID is empty, SetBotUserID is NOT called (no-op).
+func TestSessionManager_SelfHearingGuardSkippedWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	conn := &guardConnection{botUserIDCh: make(chan string, 1)}
+	platform := &audiomock.Platform{ConnectResult: conn}
+	store := &memorymock.SessionStore{}
+	cfg := &config.Config{
+		Campaign: config.CampaignConfig{Name: "GuardEmpty"},
+	}
+
+	sm := app.NewSessionManager(app.SessionManagerConfig{
+		Platform:     platform,
+		Config:       cfg,
+		Providers:    &app.Providers{},
+		SessionStore: store,
+		// BotUserID intentionally empty.
+	})
+
+	ctx := context.Background()
+	if err := sm.Start(ctx, "ch-guard-empty", "dm-1"); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer func() { _ = sm.Stop(ctx) }()
+
+	select {
+	case id := <-conn.botUserIDCh:
+		t.Errorf("SetBotUserID should NOT have been called, got %q", id)
+	case <-time.After(100 * time.Millisecond):
+		// Expected: no call when BotUserID is empty.
+	}
+}
+
 // TestSessionManager_FallbackNoopSummariser verifies graceful degradation:
 // when Providers.LLM is nil the session still starts and stops correctly,
 // using the noopSummariser fallback.

--- a/internal/gateway/contract.go
+++ b/internal/gateway/contract.go
@@ -85,6 +85,11 @@ type StartSessionRequest struct {
 	LicenseTier string
 	NPCConfigs  []NPCConfigMsg
 	BotToken    string
+
+	// BotUserID is the bot's Discord user ID (snowflake string). Workers use
+	// it to activate the self-hearing guard, filtering out the bot's own audio
+	// frames so NPCs don't respond to their own TTS output.
+	BotUserID string
 }
 
 // SessionStatus describes the current state of a session.

--- a/internal/gateway/coverage_boost_test.go
+++ b/internal/gateway/coverage_boost_test.go
@@ -552,7 +552,7 @@ func TestSetupVoiceBridge_WiresReceiverAndProvider(t *testing.T) {
 
 	conn := &mockVoiceConn{guildID: snowflake.ID(123)}
 
-	cleanup := setupVoiceBridge(conn, bridge, "sess-setup")
+	cleanup := setupVoiceBridge(conn, bridge, "sess-setup", 0)
 
 	// Receiver and provider should be set on the mock conn.
 	if conn.receiver == nil {
@@ -578,7 +578,7 @@ func TestSetupVoiceBridge_CleanupIdempotent(t *testing.T) {
 
 	conn := &mockVoiceConn{guildID: snowflake.ID(456)}
 
-	cleanup := setupVoiceBridge(conn, bridge, "sess-cleanup-idem")
+	cleanup := setupVoiceBridge(conn, bridge, "sess-cleanup-idem", 0)
 
 	// Should not panic when called multiple times.
 	cleanup()
@@ -586,6 +586,132 @@ func TestSetupVoiceBridge_CleanupIdempotent(t *testing.T) {
 
 	if !conn.closed {
 		t.Error("expected conn to be closed")
+	}
+}
+
+// ── voiceBridgeReceiver self-hearing guard ──────────────────────────────────
+
+// TestVoiceBridgeReceiver_SelfHearingGuard verifies that frames from the bot's
+// own user ID are silently dropped at the gateway layer.
+func TestVoiceBridgeReceiver_SelfHearingGuard(t *testing.T) {
+	t.Parallel()
+
+	srv := audiobridge.NewServer()
+	bridge := srv.NewSessionBridge("sess-guard")
+	defer srv.RemoveBridge("sess-guard")
+
+	botID := snowflake.ID(42)
+
+	receiver := &voiceBridgeReceiver{
+		bridge:    bridge,
+		sessionID: "sess-guard",
+		botUserID: botID,
+		done:      make(chan struct{}),
+	}
+
+	opus := []byte{0xF8, 0xFF, 0xFE}
+
+	// Frame from the bot's own user ID should be dropped.
+	if err := receiver.ReceiveOpusFrame(botID, &voice.Packet{SSRC: 1, Opus: opus}); err != nil {
+		t.Fatalf("ReceiveOpusFrame(botID): %v", err)
+	}
+
+	// Frame from a player should be forwarded.
+	playerID := snowflake.ID(123)
+	if err := receiver.ReceiveOpusFrame(playerID, &voice.Packet{SSRC: 2, Opus: opus}); err != nil {
+		t.Fatalf("ReceiveOpusFrame(playerID): %v", err)
+	}
+
+	// Only the player frame should arrive on the toWorker channel.
+	select {
+	case frame := <-bridge.ReceiveFromWorker():
+		// This reads from fromWorker, but we sent to toWorker. Let's read toWorker directly.
+		_ = frame
+	default:
+	}
+
+	// Drain toWorker to check the forwarded frame.
+	var received int
+	for {
+		select {
+		case <-bridge.Done():
+			t.Fatal("bridge closed unexpectedly")
+		default:
+		}
+		// SendToWorker is non-blocking, so the frame should be in toWorker.
+		// We can't read toWorker directly from SessionBridge, so we verify
+		// via frame count: the receiver only incremented for the player.
+		break
+	}
+	_ = received
+
+	// The receiver's frame counter should be 1 (only the player frame counted).
+	if got := receiver.frameCount.Load(); got != 1 {
+		t.Errorf("frameCount: got %d, want 1 (only player frame should be counted)", got)
+	}
+}
+
+// TestVoiceBridgeReceiver_SelfHearingGuardInactive verifies that when no bot
+// user ID is set (zero value), all frames pass through.
+func TestVoiceBridgeReceiver_SelfHearingGuardInactive(t *testing.T) {
+	t.Parallel()
+
+	srv := audiobridge.NewServer()
+	bridge := srv.NewSessionBridge("sess-guard-off")
+	defer srv.RemoveBridge("sess-guard-off")
+
+	receiver := &voiceBridgeReceiver{
+		bridge:    bridge,
+		sessionID: "sess-guard-off",
+		// botUserID is zero — guard should be inactive.
+		done: make(chan struct{}),
+	}
+
+	opus := []byte{0xF8, 0xFF, 0xFE}
+	userID := snowflake.ID(42)
+
+	if err := receiver.ReceiveOpusFrame(userID, &voice.Packet{SSRC: 1, Opus: opus}); err != nil {
+		t.Fatalf("ReceiveOpusFrame: %v", err)
+	}
+
+	if got := receiver.frameCount.Load(); got != 1 {
+		t.Errorf("frameCount: got %d, want 1", got)
+	}
+}
+
+// TestSetupVoiceBridge_BotUserIDPassedToReceiver verifies that
+// setupVoiceBridge wires the botUserID into the receiver.
+func TestSetupVoiceBridge_BotUserIDPassedToReceiver(t *testing.T) {
+	t.Parallel()
+
+	srv := audiobridge.NewServer()
+	bridge := srv.NewSessionBridge("sess-guard-wire")
+	defer srv.RemoveBridge("sess-guard-wire")
+
+	conn := &mockVoiceConn{guildID: snowflake.ID(789)}
+	botID := snowflake.ID(42)
+
+	cleanup := setupVoiceBridge(conn, bridge, "sess-guard-wire", botID)
+	defer cleanup()
+
+	// The receiver should have botUserID set. Verify by sending a frame from
+	// the bot's user ID and checking it doesn't increment the frame counter.
+	receiver, ok := conn.receiver.(*voiceBridgeReceiver)
+	if !ok {
+		t.Fatal("receiver is not a *voiceBridgeReceiver")
+	}
+
+	opus := []byte{0xF8, 0xFF, 0xFE}
+	_ = receiver.ReceiveOpusFrame(botID, &voice.Packet{SSRC: 1, Opus: opus})
+
+	if got := receiver.frameCount.Load(); got != 0 {
+		t.Errorf("frameCount after bot frame: got %d, want 0", got)
+	}
+
+	// A non-bot frame should be counted.
+	_ = receiver.ReceiveOpusFrame(snowflake.ID(999), &voice.Packet{SSRC: 2, Opus: opus})
+	if got := receiver.frameCount.Load(); got != 1 {
+		t.Errorf("frameCount after player frame: got %d, want 1", got)
 	}
 }
 

--- a/internal/gateway/grpctransport/client.go
+++ b/internal/gateway/grpctransport/client.go
@@ -94,6 +94,7 @@ func (c *Client) StartSession(ctx context.Context, req gateway.StartSessionReque
 			LicenseTier: req.LicenseTier,
 			NpcConfigs:  pbNPCConfigs,
 			BotToken:    req.BotToken,
+			BotUserId:   req.BotUserID,
 		})
 		if err != nil {
 			return fmt.Errorf("grpctransport: start session: %w", err)

--- a/internal/gateway/grpctransport/server.go
+++ b/internal/gateway/grpctransport/server.go
@@ -85,6 +85,7 @@ func (s *WorkerServer) StartSession(ctx context.Context, req *pb.StartSessionReq
 		LicenseTier: req.GetLicenseTier(),
 		NPCConfigs:  npcConfigs,
 		BotToken:    req.GetBotToken(),
+		BotUserID:   req.GetBotUserId(),
 	})
 	if err != nil {
 		slog.Warn("grpc: start session failed", "session_id", req.GetSessionId(), "err", err)

--- a/internal/gateway/sessionctrl.go
+++ b/internal/gateway/sessionctrl.go
@@ -202,6 +202,13 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 	}
 
 	if gc.dispatcher != nil {
+		// Resolve the bot's own user ID so the worker can activate its
+		// self-hearing guard and filter out the bot's audio frames.
+		var botUserID snowflake.ID
+		if gc.gwBot != nil {
+			botUserID = gc.gwBot.Client().ApplicationID
+		}
+
 		startReq := StartSessionRequest{
 			SessionID:   sessionID,
 			TenantID:    gc.tenantID,
@@ -211,6 +218,7 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 			LicenseTier: gc.tier.String(),
 			BotToken:    gc.botToken,
 			NPCConfigs:  npcConfigs,
+			BotUserID:   botUserID.String(),
 		}
 
 		// Join voice via the gateway bot's VoiceManager and set up the audio
@@ -272,7 +280,7 @@ func (gc *GatewaySessionController) Start(ctx context.Context, req SessionStartR
 			// packets, so there is no need to block here waiting for a
 			// DAVE event. This matches the full-mode code path which
 			// also starts flowing audio right after Open().
-			cleanup := setupVoiceBridge(voiceConn, bridge, sessionID)
+			cleanup := setupVoiceBridge(voiceConn, bridge, sessionID, botUserID)
 			gc.voiceCleanupsMu.Lock()
 			gc.voiceCleanups[sessionID] = func() {
 				cleanup()

--- a/internal/gateway/voicebridge.go
+++ b/internal/gateway/voicebridge.go
@@ -31,6 +31,11 @@ type voiceBridgeReceiver struct {
 	bridge    *audiobridge.SessionBridge
 	sessionID string
 
+	// botUserID is the bot's own Discord user ID. When set, frames from this
+	// user are silently dropped to prevent echo/feedback loops at the gateway
+	// layer (defense-in-depth — the worker also filters by bot user ID).
+	botUserID snowflake.ID
+
 	frameCount atomic.Uint64
 	done       chan struct{}
 	closeOnce  sync.Once
@@ -38,8 +43,16 @@ type voiceBridgeReceiver struct {
 
 // ReceiveOpusFrame receives a raw opus packet from Discord and forwards it to
 // the worker via the audio bridge.
+//
+// Frames from the bot's own user ID (set via botUserID) are silently dropped
+// to prevent echo/feedback loops where the NPC hears its own TTS output.
 func (r *voiceBridgeReceiver) ReceiveOpusFrame(userID snowflake.ID, packet *voice.Packet) error {
 	if packet == nil || len(packet.Opus) == 0 {
+		return nil
+	}
+
+	// Self-hearing guard: drop frames from the bot's own user ID.
+	if r.botUserID != 0 && userID == r.botUserID {
 		return nil
 	}
 
@@ -126,14 +139,20 @@ func (p *voiceBridgeProvider) Close() {
 // setupVoiceBridge configures a voice.Conn to bridge audio to/from a
 // SessionBridge. The gateway joins voice normally via VoiceManager, then this
 // function wires the bridge receiver/provider onto the Conn.
+//
+// botUserID is the bot's own Discord user ID. When non-zero, the receiver
+// drops frames from this user to prevent echo/feedback loops at the gateway
+// layer (defense-in-depth).
 func setupVoiceBridge(
 	voiceConn voice.Conn,
 	bridge *audiobridge.SessionBridge,
 	sessionID string,
+	botUserID snowflake.ID,
 ) (cleanup func()) {
 	receiver := &voiceBridgeReceiver{
 		bridge:    bridge,
 		sessionID: sessionID,
+		botUserID: botUserID,
 		done:      make(chan struct{}),
 	}
 	provider := &voiceBridgeProvider{

--- a/pkg/audio/discord/connection.go
+++ b/pkg/audio/discord/connection.go
@@ -15,6 +15,7 @@ import (
 // Compile-time interface assertions.
 var (
 	_ audio.Connection        = (*Connection)(nil)
+	_ audio.SelfHearingGuard  = (*Connection)(nil)
 	_ voice.OpusFrameProvider = (*Connection)(nil)
 	_ voice.OpusFrameReceiver = (*Connection)(nil)
 )
@@ -101,11 +102,18 @@ func newConnection(conn voice.Conn, guildID snowflake.ID) *Connection {
 
 // SetBotUserID sets the bot's own user ID so that its audio is filtered out.
 // This prevents echo/feedback loops where the NPC hears its own TTS output.
-// Must be called before audio starts flowing. Safe for concurrent use (the
-// field is read atomically by ReceiveOpusFrame).
-func (c *Connection) SetBotUserID(id snowflake.ID) {
-	c.botUserID = id
-	slog.Debug("discord: bot user ID set for self-hearing guard", "bot_user_id", id)
+// Must be called before audio starts flowing.
+//
+// The id parameter is a Discord snowflake string (e.g., "123456789012345678").
+// Invalid IDs are logged and ignored. Implements [audio.SelfHearingGuard].
+func (c *Connection) SetBotUserID(id string) {
+	parsed, err := snowflake.Parse(id)
+	if err != nil {
+		slog.Warn("discord: invalid bot user ID for self-hearing guard", "id", id, "err", err)
+		return
+	}
+	c.botUserID = parsed
+	slog.Debug("discord: bot user ID set for self-hearing guard", "bot_user_id", parsed)
 }
 
 // ── voice.OpusFrameReceiver implementation ──────────────────��───────────────

--- a/pkg/audio/discord/platform_test.go
+++ b/pkg/audio/discord/platform_test.go
@@ -498,7 +498,7 @@ func TestConnection_SelfHearingGuard(t *testing.T) {
 	c := newTestConnection(t)
 
 	botID := snowflake.ID(999)
-	c.SetBotUserID(botID)
+	c.SetBotUserID(botID.String())
 
 	silenceOpus := []byte{0xF8, 0xFF, 0xFE}
 
@@ -523,7 +523,7 @@ func TestConnection_SelfHearingGuardAllowsOthers(t *testing.T) {
 
 	botID := snowflake.ID(999)
 	otherID := snowflake.ID(123)
-	c.SetBotUserID(botID)
+	c.SetBotUserID(botID.String())
 
 	silenceOpus := []byte{0xF8, 0xFF, 0xFE}
 

--- a/pkg/audio/grpcbridge/connection.go
+++ b/pkg/audio/grpcbridge/connection.go
@@ -24,8 +24,9 @@ import (
 
 // Compile-time interface assertions.
 var (
-	_ audio.Connection = (*Connection)(nil)
-	_ audio.Flusher    = (*Connection)(nil)
+	_ audio.Connection       = (*Connection)(nil)
+	_ audio.Flusher          = (*Connection)(nil)
+	_ audio.SelfHearingGuard = (*Connection)(nil)
 )
 
 const (

--- a/pkg/audio/types.go
+++ b/pkg/audio/types.go
@@ -11,6 +11,14 @@ type Flusher interface {
 	Flush()
 }
 
+// SelfHearingGuard is an optional interface that [Connection] implementations
+// may support. When SetBotUserID is called with the bot's own user ID,
+// incoming audio frames from that user are silently dropped. This prevents
+// echo/feedback loops where an NPC hears its own TTS output.
+type SelfHearingGuard interface {
+	SetBotUserID(id string)
+}
+
 // AudioFrame represents a single frame of audio data flowing through the pipeline.
 // Frames are the atomic unit of audio transport — captured from input streams,
 // processed by VAD, encoded/decoded by codecs, and played through output streams.

--- a/proto/glyphoxa/v1/session.proto
+++ b/proto/glyphoxa/v1/session.proto
@@ -40,7 +40,12 @@ message StartSessionRequest {
   // Fields 9-12 were voice proxy credentials, removed in favour of
   // AudioBridgeService which streams opus frames over gRPC.
   reserved 9, 10, 11, 12;
-  reserved "voice_session_id", "voice_token", "voice_endpoint", "bot_user_id";
+  reserved "voice_session_id", "voice_token", "voice_endpoint";
+
+  // bot_user_id is the bot's Discord user ID (snowflake). Workers use it to
+  // activate the self-hearing guard — filtering out the bot's own audio frames
+  // so NPCs don't hear their own TTS output (echo/feedback loop prevention).
+  string bot_user_id = 13;
 }
 
 // StartSessionResponse is the worker's reply after attempting to start a session.


### PR DESCRIPTION
## Summary

- **Wires the self-hearing guard end-to-end** across all three audio paths (full mode, distributed worker, gateway bridge). The guard code (`SetBotUserID`, `botUserID` filtering) existed on both `discord.Connection` and `grpcbridge.Connection` but was never activated — `SetBotUserID` was never called and the pipeline's `botUserID` field was always empty.
- **Adds defense-in-depth at the gateway layer** by filtering the bot's own frames in `voiceBridgeReceiver.ReceiveOpusFrame` before they reach the gRPC stream, preventing bot audio from crossing the network boundary to workers.
- **Introduces `audio.SelfHearingGuard` interface** so the session manager and worker factory can activate the guard via type assertion on any `audio.Connection` implementation without coupling to concrete types.

Closes architecture audit finding 3.1.

## What was broken

The bot could hear its own TTS output because:
1. `session_manager.go` never called `SetBotUserID` on the connection after `platform.Connect()`
2. `session_manager.go` never set `botUserID` on `audioPipelineConfig`
3. `StartSessionRequest` did not carry `BotUserID` to workers
4. `worker_factory.go` never called `SetBotUserID` on grpcbridge or discord connections
5. The gateway `voiceBridgeReceiver` forwarded ALL Discord frames to workers, including the bot's own

## Changes

| File | Change |
|------|--------|
| `proto/session.proto` | Add `bot_user_id` field 13 to `StartSessionRequest` |
| `internal/gateway/contract.go` | Add `BotUserID` to `StartSessionRequest` |
| `internal/gateway/sessionctrl.go` | Populate `BotUserID` from `gwBot.Client().ApplicationID` |
| `internal/gateway/voicebridge.go` | Add `botUserID` to `voiceBridgeReceiver`, filter in `ReceiveOpusFrame` |
| `internal/gateway/grpctransport/client.go` | Wire `BotUserId` into gRPC request |
| `internal/gateway/grpctransport/server.go` | Wire `BotUserId` from gRPC message |
| `cmd/glyphoxa/main.go` | Pass `bot.Client().ApplicationID` to `SessionManagerConfig.BotUserID` |
| `cmd/glyphoxa/worker_factory.go` | Call `SetBotUserID` on grpcbridge + discord connections, pass to pipeline |
| `internal/app/session_manager.go` | Add `BotUserID` to config, call `SetBotUserID` via `SelfHearingGuard` interface |
| `internal/app/exports.go` | Add `BotUserID` to exported `AudioPipelineConfig` |
| `pkg/audio/types.go` | Add `SelfHearingGuard` optional interface |
| `pkg/audio/discord/connection.go` | Change `SetBotUserID` to accept `string` (satisfies interface) |
| `pkg/audio/grpcbridge/connection.go` | Add compile-time `SelfHearingGuard` assertion |

## Test plan

- [x] `TestVoiceBridgeReceiver_SelfHearingGuard` — bot frames dropped at gateway layer
- [x] `TestVoiceBridgeReceiver_SelfHearingGuardInactive` — no filtering when botUserID is zero
- [x] `TestSetupVoiceBridge_BotUserIDPassedToReceiver` — setupVoiceBridge wires botUserID
- [x] `TestConnection_SelfHearingGuard` (discord) — bot frames dropped at connection layer
- [x] `TestConnection_SelfHearingGuardAllowsOthers` (discord) — player frames pass through
- [x] `TestConnection_SelfHearingGuardNoID` (discord) — guard inactive without SetBotUserID
- [x] `TestConnection_SelfHearingGuard` (grpcbridge) — bot frames dropped at worker connection
- [x] `TestAudioPipeline_BotUserIDSkipped` — pipeline skips bot's worker (defense-in-depth)
- [x] `TestSessionManager_SelfHearingGuardWired` — SessionManager calls SetBotUserID on connection
- [x] `TestSessionManager_SelfHearingGuardSkippedWhenEmpty` — no call when BotUserID is empty
- [x] Full test suite passes (55+ packages, race detector enabled)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)